### PR TITLE
Added missing MSP_ERR_NO_MEMORY.

### DIFF
--- a/lib/hapgen.c
+++ b/lib/hapgen.c
@@ -148,6 +148,7 @@ hapgen_alloc(hapgen_t *self, tree_sequence_t *tree_sequence)
             sizeof(uint64_t));
     self->haplotype = malloc(self->words_per_row * HG_WORD_SIZE + 1);
     if (self->haplotype_matrix == NULL || self->haplotype == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
     ret = hapgen_generate_all_haplotypes(self);

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -62,7 +62,7 @@ msp_strerror(int err)
     const char *ret = "Unknown error";
 
     if (err == MSP_ERR_NO_MEMORY) {
-        ret = "Out of memory. Try increasing the max_memory parameter";
+        ret = "Out of memory.";
     } else if (err == MSP_ERR_GENERIC) {
         ret = "Generic error; please file a bug report";
     } else if (err == MSP_ERR_FILE_FORMAT) {


### PR DESCRIPTION
This resulted in a segfault when calling the haplotypes() method for
very large sample sizes. Closes issue #29