### PR TITLE
Add 'file' option

### DIFF
--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -557,6 +557,16 @@ class IndexedAction(argparse._AppendAction):
         IndexedAction.index += 1
 
 
+class LoadFromFile (argparse.Action):
+    """
+    Argparse action class to allow passing a filename containing arguments
+    on the command line (for super-long argument files).
+    From http://stackoverflow.com/questions/27433316/how-to-get-argparse-to-read-arguments-from-a-file-with-an-option-rather-than-pre
+    """
+    def __call__ (self, parser, namespace, values, option_string = None):
+        with values as f:
+            parser.parse_args(f.read().split(), namespace)
+
 def get_mspms_parser():
     # Ensure that the IndexedAction counter is set to zero. This is useful
     # for testing where we'll be creating lots of these parsers.
@@ -692,6 +702,9 @@ def get_mspms_parser():
     group.add_argument(
         "--precision", "-p", type=positive_int, default=3,
         help="Number of values after decimal place to print")
+    group.add_argument(
+        "--filename", "-f", type=open, action=LoadFromFile,
+        help="Read command line arguments from this file.")
     return parser
 
 

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -556,34 +556,39 @@ class IndexedAction(argparse._AppendAction):
             parser, namespace, (IndexedAction.index, values), option_string)
         IndexedAction.index += 1
 
+
 def convert_arg_line_to_args(arg_line):
     # from the docs on argparse.ArgumentParser.convert_arg_line_to_args
     return arg_line.split()
+
 
 def make_load_file_action(next_parser):
     """
     Argparse action class to allow passing a filename containing arguments
     on the command line (for super-long argument files).
-    From 
-        http://stackoverflow.com/questions/27433316/how-to-get-argparse-to-read-arguments-from-a-file-with-an-option-rather-than-pre
-    and 
-        http://stackoverflow.com/questions/40060571/how-to-get-argparse-to-read-arguments-from-a-file-with-an-option-after-positiona/40062344
+    From
+        http://stackoverflow.com/q/27433316
+    and
+        http://stackoverflow.com/q/40060571
     """
-    class LoadFromFile (argparse.Action):
-        def __call__ (self, parser, namespace, values, option_string = None):
+    class LoadFromFile(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
             with values as f:
-                # note parses with 'next_parser' *not* with parser that is passed in
+                # note parses with 'next_parser' *not* with parser that is
+                # passed in
                 next_parser.parse_args(f.read().split(), namespace)
 
-    return( LoadFromFile )
+    return LoadFromFile
+
 
 def get_mspms_parser():
     # Ensure that the IndexedAction counter is set to zero. This is useful
     # for testing where we'll be creating lots of these parsers.
     IndexedAction.index = 0
-    # to allow `-f` options we'll need a parser that can do all the arguments except the positional
-    # (nonoptional) arguments.  We'll create this one first, then at the end make the parser
-    # that includes the positional arguments.
+    # to allow `-f` options we'll need a parser that can do all the
+    # arguments except the positional (nonoptional) arguments.  We'll
+    # create this one first, then at the end make the parser that
+    # includes the positional arguments.
     parser = argparse.ArgumentParser(
         description=mscompat_description,
         epilog=msprime_citation_text)
@@ -711,13 +716,13 @@ def get_mspms_parser():
         help="Number of values after decimal place to print")
     group.add_argument(
         "--filename", "-f", type=open, action=make_load_file_action(parser),
-        help= "Insert commands from a file at this point in the command line." )
+        help="Insert commands from a file at this point in the command line.")
 
     # now for the parser that gets called first
     init_parser = argparse.ArgumentParser(
         description=mscompat_description,
         epilog=msprime_citation_text,
-        add_help=False, 
+        add_help=False,
         parents=[parser])
     init_parser.convert_arg_line_to_args = convert_arg_line_to_args
 

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -556,6 +556,9 @@ class IndexedAction(argparse._AppendAction):
             parser, namespace, (IndexedAction.index, values), option_string)
         IndexedAction.index += 1
 
+def convert_arg_line_to_args(arg_line):
+    # from the docs on argparse.ArgumentParser.convert_arg_line_to_args
+    return arg_line.split()
 
 class LoadFromFile (argparse.Action):
     """
@@ -571,9 +574,16 @@ def get_mspms_parser():
     # Ensure that the IndexedAction counter is set to zero. This is useful
     # for testing where we'll be creating lots of these parsers.
     IndexedAction.index = 0
+    fromfile_help_epilog = """
+    Inserting the name of a file prepended with '@' will insert the contents of that file into the command line at that point, for instance:
+       mspms 10 2 @config.txt
+    with arguments listed in 'config.txt'.
+    """
     parser = argparse.ArgumentParser(
         description=mscompat_description,
-        epilog=msprime_citation_text)
+        fromfile_prefix_chars='@',  # can prefix filenames with this to have their contents inserted into argument string at that point
+        epilog=fromfile_help_epilog+"\n\n"+msprime_citation_text)
+    parser.convert_arg_line_to_args = convert_arg_line_to_args
     add_sample_size_argument(parser)
     parser.add_argument(
         "num_replicates", type=positive_int,

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -574,15 +574,10 @@ def get_mspms_parser():
     # Ensure that the IndexedAction counter is set to zero. This is useful
     # for testing where we'll be creating lots of these parsers.
     IndexedAction.index = 0
-    fromfile_help_epilog = """
-    Inserting the name of a file prepended with '@' will insert the contents of that file into the command line at that point, for instance:
-       mspms 10 2 @config.txt
-    with arguments listed in 'config.txt'.
-    """
     parser = argparse.ArgumentParser(
         description=mscompat_description,
         fromfile_prefix_chars='@',  # can prefix filenames with this to have their contents inserted into argument string at that point
-        epilog=fromfile_help_epilog+"\n\n"+msprime_citation_text)
+        epilog=msprime_citation_text)
     parser.convert_arg_line_to_args = convert_arg_line_to_args
     add_sample_size_argument(parser)
     parser.add_argument(
@@ -714,7 +709,11 @@ def get_mspms_parser():
         help="Number of values after decimal place to print")
     group.add_argument(
         "--filename", "-f", type=open, action=LoadFromFile,
-        help="Read command line arguments from this file.")
+        help=(
+            "Read *all* command line arguments from this file. "
+            "Alternatively, inserting the name of a file prepended with '@' "
+            "on the command line will insert the contents of that file at that point, "
+            "for instance: 'mspms 10 1 @config.txt'."))
     return parser
 
 


### PR DESCRIPTION
This allows two different methods for passing options in a file:
 1. doing '-f filename' will work if the *entire* command line is in the file
 2. inserting '@filename' will include commands in the file at the point it is inserted (this is the [fromfile](https://docs.python.org/3.5/library/argparse.html#fromfile-prefix-chars) option from argparse).

I have not figured out how to replicate `ms`'s behavior, allowing `-f` to coexist with other arguments: my implementation is straight from [this stackoverflow question](http://stackoverflow.com/questions/27433316/how-to-get-argparse-to-read-arguments-from-a-file-with-an-option-rather-than-pre), but the problem is that the `LoadFromFile` Action just calls `parse_args( )`, which causes an exception if the positional arguments aren't in the file.