### PR TITLE
Migration records.

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -2714,7 +2714,7 @@ TreeSequence_get_record(TreeSequence *self, PyObject *args)
     PyObject *ret = NULL;
     int order = MSP_ORDER_TIME;
     Py_ssize_t record_index, num_records;
-    coalescence_record_t *cr;
+    coalescence_record_t cr;
 
     if (TreeSequence_check_tree_sequence(self) != 0) {
         goto out;
@@ -2728,13 +2728,13 @@ TreeSequence_get_record(TreeSequence *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "record index out of bounds");
         goto out;
     }
-    err = tree_sequence_get_record(self->tree_sequence,
+    err = tree_sequence_get_coalescence_record(self->tree_sequence,
             (size_t) record_index, &cr, order);
     if (err != 0) {
         handle_library_error(err);
         goto out;
     }
-    ret = make_coalescence_record(cr);
+    ret = make_coalescence_record(&cr);
 out:
     return ret;
 }

--- a/dev.py
+++ b/dev.py
@@ -1070,6 +1070,26 @@ def subset_error(infile):
         # print(t)
 
 
+# def migration_records_example():
+
+    population_configurations = [
+        msprime.PopulationConfiguration(1),
+        msprime.PopulationConfiguration(1),
+        msprime.PopulationConfiguration(0),
+    ]
+    demographic_events = [
+        msprime.MassMigration(time=5, source=0, destination=2),
+        msprime.MassMigration(time=6, source=1, destination=2),
+    ]
+    ts = msprime.simulate(
+        Ne=0.25, population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        random_seed=1, length=10, recombination_rate=0.5,
+        record_migrations=True)
+    for mr in ts.migrations():
+        print(mr)
+
+
 if __name__ == "__main__":
     # mutations()
 
@@ -1108,15 +1128,10 @@ if __name__ == "__main__":
     # subset_samples(30000, [5, 7, 8,9, 10, 11])
 
     # subset_samples(300, list(range(20)))
-    # subset_samples(30, list(range(3)))
-    # for j in range(1, 100):
-    #     print("SEED = ", j)
-    #     # subset_samples(10, list(range(3)), j)
-    #     subset_samples(10, list(range(3)), j)
-
     # check_single_records("inferred_records.txt", "inferred_mutations.txt")
     # for n in [100, 1000, 10000]:
     #     for k in [2, 10, 50, n - 1, n]:
     #         print(n, k, file=sys.stderr)
     #         subset_samples(n, range(k))
-    subset_error(sys.argv[1])
+    # subset_error(sys.argv[1])
+    migration_records_example()

--- a/lib/dev.cfg
+++ b/lib/dev.cfg
@@ -24,21 +24,20 @@ max_memory = 10;
 
 # Population structure
 migration_matrix = [
-    0.0
-    /* 0.0, 0.0, 0.0, */ 
-    /* 0.0, 0.0, 0.0, */ 
-    /* 0.0, 0.0, 0.0 */
+    0.0, 2.0, 2.0, 
+    2.0, 0.0, 2.0, 
+    2.0, 2.0, 0.0
 ];
 
 population_configuration = (
-    /* { */
-    /*     growth_rate = 0.0; */
-    /*     initial_size = 1.0; */
-    /* }, */
-    /* { */
-    /*     growth_rate = 2.0; */
-    /*     initial_size = 1.0; */
-    /* }, */
+    {
+        growth_rate = 0.0;
+        initial_size = 1.0;
+    },
+    {
+        growth_rate = 2.0;
+        initial_size = 1.0;
+    },
     {
         growth_rate = 0.0;
         initial_size = 5.0;
@@ -235,19 +234,25 @@ demographic_events = (
     /*     initial_size = 2.0; */
     /*     growth_rate = 0.0; */
     /* }, */
-    /* { */   
-    /*     type = "migration_rate_change"; */
-    /*     time = 0.25; */
-    /*     matrix_index = -1; */
-    /*     migration_rate = 0.1; */
-    /* }, */
-    /* { */   
-        /* type = "mass_migration"; */
-        /* time = 0.3; */
-        /* source = 0; */
-        /* dest = 1; */
-        /* proportion = 1.0; */
-    /* } */
+    {   
+        type = "migration_rate_change";
+        time = 0.3;
+        matrix_index = -1;
+        migration_rate = 0.0;
+    },
+    {   
+        type = "mass_migration";
+        time = 0.3;
+        source = 1;
+        dest = 0;
+        proportion = 1.0;
+    },
+    {   
+        type = "mass_migration";
+        time = 0.3;
+        source = 2;
+        dest = 0;
+        proportion = 1.0;
+    }
 );
-
 

--- a/lib/main.c
+++ b/lib/main.c
@@ -742,13 +742,12 @@ run_simulate(char *conf_file, char *output_file)
     if (ret != 0) {
         goto out;
     }
-    /* recomb_map_print_state(recomb_map); */
     ret = msp_initialise(msp);
     if (ret != 0) {
         goto out;
     }
     if (0) {
-        /* print out the demographic event debug state */
+        /* recomb_map_print_state(recomb_map); */
         start_time = 0;
         do {
 

--- a/lib/main.c
+++ b/lib/main.c
@@ -506,7 +506,7 @@ print_variants(tree_sequence_t *ts)
     if (genotypes == NULL) {
         fatal_error("no memory");
     }
-    printf("variants (%d) \n", (int) ts->num_mutations);
+    printf("variants (%d) \n", (int) ts->mutations.num_records);
     ret = vargen_alloc(&vg, ts, 0);
     if (ret != 0) {
         fatal_library_error(ret, "vargen_alloc");
@@ -523,8 +523,8 @@ print_variants(tree_sequence_t *ts)
     if (ret != 0) {
         fatal_library_error(ret, "vargen_next");
     }
-    if (j != ts->num_mutations) {
-        printf("ERROR!! missing variants %d %d\n", j, (int) ts->num_mutations);
+    if (j != ts->mutations.num_records) {
+        printf("ERROR!! missing variants %d %d\n", j, (int) ts->mutations.num_records);
     }
 
     while ((ret = vargen_next(&vg, &mut, genotypes)) == 1) {

--- a/lib/main.c
+++ b/lib/main.c
@@ -685,17 +685,17 @@ print_tree_sequence(tree_sequence_t *ts)
     size_t j;
     size_t num_records = tree_sequence_get_num_coalescence_records(ts);
     sparse_tree_t tree;
-    coalescence_record_t *cr;
+    coalescence_record_t cr;
 
     // TODO tidy this up to make it more specific to the task of examining the
     // tree sequence itself.
     printf("Records:\n");
     for (j = 0; j < num_records; j++) {
-        if (tree_sequence_get_record(ts, j, &cr, MSP_ORDER_TIME) != 0) {
+        if (tree_sequence_get_coalescence_record(ts, j, &cr, MSP_ORDER_TIME) != 0) {
             fatal_error("tree sequence out of bounds\n");
         }
-        printf("\t%f\t%f\t%d\t%d\t%d\t%f\n", cr->left, cr->right, cr->children[0],
-                cr->children[1], cr->node, cr->time);
+        printf("\t%f\t%f\t%d\t%d\t%d\t%f\n", cr.left, cr.right, cr.children[0],
+                cr.children[1], cr.node, cr.time);
     }
 
     tree_sequence_print_state(ts, stdout);
@@ -792,7 +792,6 @@ run_simulate(char *conf_file, char *output_file)
     if (ret != 0) {
         goto out;
     }
-
     ret = tree_sequence_add_provenance_string(tree_seq, "Tree Provenance!!!");
     if (ret != 0) {
         goto out;
@@ -814,7 +813,8 @@ run_simulate(char *conf_file, char *output_file)
     if (ret != 0) {
         goto out;
     }
-
+    printf("================\n");
+    tree_sequence_print_state(tree_seq, stdout);
 out:
     if (msp != NULL) {
         msp_free(msp);

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -314,6 +314,12 @@ msp_get_num_coalescence_record_blocks(msp_t *self)
 }
 
 size_t
+msp_get_num_migration_record_blocks(msp_t *self)
+{
+    return self->num_migration_record_blocks;
+}
+
+size_t
 msp_get_used_memory(msp_t *self)
 {
     return self->used_memory;
@@ -560,6 +566,20 @@ out:
     return ret;
 }
 
+int
+msp_set_migration_record_block_size(msp_t *self, size_t block_size)
+{
+    int ret = 0;
+
+    if (block_size < 1) {
+        ret = MSP_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    self->migration_record_block_size = block_size;
+out:
+    return ret;
+}
+
 /* Top level allocators and initialisation */
 
 int
@@ -635,6 +655,7 @@ msp_alloc(msp_t *self, size_t sample_size, sample_t *samples, gsl_rng *rng)
     self->segment_block_size = 1024;
     self->max_memory = 1024 * 1024 * 1024; /* 1MiB */
     self->coalescence_record_block_size = 1024;
+    self->migration_record_block_size = 1024;
     /* set up the AVL trees */
     avl_init_tree(&self->breakpoints, cmp_node_mapping, NULL);
     avl_init_tree(&self->overlap_counts, cmp_node_mapping, NULL);
@@ -691,6 +712,15 @@ msp_alloc_memory_blocks(msp_t *self)
     self->max_coalescence_records = self->coalescence_record_block_size;
     self->num_coalescence_record_blocks = 1;
     if (self->coalescence_records == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    /* Allocate the migration records */
+    self->migration_records = malloc(
+            self->migration_record_block_size * sizeof(migration_record_t));
+    self->max_migration_records = self->migration_record_block_size;
+    self->num_migration_record_blocks = 1;
+    if (self->migration_records == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
@@ -800,6 +830,9 @@ msp_free(msp_t *self)
     fenwick_free(&self->links);
     if (self->coalescence_records != NULL) {
         free(self->coalescence_records);
+    }
+    if (self->migration_records != NULL) {
+        free(self->migration_records);
     }
     ret = 0;
     return ret;
@@ -1064,6 +1097,7 @@ msp_print_state(msp_t *self, FILE *out)
     node_mapping_t *nm;
     segment_t *u;
     coalescence_record_t *cr;
+    migration_record_t *mr;
     demographic_event_t *de;
     sampling_event_t *se;
     int64_t v;
@@ -1165,6 +1199,13 @@ msp_print_state(msp_t *self, FILE *out)
         }
         fprintf(out, ")\t%f\t%d\n", cr->time, cr->population_id);
     }
+    fprintf(out, "Migration records = %ld\n",
+            (long) self->num_migration_records);
+    for (j = 0; j < self->num_migration_records; j++) {
+        mr = &self->migration_records[j];
+        fprintf(out, "\t%f\t%f\t%d\t%f\t%d\t%d\n", mr->left, mr->right,
+                mr->node, mr->time, mr->source_pop, mr->dest_pop);
+    }
     fprintf(out, "Memory heaps\n");
     fprintf(out, "avl_node_heap:");
     object_heap_print_state(&self->avl_node_heap, out);
@@ -1182,6 +1223,38 @@ out:
     return ret;
 }
 
+
+static int WARN_UNUSED
+msp_record_migration(msp_t *self, uint32_t left, uint32_t right,
+        uint32_t node, uint32_t source_pop, uint32_t dest_pop)
+{
+    int ret = 0;
+    migration_record_t *mr;
+
+    if (self->num_migration_records == self->max_migration_records - 1) {
+        /* Grow the array */
+        self->max_migration_records += self->migration_record_block_size;;
+        mr = realloc(self->migration_records,
+                self->max_migration_records * sizeof(migration_record_t));
+        if (mr == NULL) {
+            ret = MSP_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->migration_records = mr;
+        self->num_migration_record_blocks++;
+    }
+    mr = &self->migration_records[self->num_migration_records];
+    mr->left = (double) left;
+    mr->right = (double) right;
+    mr->node = node;
+    mr->time = self->time;
+    mr->source_pop = (uint8_t) source_pop;
+    mr->dest_pop = (uint8_t) dest_pop;
+    self->num_migration_records++;
+out:
+    return ret;
+}
+
 static int WARN_UNUSED
 msp_move_individual(msp_t *self, avl_node_t *node, avl_tree_t *source,
         uint32_t dest_pop)
@@ -1196,9 +1269,15 @@ msp_move_individual(msp_t *self, avl_node_t *node, avl_tree_t *source,
     x = ind;
     while (x != NULL) {
         x->population_id = dest_pop;
+        ret = msp_record_migration(self, x->left, x->right, x->value,
+                x->population_id, dest_pop);
+        if (ret != 0) {
+            goto out;
+        }
         x = x->next;
     }
     ret = msp_insert_individual(self, ind);
+out:
     return ret;
 }
 
@@ -2397,6 +2476,12 @@ msp_get_num_coalescence_records(msp_t *self)
     return self->num_coalescence_records;
 }
 
+size_t
+msp_get_num_migration_records(msp_t *self)
+{
+    return self->num_migration_records;
+}
+
 int WARN_UNUSED
 msp_get_ancestors(msp_t *self, segment_t **ancestors)
 {
@@ -2457,6 +2542,13 @@ int WARN_UNUSED
 msp_get_coalescence_records(msp_t *self, coalescence_record_t **coalescence_records)
 {
     *coalescence_records = self->coalescence_records;
+    return 0;
+}
+
+int WARN_UNUSED
+msp_get_migration_records(msp_t *self, migration_record_t **migration_records)
+{
+    *migration_records = self->migration_records;
     return 0;
 }
 

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -1204,7 +1204,7 @@ msp_print_state(msp_t *self, FILE *out)
     for (j = 0; j < self->num_migration_records; j++) {
         mr = &self->migration_records[j];
         fprintf(out, "\t%f\t%f\t%d\t%f\t%d\t%d\n", mr->left, mr->right,
-                mr->node, mr->time, mr->source_pop, mr->dest_pop);
+                mr->node, mr->time, mr->source, mr->dest);
     }
     fprintf(out, "Memory heaps\n");
     fprintf(out, "avl_node_heap:");
@@ -1248,8 +1248,8 @@ msp_record_migration(msp_t *self, uint32_t left, uint32_t right,
     mr->right = (double) right;
     mr->node = node;
     mr->time = self->time;
-    mr->source_pop = (uint8_t) source_pop;
-    mr->dest_pop = (uint8_t) dest_pop;
+    mr->source = source_pop;
+    mr->dest = dest_pop;
     self->num_migration_records++;
 out:
     return ret;

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -2008,8 +2008,7 @@ msp_migration_event(msp_t *self, uint32_t source_pop, uint32_t dest_pop)
     avl_node_t *node;
     avl_tree_t *source = &self->populations[source_pop].ancestors;
 
-    self->num_migration_events[
-        source_pop * self->num_populations + dest_pop]++;
+    self->num_migration_events[source_pop * self->num_populations + dest_pop]++;
     j = (uint32_t) gsl_rng_uniform_int(self->rng, avl_count(source));
     node = avl_at(source, j);
     assert(node != NULL);
@@ -2549,8 +2548,7 @@ msp_get_num_migration_events(msp_t *self, size_t *num_migration_events)
 {
     size_t N = self->num_populations;
 
-    memcpy(num_migration_events, self->num_migration_events,
-        N * N * sizeof(size_t));
+    memcpy(num_migration_events, self->num_migration_events, N * N * sizeof(size_t));
     return 0;
 }
 

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -254,6 +254,7 @@ typedef struct {
     uint32_t sample_size;
     double sequence_length;
     struct {
+        size_t num_records;
         double *breakpoints;
         size_t num_breakpoints;
         struct {
@@ -274,6 +275,7 @@ typedef struct {
         } indexes;
     } trees;
     struct {
+        size_t num_records;
         uint32_t *node;
         double *position;
         size_t *num_tree_mutations;
@@ -284,8 +286,6 @@ typedef struct {
     size_t num_provenance_strings;
     size_t num_nodes;
     size_t num_child_nodes;
-    size_t num_records;
-    size_t num_mutations;
     coalescence_record_t returned_record;
     /* The number of trees referencing this tree sequence.
      * This is NOT threadsafe! TODO when we want to have trees

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -88,6 +88,15 @@ typedef struct {
 } coalescence_record_t;
 
 typedef struct {
+    uint8_t source_pop;
+    uint8_t dest_pop;
+    uint32_t node;
+    double left;
+    double right;
+    double time;
+} migration_record_t;
+
+typedef struct {
     uint32_t left; /* TODO CHANGE THIS - not a good name! */
     uint32_t value;
 } node_mapping_t;
@@ -173,6 +182,12 @@ typedef struct {
     size_t max_coalescence_records;
     size_t coalescence_record_block_size;
     size_t num_coalescence_record_blocks;
+    /* migration records are stored in a flat array */
+    migration_record_t *migration_records;
+    size_t num_migration_records;
+    size_t max_migration_records;
+    size_t migration_record_block_size;
+    size_t num_migration_record_blocks;
 } msp_t;
 
 /* Demographic events */
@@ -438,6 +453,7 @@ int msp_set_node_mapping_block_size(msp_t *self, size_t block_size);
 int msp_set_segment_block_size(msp_t *self, size_t block_size);
 int msp_set_avl_node_block_size(msp_t *self, size_t block_size);
 int msp_set_coalescence_record_block_size(msp_t *self, size_t block_size);
+int msp_set_migration_record_block_size(msp_t *self, size_t block_size);
 int msp_set_sample_configuration(msp_t *self, size_t num_populations,
         size_t *sample_configuration);
 int msp_set_migration_matrix(msp_t *self, size_t size,
@@ -469,6 +485,7 @@ int msp_get_breakpoints(msp_t *self, size_t *breakpoints);
 int msp_get_migration_matrix(msp_t *self, double *migration_matrix);
 int msp_get_num_migration_events(msp_t *self, size_t *num_migration_events);
 int msp_get_coalescence_records(msp_t *self, coalescence_record_t **records);
+int msp_get_migration_records(msp_t *self, migration_record_t **records);
 int msp_get_samples(msp_t *self, sample_t **samples);
 int msp_get_population_configuration(msp_t *self, size_t population_id,
         double *initial_size, double *growth_rate);
@@ -484,10 +501,12 @@ size_t msp_get_num_populations(msp_t *self);
 size_t msp_get_num_ancestors(msp_t *self);
 size_t msp_get_num_breakpoints(msp_t *self);
 size_t msp_get_num_coalescence_records(msp_t *self);
+size_t msp_get_num_migration_records(msp_t *self);
 size_t msp_get_num_avl_node_blocks(msp_t *self);
 size_t msp_get_num_node_mapping_blocks(msp_t *self);
 size_t msp_get_num_segment_blocks(msp_t *self);
 size_t msp_get_num_coalescence_record_blocks(msp_t *self);
+size_t msp_get_num_migration_record_blocks(msp_t *self);
 size_t msp_get_used_memory(msp_t *self);
 size_t msp_get_num_common_ancestor_events(msp_t *self);
 size_t msp_get_num_rejected_common_ancestor_events(msp_t *self);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -88,8 +88,8 @@ typedef struct {
 } coalescence_record_t;
 
 typedef struct {
-    uint8_t source_pop;
-    uint8_t dest_pop;
+    uint32_t source;
+    uint32_t dest;
     uint32_t node;
     double left;
     double right;
@@ -282,6 +282,17 @@ typedef struct {
         mutation_t *tree_mutations_mem;
         mutation_t **tree_mutations;
     } mutations;
+    struct {
+        size_t num_records;
+        double *breakpoints;
+        size_t num_breakpoints;
+        uint32_t *node;
+        uint32_t *source;
+        uint32_t *dest;
+        uint32_t *left;
+        uint32_t *right;
+        double *time;
+    } migrations;
     char **provenance_strings;
     size_t num_provenance_strings;
     size_t num_nodes;
@@ -529,8 +540,10 @@ uint32_t tree_sequence_get_num_nodes(tree_sequence_t *self);
 uint32_t tree_sequence_get_sample_size(tree_sequence_t *self);
 double tree_sequence_get_sequence_length(tree_sequence_t *self);
 
-int tree_sequence_get_record(tree_sequence_t *self, size_t index,
-        coalescence_record_t **record, int order);
+int tree_sequence_get_coalescence_record(tree_sequence_t *self, size_t index,
+        coalescence_record_t *record, int order);
+int tree_sequence_get_migration_record(tree_sequence_t *self, size_t index,
+        migration_record_t *record);
 int tree_sequence_get_mutations(tree_sequence_t *self, mutation_t **mutations);
 int tree_sequence_get_sample(tree_sequence_t *self, uint32_t u,
         sample_t *sample);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -25,6 +25,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdbool.h>
 
 #include <gsl/gsl_rng.h>
 
@@ -134,6 +135,7 @@ typedef struct {
     gsl_rng *rng;
     /* input parameters */
     int model;
+    bool store_migration_records;
     uint32_t sample_size;
     uint32_t num_loci;
     double scaled_recombination_rate;
@@ -456,6 +458,7 @@ typedef struct {
 int msp_alloc(msp_t *self, size_t sample_size, sample_t *samples, gsl_rng *rng);
 int msp_set_model(msp_t *self, int model);
 int msp_set_num_loci(msp_t *self, size_t num_loci);
+int msp_set_store_migration_records(msp_t *self, bool store_migration_records);
 int msp_set_num_populations(msp_t *self, size_t num_populations);
 int msp_set_scaled_recombination_rate(msp_t *self,
         double scaled_recombination_rate);
@@ -506,6 +509,7 @@ int msp_is_completed(msp_t *self);
 
 int msp_get_model(msp_t *self);
 const char * msp_get_model_str(msp_t *self);
+bool msp_get_store_migration_records(msp_t *self);
 size_t msp_get_sample_size(msp_t *self);
 size_t msp_get_num_loci(msp_t *self);
 size_t msp_get_num_populations(msp_t *self);
@@ -534,6 +538,7 @@ int tree_sequence_dump(tree_sequence_t *self, const char *filename, int flags);
 int tree_sequence_increment_refcount(tree_sequence_t *self);
 int tree_sequence_decrement_refcount(tree_sequence_t *self);
 size_t tree_sequence_get_num_coalescence_records(tree_sequence_t *self);
+size_t tree_sequence_get_num_migration_records(tree_sequence_t *self);
 size_t tree_sequence_get_num_mutations(tree_sequence_t *self);
 size_t tree_sequence_get_num_trees(tree_sequence_t *self);
 uint32_t tree_sequence_get_num_nodes(tree_sequence_t *self);

--- a/lib/mutgen.c
+++ b/lib/mutgen.c
@@ -179,15 +179,15 @@ mutgen_generate(mutgen_t *self)
 {
     int ret = -1;
     tree_sequence_t *ts = self->tree_sequence;
-    coalescence_record_t *cr = NULL;
+    coalescence_record_t cr;
     size_t j;
 
     for (j = 0; j < tree_sequence_get_num_coalescence_records(ts); j++) {
-        ret = tree_sequence_get_record(ts, j, &cr, MSP_ORDER_TIME);
+        ret = tree_sequence_get_coalescence_record(ts, j, &cr, MSP_ORDER_TIME);
         if (ret != 0) {
             goto out;
         }
-        ret = mutgen_generate_record_mutations(self, cr);
+        ret = mutgen_generate_record_mutations(self, &cr);
         if (ret != 0) {
             goto out;
         }

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -837,6 +837,8 @@ test_simulator_getters_setters(void)
             MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(msp_set_coalescence_record_block_size(&msp, 0),
             MSP_ERR_BAD_PARAM_VALUE);
+    CU_ASSERT_EQUAL(msp_set_migration_record_block_size(&msp, 0),
+            MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(msp_set_num_loci(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(msp_set_num_populations(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(
@@ -906,6 +908,7 @@ test_simulator_getters_setters(void)
     CU_ASSERT_EQUAL(msp_get_num_node_mapping_blocks(&msp), 1);
     CU_ASSERT_EQUAL(msp_get_num_segment_blocks(&msp), 1);
     CU_ASSERT_EQUAL(msp_get_num_coalescence_record_blocks(&msp), 1);
+    CU_ASSERT_EQUAL(msp_get_num_migration_record_blocks(&msp), 1);
     CU_ASSERT(msp_get_used_memory(&msp) > 0);
     CU_ASSERT_EQUAL(msp_get_num_populations(&msp), 2);
 
@@ -1239,7 +1242,6 @@ test_multi_locus_simulation(void)
         CU_ASSERT_FATAL(msp != NULL);
         CU_ASSERT_FATAL(samples != NULL);
         CU_ASSERT_FATAL(rng != NULL);
-
         gsl_rng_set(rng, seed);
         memset(samples, 0, n * sizeof(sample_t));
         ret = msp_alloc(msp, n, samples, rng);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -253,6 +253,8 @@ get_example_tree_sequence(uint32_t sample_size,
     ret = msp_set_migration_matrix(msp, num_populations * num_populations,
             migration_matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = msp_set_store_migration_records(msp, true);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_initialise(msp);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_run(msp, DBL_MAX, ULONG_MAX);
@@ -268,10 +270,6 @@ get_example_tree_sequence(uint32_t sample_size,
      * We want to use coalescent time here, so use an Ne of 1/4
      * to cancel scaling factor. */
     ret = tree_sequence_create(tree_seq, msp, recomb_map, 0.25);
-    if (ret != 0) {
-        printf("ret = %s\n", msp_strerror(ret));
-
-    }
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(
             tree_sequence_get_num_coalescence_records(tree_seq),
@@ -279,6 +277,9 @@ get_example_tree_sequence(uint32_t sample_size,
     CU_ASSERT_EQUAL_FATAL(
             tree_sequence_get_sample_size(tree_seq),
             msp_get_sample_size(msp));
+    CU_ASSERT_EQUAL_FATAL(
+            tree_sequence_get_num_migration_records(tree_seq),
+            msp_get_num_migration_records(msp));
     CU_ASSERT_FATAL(
             tree_sequence_get_num_nodes(tree_seq) >= sample_size);
     ret = msp_get_coalescence_records(msp, &sim_records);
@@ -926,6 +927,8 @@ test_simulator_getters_setters(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_scaled_recombination_rate(&msp, 1.0);
     CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_store_migration_records(&msp, true);
+    CU_ASSERT_EQUAL(ret, 0);
 
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -944,6 +947,7 @@ test_simulator_getters_setters(void)
     CU_ASSERT_EQUAL(population->growth_rate, 0.5);
     CU_ASSERT_EQUAL(population->start_time, 0.0);
 
+    CU_ASSERT_TRUE(msp_get_store_migration_records(&msp));
     CU_ASSERT_EQUAL(msp_get_num_avl_node_blocks(&msp), 1);
     CU_ASSERT_EQUAL(msp_get_num_node_mapping_blocks(&msp), 1);
     CU_ASSERT_EQUAL(msp_get_num_segment_blocks(&msp), 1);

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -92,7 +92,7 @@ tree_sequence_check_state(tree_sequence_t *self)
 {
     size_t j;
 
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         assert(self->trees.records.num_children[j] >= 1);
     }
 }
@@ -122,8 +122,8 @@ tree_sequence_print_state(tree_sequence_t *self, FILE *out)
                 self->trees.breakpoints[j]);
     }
 
-    fprintf(out, "trees.records = (%d records)\n", (int) self->num_records);
-    for (j = 0; j < self->num_records; j++) {
+    fprintf(out, "trees.records = (%d records)\n", (int) self->trees.num_records);
+    for (j = 0; j < self->trees.num_records; j++) {
         fprintf(out, "\t%d\t%d\t%d\t%d\t(",
                 (int) j,
                 self->trees.records.left[j],
@@ -139,12 +139,12 @@ tree_sequence_print_state(tree_sequence_t *self, FILE *out)
                 (int) self->trees.indexes.insertion_order[j],
                 (int) self->trees.indexes.removal_order[j]);
     }
-    fprintf(out, "mutations = (%d records)\n", (int) self->num_mutations);
-    for (j = 0; j < self->num_mutations; j++) {
+    fprintf(out, "mutations = (%d records)\n", (int) self->mutations.num_records);
+    for (j = 0; j < self->mutations.num_records; j++) {
         fprintf(out, "\t%d\t%f\t%d\n", (int) j, self->mutations.position[j],
                (int) self->mutations.node[j]);
     }
-    if (self->num_mutations > 0) {
+    if (self->mutations.num_records > 0) {
         fprintf(out, "tree_mutations\n");
         for (j = 0; j < self->trees.num_breakpoints; j++) {
             fprintf(out, "\ttree %d\t%f\n", (int) j, self->trees.breakpoints[j]);
@@ -177,11 +177,11 @@ tree_sequence_alloc(tree_sequence_t *self)
     if (self->trees.breakpoints == NULL) {
         goto out;
     }
-    self->trees.records.left = malloc(self->num_records * sizeof(double));
-    self->trees.records.right = malloc(self->num_records * sizeof(double));
-    self->trees.records.num_children = malloc(self->num_records * sizeof(uint32_t));
-    self->trees.records.children = malloc(self->num_records * sizeof(uint32_t *));
-    self->trees.records.node = malloc(self->num_records * sizeof(uint32_t));
+    self->trees.records.left = malloc(self->trees.num_records * sizeof(double));
+    self->trees.records.right = malloc(self->trees.num_records * sizeof(double));
+    self->trees.records.num_children = malloc(self->trees.num_records * sizeof(uint32_t));
+    self->trees.records.children = malloc(self->trees.num_records * sizeof(uint32_t *));
+    self->trees.records.node = malloc(self->trees.num_records * sizeof(uint32_t));
     self->trees.records.children_mem = malloc(self->num_child_nodes * sizeof(uint32_t));
     if (self->trees.records.left == NULL
             || self->trees.records.right == NULL
@@ -191,8 +191,8 @@ tree_sequence_alloc(tree_sequence_t *self)
             || self->trees.records.children_mem == NULL) {
         goto out;
     }
-    self->trees.indexes.insertion_order = malloc(self->num_records * sizeof(uint32_t));
-    self->trees.indexes.removal_order = malloc(self->num_records * sizeof(uint32_t));
+    self->trees.indexes.insertion_order = malloc(self->trees.num_records * sizeof(uint32_t));
+    self->trees.indexes.removal_order = malloc(self->trees.num_records * sizeof(uint32_t));
     if (self->trees.indexes.insertion_order == NULL
             || self->trees.indexes.removal_order == NULL) {
         goto out;
@@ -202,10 +202,10 @@ tree_sequence_alloc(tree_sequence_t *self)
         self->trees.nodes.population[j] = MSP_NULL_POPULATION_ID;
         self->trees.nodes.time[j] = 0.0;
     }
-    if (self->num_mutations > 0) {
-        self->mutations.node = malloc(self->num_mutations * sizeof(uint32_t));
+    if (self->mutations.num_records > 0) {
+        self->mutations.node = malloc(self->mutations.num_records * sizeof(uint32_t));
         self->mutations.position = malloc(
-                self->num_mutations * sizeof(double));
+                self->mutations.num_records * sizeof(double));
         if (self->mutations.node == NULL || self->mutations.position == NULL) {
             goto out;
         }
@@ -353,7 +353,7 @@ tree_sequence_check(tree_sequence_t *self)
     uint32_t j, k, child, node, left;
 
     left = UINT32_MAX;
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         node = self->trees.records.node[j];
         if (node == MSP_NULL_NODE) {
             ret = MSP_ERR_NULL_NODE_IN_RECORD;
@@ -431,12 +431,12 @@ tree_sequence_init_from_records(tree_sequence_t *self,
      * size. Also do some basic error checking.
      */
     self->sample_size = UINT32_MAX;
-    self->num_mutations = 0;
+    self->mutations.num_records = 0;
     self->num_child_nodes = 0;
     self->sequence_length = 0.0;
-    self->num_records = num_records;
+    self->trees.num_records = num_records;
     self->num_nodes = 0;
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         self->num_child_nodes += records[j].num_children;
         if (records[j].node == MSP_NULL_NODE) {
             ret = MSP_ERR_NULL_NODE_IN_RECORD;
@@ -491,7 +491,7 @@ tree_sequence_init_from_records(tree_sequence_t *self,
     }
     /* Set up the nodes and the children pointers */
     offset = 0;
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         node = records[j].node;
         if (self->trees.nodes.time[node] == 0.0) {
             self->trees.nodes.time[node] = records[j].time;
@@ -517,14 +517,14 @@ tree_sequence_init_from_records(tree_sequence_t *self,
 
     /* Now sort create the indexes and set the breakpoint indexes in
      * left and right. */
-    sort_buff = malloc(self->num_records * sizeof(index_sort_t));
+    sort_buff = malloc(self->trees.num_records * sizeof(index_sort_t));
     if (sort_buff == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
     /* sort by left and increasing time to give us the order in which
      * records should be inserted */
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         sort_buff[j].index = (uint32_t ) j;
         sort_buff[j].value = records[j].left;
         /* When comparing equal left values, we sort by time. Since we require
@@ -537,9 +537,9 @@ tree_sequence_init_from_records(tree_sequence_t *self,
          */
         sort_buff[j].time = (int64_t ) j;
     }
-    qsort(sort_buff, self->num_records, sizeof(index_sort_t), cmp_index_sort);
+    qsort(sort_buff, self->trees.num_records, sizeof(index_sort_t), cmp_index_sort);
     k = 0;
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         self->trees.indexes.insertion_order[j] = sort_buff[j].index;
         while (self->trees.breakpoints[k] < sort_buff[j].value) {
             k++;
@@ -549,14 +549,14 @@ tree_sequence_init_from_records(tree_sequence_t *self,
     }
     /* sort by right and decreasing time to give us the order in which
      * records should be removed. */
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         sort_buff[j].index = (uint32_t ) j;
         sort_buff[j].value = records[j].right;
         sort_buff[j].time = -1 * (int64_t ) j;
     }
-    qsort(sort_buff, self->num_records, sizeof(index_sort_t), cmp_index_sort);
+    qsort(sort_buff, self->trees.num_records, sizeof(index_sort_t), cmp_index_sort);
     k = 0;
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         self->trees.indexes.removal_order[j] = sort_buff[j].index;
         while (self->trees.breakpoints[k] < sort_buff[j].value) {
             k++;
@@ -618,7 +618,7 @@ tree_sequence_create(tree_sequence_t *self, msp_t *sim,
     }
     assert(self->sample_size == msp_get_sample_size(sim));
     assert(self->sequence_length == (double) msp_get_num_loci(sim));
-    assert(self->num_records == msp_get_num_coalescence_records(sim));
+    assert(self->trees.num_records == msp_get_num_coalescence_records(sim));
 
     ret = msp_get_samples(sim, &samples);
     if (ret != 0) {
@@ -649,7 +649,7 @@ tree_sequence_init_tree_mutations(tree_sequence_t *self)
     mutation_t *mut;
 
     self->mutations.tree_mutations_mem = malloc(
-            self->num_mutations * sizeof(mutation_t));
+            self->mutations.num_records * sizeof(mutation_t));
     self->mutations.tree_mutations = calloc(self->trees.num_breakpoints,
             sizeof(mutation_t *));
     self->mutations.num_tree_mutations = calloc(self->trees.num_breakpoints,
@@ -662,7 +662,7 @@ tree_sequence_init_tree_mutations(tree_sequence_t *self)
     }
     tree_index = 0;
     self->mutations.tree_mutations[0] = self->mutations.tree_mutations_mem;
-    for (j = 0; j < self->num_mutations; j++) {
+    for (j = 0; j < self->mutations.num_records; j++) {
         mut = &self->mutations.tree_mutations_mem[j];
         mut->index = j;
         mut->position = self->mutations.position[j];
@@ -756,25 +756,25 @@ tree_sequence_check_hdf5_dimensions(tree_sequence_t *self, hid_t file_id)
         int required;
     };
     struct _dimension_check fields[] = {
-        {"/mutations/node", 1, self->num_mutations, 1},
-        {"/mutations/position", 1, self->num_mutations, 1},
+        {"/mutations/node", 1, self->mutations.num_records, 1},
+        {"/mutations/position", 1, self->mutations.num_records, 1},
         {"/trees/nodes/population", 1, self->num_nodes, 1},
         {"/trees/nodes/time", 1, self->num_nodes, 1},
         {"/trees/breakpoints", 1, self->trees.num_breakpoints, 1},
-        {"/trees/records/left", 1, self->num_records, 1},
-        {"/trees/records/right", 1, self->num_records, 1},
-        {"/trees/records/node", 1, self->num_records, 1},
-        {"/trees/records/num_children", 1, self->num_records, 1},
+        {"/trees/records/left", 1, self->trees.num_records, 1},
+        {"/trees/records/right", 1, self->trees.num_records, 1},
+        {"/trees/records/node", 1, self->trees.num_records, 1},
+        {"/trees/records/num_children", 1, self->trees.num_records, 1},
         {"/trees/records/children", 0, self->num_child_nodes, 1},
-        {"/trees/indexes/insertion_order", 1, self->num_records, 1},
-        {"/trees/indexes/removal_order", 1, self->num_records, 1},
+        {"/trees/indexes/insertion_order", 1, self->trees.num_records, 1},
+        {"/trees/indexes/removal_order", 1, self->trees.num_records, 1},
     };
     size_t num_fields = sizeof(fields) / sizeof(struct _dimension_check);
     size_t j;
 
     for (j = 0; j < 2; j++) {
-        fields[j].size = self->num_mutations;
-        fields[j].required = self->num_mutations > 0;
+        fields[j].size = self->mutations.num_records;
+        fields[j].required = self->mutations.num_records > 0;
     }
     for (j = 0; j < num_fields; j++) {
         if (fields[j].required) {
@@ -832,11 +832,11 @@ tree_sequence_read_hdf5_dimensions(tree_sequence_t *self, hid_t file_id)
         int included;
     };
     struct _dimension_read fields[] = {
-        {"/mutations/node", &self->num_mutations, 0},
+        {"/mutations/node", &self->mutations.num_records, 0},
         {"/provenance", &self->num_provenance_strings, 0},
         {"/trees/breakpoints", &self->trees.num_breakpoints, 1},
         {"/trees/nodes/time", &self->num_nodes, 1},
-        {"/trees/records/left", &self->num_records, 1},
+        {"/trees/records/left", &self->trees.num_records, 1},
         {"/trees/records/children", &self->num_child_nodes, 1},
     };
     size_t num_fields = sizeof(fields) / sizeof(struct _dimension_read);
@@ -848,7 +848,7 @@ tree_sequence_read_hdf5_dimensions(tree_sequence_t *self, hid_t file_id)
     if (exists < 0) {
         goto out;
     }
-    self->num_mutations = 0;
+    self->mutations.num_records = 0;
     if (exists) {
         fields[0].included = 1;
     }
@@ -960,7 +960,7 @@ tree_sequence_read_hdf5_data(tree_sequence_t *self, hid_t file_id)
      * would then allow one or the other. This would be an error.
      * However, we should improve this logic as it's a bit messy.
      */
-    if (self->num_mutations == 0) {
+    if (self->mutations.num_records == 0) {
         fields[1].empty = 1;
         fields[2].empty = 1;
     }
@@ -996,7 +996,7 @@ tree_sequence_read_hdf5_data(tree_sequence_t *self, hid_t file_id)
     /* Now update the children vectors and find sample size */
     self->sample_size = UINT32_MAX;
     offset = 0;
-    for (j = 0; j < self->num_records; j++) {
+    for (j = 0; j < self->trees.num_records; j++) {
         assert(offset < self->num_child_nodes);
         self->trees.records.children[j] =
             &self->trees.records.children_mem[offset];
@@ -1081,34 +1081,34 @@ tree_sequence_write_hdf5_data(tree_sequence_t *self, hid_t file_id, int flags)
             self->num_nodes, self->trees.nodes.time},
         {"/trees/records/left",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
-            self->num_records, self->trees.records.left},
+            self->trees.num_records, self->trees.records.left},
         {"/trees/records/right",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
-            self->num_records, self->trees.records.right},
+            self->trees.num_records, self->trees.records.right},
         {"/trees/records/node",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
-            self->num_records, self->trees.records.node},
+            self->trees.num_records, self->trees.records.node},
         {"/trees/records/num_children",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
-            self->num_records, self->trees.records.num_children},
+            self->trees.num_records, self->trees.records.num_children},
         {"/trees/records/children",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
             self->num_child_nodes, self->trees.records.children_mem},
         {"/trees/indexes/insertion_order",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
-            self->num_records, self->trees.indexes.insertion_order},
+            self->trees.num_records, self->trees.indexes.insertion_order},
         {"/trees/indexes/removal_order",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
-            self->num_records, self->trees.indexes.removal_order},
+            self->trees.num_records, self->trees.indexes.removal_order},
         {"/trees/breakpoints",
             H5T_IEEE_F64LE, H5T_NATIVE_DOUBLE,
             self->trees.num_breakpoints, self->trees.breakpoints},
         {"/mutations/node",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
-            self->num_mutations, self->mutations.node},
+            self->mutations.num_records, self->mutations.node},
         {"/mutations/position",
             H5T_IEEE_F64LE, H5T_NATIVE_DOUBLE,
-            self->num_mutations, self->mutations.position},
+            self->mutations.num_records, self->mutations.position},
     };
     size_t num_fields = sizeof(fields) / sizeof(struct _hdf5_field_write);
     struct _hdf5_group_write {
@@ -1149,7 +1149,7 @@ tree_sequence_write_hdf5_data(tree_sequence_t *self, hid_t file_id, int flags)
     fields[0].memory_type = memtype_str;
 
     /* We only create the mutations group if it's non-empty */
-    if (self->num_mutations == 0) {
+    if (self->mutations.num_records == 0) {
         groups[0].included = 0;
     }
     /* Create the groups */
@@ -1435,13 +1435,13 @@ out:
 size_t
 tree_sequence_get_num_coalescence_records(tree_sequence_t *self)
 {
-    return self->num_records;
+    return self->trees.num_records;
 }
 
 size_t
 tree_sequence_get_num_mutations(tree_sequence_t *self)
 {
-    return self->num_mutations;
+    return self->mutations.num_records;
 }
 
 size_t
@@ -1457,7 +1457,7 @@ tree_sequence_get_record(tree_sequence_t *self, size_t index,
     int ret = 0;
     size_t j;
 
-    if (index >= self->num_records) {
+    if (index >= self->trees.num_records) {
         ret = MSP_ERR_OUT_OF_BOUNDS;
         goto out;
     }
@@ -1532,7 +1532,7 @@ tree_sequence_set_mutations(tree_sequence_t *self, size_t num_mutations,
         ret = MSP_ERR_REFCOUNT_NONZERO;
         goto out;
     }
-    if (self->num_mutations > 0) {
+    if (self->mutations.num_records > 0) {
         /* any mutations that were there previously are overwritten. */
         if (self->mutations.node != NULL) {
             free(self->mutations.node);
@@ -1555,7 +1555,7 @@ tree_sequence_set_mutations(tree_sequence_t *self, size_t num_mutations,
             self->mutations.num_tree_mutations = NULL;
         }
     }
-    self->num_mutations = 0;
+    self->mutations.num_records = 0;
     self->mutations.position = NULL;
     self->mutations.node = NULL;
     if (num_mutations > 0) {
@@ -1581,7 +1581,7 @@ tree_sequence_set_mutations(tree_sequence_t *self, size_t num_mutations,
         /* Mutations are required to be sorted in position order. */
         qsort(mutation_ptrs, num_mutations, sizeof(mutation_t *),
                 cmp_mutation_pointer);
-        self->num_mutations = num_mutations;
+        self->mutations.num_records = num_mutations;
         for (j = 0; j < num_mutations; j++) {
             self->mutations.node[j] = mutation_ptrs[j]->node;
             self->mutations.position[j] = mutation_ptrs[j]->position;
@@ -1672,7 +1672,7 @@ tree_sequence_simplify(tree_sequence_t *self, uint32_t *samples,
     mutation_t *output_mutations = NULL;
     uint32_t *I = self->trees.indexes.insertion_order;
     uint32_t *O = self->trees.indexes.removal_order;
-    size_t M = self->num_records;
+    size_t M = self->trees.num_records;
     size_t j, k, h, next_avl_node, mapped_children_mem_offset, num_output_records,
            num_output_mutations, max_num_child_nodes, max_num_records;
     uint32_t u, v, w, x, c, l, num_mapped_children;
@@ -1702,10 +1702,10 @@ tree_sequence_simplify(tree_sequence_t *self, uint32_t *samples,
     mapped_children = malloc(self->num_nodes * sizeof(uint32_t));
     /* TODO work out better bounds for these values */
     max_num_child_nodes = 2 * self->num_child_nodes;
-    max_num_records = 2 * self->num_records;
+    max_num_records = 2 * self->trees.num_records;
     mapped_children_mem = malloc(max_num_child_nodes * sizeof(uint32_t));
     output_records = malloc(max_num_records * sizeof(coalescence_record_t));
-    output_mutations = malloc(self->num_mutations * sizeof(mutation_t));
+    output_mutations = malloc(self->mutations.num_records * sizeof(mutation_t));
     if (parent == NULL || children == NULL || num_children == NULL
             || mapping == NULL || sample_objects == NULL
             || avl_node_mem == NULL || avl_node_value_mem == NULL
@@ -1884,7 +1884,7 @@ tree_sequence_simplify(tree_sequence_t *self, uint32_t *samples,
         }
         /* Update the mutations for this tree */
         right = self->trees.breakpoints[self->trees.records.right[O[k]]];
-        while (l < self->num_mutations && self->mutations.position[l] < right) {
+        while (l < self->mutations.num_records && self->mutations.position[l] < right) {
             u = self->mutations.node[l];
             if (mapping[u] != MSP_NULL_NODE) {
                 keep = true;
@@ -1898,7 +1898,7 @@ tree_sequence_simplify(tree_sequence_t *self, uint32_t *samples,
                     keep = v != MSP_NULL_NODE;
                 }
                 if (keep) {
-                    assert(num_output_mutations < self->num_mutations);
+                    assert(num_output_mutations < self->mutations.num_records);
                     mut = &output_mutations[num_output_mutations];
                     num_output_mutations++;
                     mut->node = mapping[u];
@@ -2397,7 +2397,7 @@ sparse_tree_copy(sparse_tree_t *self, sparse_tree_t *source)
     self->right_breakpoint = source->right_breakpoint;
     self->root = source->root;
     self->index = source->index;
-    self->num_mutations = source->num_mutations;
+    self->num_mutations= source->num_mutations;
     self->mutations = source->mutations;
 
     memcpy(self->parent, source->parent, N * sizeof(uint32_t));
@@ -2851,7 +2851,7 @@ sparse_tree_advance(sparse_tree_t *self, int direction,
     uint32_t x = in_breakpoints[in_order[in]];
     double oldest_child_time;
     tree_sequence_t *s = self->tree_sequence;
-    ssize_t R = (ssize_t) s->num_records;
+    ssize_t R = (ssize_t) s->trees.num_records;
 
     while (out_breakpoints[out_order[out]] == x) {
         k = out_order[out];
@@ -2913,7 +2913,7 @@ sparse_tree_advance(sparse_tree_t *self, int direction,
     self->index = (uint32_t) ((int) self->index + direction);
     *out_index = (size_t) out;
     *in_index = (size_t) in;
-    if (s->num_mutations > 0) {
+    if (s->mutations.num_records > 0) {
         self->mutations = s->mutations.tree_mutations[self->index];
         self->num_mutations = s->mutations.num_tree_mutations[self->index];
     }
@@ -2968,8 +2968,8 @@ sparse_tree_last(sparse_tree_t *self)
     if (ret != 0) {
         goto out;
     }
-    self->left_index = s->num_records - 1;
-    self->right_index = s->num_records - 1;
+    self->left_index = s->trees.num_records - 1;
+    self->right_index = s->trees.num_records - 1;
     self->direction = MSP_DIR_REVERSE;
     self->index = tree_sequence_get_num_trees(s);
 

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -763,10 +763,14 @@ tree_sequence_create(tree_sequence_t *self, msp_t *sim,
     }
     assert(self->migrations.num_records == num_migration_records);
 
-    /* Rescale node times into generations */
+    /* Rescale times into generations */
     for (j = 0; j < self->num_nodes; j++) {
         self->trees.nodes.time[j] *= 4 * Ne;
     }
+    for (j = 0; j < self->migrations.num_records; j++) {
+        self->migrations.time[j] *= 4 * Ne;
+    }
+    /* Remap coordinates into physical coordinates */
     self->sequence_length = recomb_map_get_sequence_length(recomb_map);
     ret = recomb_map_genetic_to_phys_bulk(
         recomb_map, self->trees.breakpoints, self->trees.num_breakpoints);
@@ -1577,6 +1581,12 @@ size_t
 tree_sequence_get_num_coalescence_records(tree_sequence_t *self)
 {
     return self->trees.num_records;
+}
+
+size_t
+tree_sequence_get_num_migration_records(tree_sequence_t *self)
+{
+    return self->migrations.num_records;
 }
 
 size_t

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -581,6 +581,7 @@ out:
     return ret;
 }
 
+
 int WARN_UNUSED
 tree_sequence_load_records(tree_sequence_t *self,
       size_t num_records, coalescence_record_t *records)
@@ -601,16 +602,17 @@ tree_sequence_create(tree_sequence_t *self, msp_t *sim,
         recomb_map_t *recomb_map, double Ne)
 {
     int ret = MSP_ERR_GENERIC;
-    size_t j, num_records;
-    coalescence_record_t *records = NULL;
+    size_t j, num_coalesence_records;
+    coalescence_record_t *coalescence_records = NULL;
     sample_t *samples = NULL;
 
-    ret = msp_get_coalescence_records(sim, &records);
+    ret = msp_get_coalescence_records(sim, &coalescence_records);
     if (ret != 0) {
         goto out;
     }
-    num_records = msp_get_num_coalescence_records(sim);
-    ret = tree_sequence_init_from_records(self, num_records, records);
+    num_coalesence_records = msp_get_num_coalescence_records(sim);
+    ret = tree_sequence_init_from_records(self, num_coalesence_records,
+            coalescence_records);
     if (ret != 0) {
         goto out;
     }


### PR DESCRIPTION
Migration records as decribed in #10.

Basically, turn migration record storage on using the ``record_migrations=True``, and get the results using the ``migrations()`` iterator. This is preliminary, so any feeback on the API would be very welcome.

```python
population_configurations = [
        msprime.PopulationConfiguration(1),
        msprime.PopulationConfiguration(1),
        msprime.PopulationConfiguration(0),
    ]
    demographic_events = [
        msprime.MassMigration(time=5, source=0, destination=2),
        msprime.MassMigration(time=6, source=1, destination=2),
    ]
    ts = msprime.simulate(
        Ne=0.25, population_configurations=population_configurations,
        demographic_events=demographic_events,
        random_seed=1, length=10, recombination_rate=0.5,
        record_migrations=True)
    for mr in ts.migrations():
        print(mr)
```
Gives
```
MigrationRecord(left=0.163984030988995, right=4.235752954668309, node=0, source=0, dest=2, time=5.0)
MigrationRecord(left=4.235752954668309, right=4.745232419750009, node=0, source=0, dest=2, time=5.0)
MigrationRecord(left=5.7137565281507, right=10.0, node=0, source=0, dest=2, time=5.0)
MigrationRecord(left=0.0, right=0.163984030988995, node=0, source=0, dest=2, time=5.0)
MigrationRecord(left=4.745232419750009, right=5.7137565281507, node=0, source=0, dest=2, time=5.0)
MigrationRecord(left=1.046005697233138, right=10.0, node=1, source=1, dest=2, time=6.0)
MigrationRecord(left=0.0, right=1.046005697233138, node=1, source=1, dest=2, time=6.0)
```

TODO

- [ ] Update HDF5 format to store these records
- [ ] Improve low-level test coverage.
- [ ] Much better high-level tests, including seeing whether these records imply the same values as the migration counts, and whether the records are consistent with the populations associated with nodes in the tree
- [ ] Documentation