### PR TITLE
moved division outside of sum

### DIFF
--- a/lib/tests.c
+++ b/lib/tests.c
@@ -3864,6 +3864,35 @@ verify_vargen(tree_sequence_t *ts)
 }
 
 static void
+verify_stats(tree_sequence_t *ts)
+{
+    int ret;
+    uint32_t sample_size = tree_sequence_get_sample_size(ts);
+    uint32_t *samples = malloc(sample_size * sizeof(uint32_t));
+    uint32_t j;
+    double pi;
+
+    CU_ASSERT_FATAL(samples != NULL);
+
+    ret = tree_sequence_get_pairwise_diversity(ts, NULL, 0, &pi);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = tree_sequence_get_pairwise_diversity(ts, NULL, 1, &pi);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = tree_sequence_get_pairwise_diversity(ts, NULL, sample_size + 1, &pi);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+
+    for (j = 0; j < sample_size; j++) {
+        samples[j] = j;
+    }
+    for (j = 2; j < sample_size; j++) {
+        ret = tree_sequence_get_pairwise_diversity(ts, samples, j, &pi);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_TRUE(pi >= 0);
+    }
+    free(samples);
+}
+
+static void
 test_vargen_from_examples(void)
 {
     tree_sequence_t **examples = get_example_tree_sequences(1);
@@ -3872,6 +3901,21 @@ test_vargen_from_examples(void)
     CU_ASSERT_FATAL(examples != NULL);
     for (j = 0; examples[j] != NULL; j++) {
         verify_vargen(examples[j]);
+        tree_sequence_free(examples[j]);
+        free(examples[j]);
+    }
+    free(examples);
+}
+
+static void
+test_stats_from_examples(void)
+{
+    tree_sequence_t **examples = get_example_tree_sequences(1);
+    uint32_t j;
+
+    CU_ASSERT_FATAL(examples != NULL);
+    for (j = 0; examples[j] != NULL; j++) {
+        verify_stats(examples[j]);
         tree_sequence_free(examples[j]);
         free(examples[j]);
     }
@@ -4444,6 +4488,7 @@ main(int argc, char **argv)
         {"Test hapgen from examples", test_hapgen_from_examples},
         {"Test vargen from examples", test_vargen_from_examples},
         {"Test newick from examples", test_newick_from_examples},
+        {"Test stats from examples", test_stats_from_examples},
         {"Test ld from examples", test_ld_from_examples},
         {"Test simplify from examples", test_simplify_from_examples},
         {"Test records equivalent after import", test_records_equivalent},

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -1412,13 +1412,13 @@ tree_sequence_get_pairwise_diversity(tree_sequence_t *self,
         for (j = 0; j < tree->num_mutations; j++) {
             node = tree->mutations[j].node;
             count = (double) tree->num_tracked_leaves[node];
-            result += count * (num_samples - count) / denom;
+            result += count * (num_samples - count);
         }
     }
     if (ret != 0) {
         goto out;
     }
-    *pi = result;
+    *pi = result/denom;
 out:
     if (tree != NULL) {
         sparse_tree_free(tree);

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -1391,6 +1391,10 @@ tree_sequence_get_pairwise_diversity(tree_sequence_t *self,
     sparse_tree_t *tree = NULL;
     double result, denom, count;
 
+    if (num_samples < 2 || num_samples > self->sample_size) {
+        ret = MSP_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
     tree = malloc(sizeof(sparse_tree_t));
     if (tree == NULL) {
         ret = MSP_ERR_NO_MEMORY;
@@ -1405,10 +1409,8 @@ tree_sequence_get_pairwise_diversity(tree_sequence_t *self,
         goto out;
     }
     /* Allocation done; move onto main algorithm. */
-    denom = (num_samples * ((double) num_samples - 1)) / 2.0;
     result = 0.0;
-    for (ret = sparse_tree_first(tree); ret == 1;
-            ret = sparse_tree_next(tree)) {
+    for (ret = sparse_tree_first(tree); ret == 1; ret = sparse_tree_next(tree)) {
         for (j = 0; j < tree->num_mutations; j++) {
             node = tree->mutations[j].node;
             count = (double) tree->num_tracked_leaves[node];
@@ -1418,7 +1420,8 @@ tree_sequence_get_pairwise_diversity(tree_sequence_t *self,
     if (ret != 0) {
         goto out;
     }
-    *pi = result/denom;
+    denom = (num_samples * ((double) num_samples - 1)) / 2.0;
+    *pi = result / denom;
 out:
     if (tree != NULL) {
         sparse_tree_free(tree);

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -617,8 +617,9 @@ class SparseTree(object):
         is provided, iterate over the nodes in required tree traversal order.
 
         :param int root: The root of the subtree we are traversing.
-        :param str order: The traversal ordering. Currently 'preorder', 'inorder',
-            'postorder' and 'levelorder' ('breadthfirst') are supported.
+        :param str order: The traversal ordering. Currently 'preorder',
+            'inorder', 'postorder' and 'levelorder' ('breadthfirst')
+            are supported.
         :rtype: iterator
         """
         u = self.get_root() if root is None else root
@@ -1795,8 +1796,10 @@ class TreeSequence(object):
 
     def get_pairwise_diversity(self, samples=None):
         """
-        Returns the value of pi, the pairwise nucleotide site diversity.
-        If `samples` is specified, calculate the diversity within this set.
+        Returns the value of pi, the pairwise nucleotide site diversity,
+        which is the average number of mutations that differ between a randomly
+        chosen pair of samples.  If `samples` is specified, calculate the
+        diversity within this set.
 
         :param iterable samples: The set of samples within which we calculate
             the diversity. If None, calculate diversity within the entire

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -453,7 +453,7 @@ class HighLevelTestCase(tests.MsprimeTestCase):
         pi2 = simple_get_pairwise_diversity(haplotypes)
         pi3 = get_pairwise_diversity(ts)
         self.assertAlmostEqual(pi1, pi2)
-        self.assertEqual(pi1, pi3)
+        self.assertAlmostEqual(pi1, pi3)
         self.assertGreaterEqual(pi1, 0.0)
         self.assertFalse(math.isnan(pi1))
         # Check for a subsample.
@@ -462,7 +462,7 @@ class HighLevelTestCase(tests.MsprimeTestCase):
         pi2 = simple_get_pairwise_diversity([haplotypes[j] for j in samples])
         pi3 = get_pairwise_diversity(ts, samples)
         self.assertAlmostEqual(pi1, pi2)
-        self.assertEqual(pi1, pi3)
+        self.assertAlmostEqual(pi1, pi3)
         self.assertGreaterEqual(pi1, 0.0)
         self.assertFalse(math.isnan(pi1))
 


### PR DESCRIPTION
Reading the code I noticed this obvious speedup: why not?

I also put in the definition, as it's easy to mix this up with the same thing divided by sequence length.