### PR TITLE
Mutation generator

### DIFF
--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -158,6 +158,8 @@ class SimulationRunner(object):
         self._random_generator = msprime.RandomGenerator(seed)
         self._ms_random_seeds = ms_seeds
         self._simulator.set_random_generator(self._random_generator)
+        self._mutation_generator = msprime.MutationGenerator(
+            self._random_generator, self._mutation_rate)
 
     def get_num_replicates(self):
         """
@@ -188,7 +190,7 @@ class SimulationRunner(object):
         print(" ".join(str(s) for s in self._ms_random_seeds), file=output)
         for j in range(self._num_replicates):
             self._simulator.run()
-            tree_sequence = self._simulator.get_tree_sequence(self._mutation_rate)
+            tree_sequence = self._simulator.get_tree_sequence(self._mutation_generator)
             breakpoints = self._simulator.get_breakpoints()
             print(file=output)
             print("//", file=output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1466,26 +1466,26 @@ class TestUpgrade(TestCli):
     Tests the results of the upgrade operation to ensure they are
     correct.
     """
-    @unittest.skip("v4 format")
     def test_conversion(self):
         ts1 = msprime.simulate(10)
-        v2_file_name = self.temp_file + ".v2"
-        v3_file_name = self.temp_file + ".v3"
-        try:
-            msprime.dump_legacy(ts1, v2_file_name)
-            stdout, stderr = capture_output(
-                cli.msp_main, ["upgrade", v2_file_name, v3_file_name])
-            ts2 = msprime.load(v3_file_name)
-        finally:
-            os.unlink(v2_file_name)
-            os.unlink(v3_file_name)
-        self.assertEqual(stdout, "")
-        # We get some cruft on stderr that comes from h5py. This only happens
-        # because we're mixing h5py and msprime for this test, so we can ignore
-        # it.
-        # self.assertEqual(stderr, "")
-        # Quick checks to ensure we have the right tree sequence.
-        # More thorough checks are done elsewhere.
-        self.assertEqual(ts1.get_sample_size(), ts2.get_sample_size())
-        self.assertEqual(ts1.get_num_records(), ts2.get_num_records())
-        self.assertEqual(ts1.get_num_trees(), ts2.get_num_trees())
+        for version in [2, 3]:
+            legacy_file_name = self.temp_file + ".legacy"
+            current_file_name = self.temp_file + ".current"
+            try:
+                msprime.dump_legacy(ts1, legacy_file_name, version=version)
+                stdout, stderr = capture_output(
+                    cli.msp_main, ["upgrade", legacy_file_name, current_file_name])
+                ts2 = msprime.load(current_file_name)
+            finally:
+                os.unlink(legacy_file_name)
+                os.unlink(current_file_name)
+            self.assertEqual(stdout, "")
+            # We get some cruft on stderr that comes from h5py. This only happens
+            # because we're mixing h5py and msprime for this test, so we can ignore
+            # it.
+            # self.assertEqual(stderr, "")
+            # Quick checks to ensure we have the right tree sequence.
+            # More thorough checks are done elsewhere.
+            self.assertEqual(ts1.get_sample_size(), ts2.get_sample_size())
+            self.assertEqual(ts1.get_num_records(), ts2.get_num_records())
+            self.assertEqual(ts1.get_num_trees(), ts2.get_num_trees())

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -891,11 +891,11 @@ class TestNewickConversion(HighLevelTestCase):
         ]
         for n, m, r, Ne in cases:
             recomb_map = msprime.RecombinationMap.uniform_map(m, r, m)
-            ts = msprime.simulator_factory(
+            sim = msprime.simulator_factory(
                 n, Ne=Ne, recombination_map=recomb_map)
-            ts.run()
-            tree_sequence = ts.get_tree_sequence()
-            breakpoints = ts.get_breakpoints()
+            sim.run()
+            tree_sequence = sim.get_tree_sequence()
+            breakpoints = sim.get_breakpoints()
             self.verify_trees(tree_sequence, breakpoints, Ne)
             self.verify_all_breakpoints(tree_sequence, breakpoints)
 
@@ -1917,6 +1917,27 @@ class TestSimulateInterface(unittest.TestCase):
         self.assertEqual(ts.get_sample_size(), n)
         self.assertEqual(ts.get_num_trees(), 1)
         self.assertGreater(ts.get_num_mutations(), 0)
+
+    def test_mutation_generator(self):
+        n = 10
+        rng = msprime.RandomGenerator(1)
+        mutgen = msprime.MutationGenerator(rng, 10)
+        ts = msprime.simulate(n, mutation_generator=mutgen)
+        self.assertIsInstance(ts, msprime.TreeSequence)
+        self.assertEqual(ts.get_sample_size(), n)
+        self.assertEqual(ts.get_num_trees(), 1)
+        self.assertGreater(ts.get_num_mutations(), 0)
+
+    def test_mutation_interface(self):
+        for bad_type in ["x", [], {}]:
+            self.assertRaises(
+                TypeError, msprime.simulate, 10, mutation_generator=bad_type)
+            self.assertRaises(
+                TypeError, msprime.simulate, 10, mutation_rate=bad_type)
+        mutgen = msprime.MutationGenerator(msprime.RandomGenerator(1), 1)
+        self.assertRaises(
+            ValueError, msprime.simulate, 10, mutation_generator=mutgen,
+            mutation_rate=1)
 
     def test_recombination(self):
         n = 10


### PR DESCRIPTION
Allow the mutation generator to be specified explicitly in simulate. Usage:

```python
mut_rng = msprime.RandomGenerator(mutation_seed)
mutation_generator = msprime.MutationGenerator(mut_rng, mutation_rate)
ts = msprime.simulate(
    sample_size=10, mutation_generator=mutation_generator, random_seed=tree_seed)
```

This opens up the API to specifying different mutation models, as well as having control of the random seed used for generating the mutations.

What do you think @hyanwong? This should fit your use-case where you want to throw different mutations on the same trees.
