### PR TITLE
Bumped HDF5 file format version to 5.

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -36,7 +36,7 @@
 /* Flags for tree sequence dump/load */
 #define MSP_ZLIB_COMPRESSION 1
 
-#define MSP_FILE_FORMAT_VERSION_MAJOR UINT32_MAX
+#define MSP_FILE_FORMAT_VERSION_MAJOR 5
 #define MSP_FILE_FORMAT_VERSION_MINOR 0
 
 /* Flags for simplify() */

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -290,8 +290,7 @@ class TestHdf5Format(TestHdf5):
         root = h5py.File(self.temp_file, "r")
         # Check the basic root attributes
         format_version = root.attrs['format_version']
-        # FIXME marking this version as transitional
-        self.assertEqual(format_version[0], 2**32 - 1)
+        self.assertEqual(format_version[0], 5)
         self.assertEqual(format_version[1], 0)
         keys = set(root.keys())
         self.assertIn("nodes", keys)


### PR DESCRIPTION
This changes the file format version from 4 to 5. The last released version was 3, and the tip of master has been on 4 for a while. This may affect @ashander, @petrelharp and @hyanwong.

Because version 4 was never released, I haven't written an upgrade path for it (doesn't seem worthwhile). If you have version 4 files lying around, the simplest thing to do is to regenerate them using the new code. If this is inconvenient, then it is quite easy to modify the version 4 files so that they are valid v3 files which ``msp upgrade`` will work on using h5py. Just let me know and I'll make a quick script to do so.
