### PR TITLE
Initial changes for samples != {0 ,..., n - 1}.

### DIFF
--- a/lib/dev.cfg
+++ b/lib/dev.cfg
@@ -43,7 +43,7 @@ recombination_map = (
     # until the next breakpoint. This specifies a rate of 0.1 along
     # the interval 0-100.
     [0.0, 0.1],
-    [100000.0, 0.0]
+    [100.0, 0.0]
 );
 
 # The mutation rate in coalescent units.

--- a/lib/err.h
+++ b/lib/err.h
@@ -72,7 +72,6 @@
 #define MSP_ERR_BAD_RECORD_INTERVAL                                 -41
 #define MSP_ERR_ZERO_RECORDS                                        -42
 #define MSP_ERR_NOT_INITIALISED                                     -43
-#define MSP_ERR_SAMPLES_NOT_CONTIGUOUS                              -44
 #define MSP_ERR_UNSORTED_MUTATION_NODES                             -45
 #define MSP_ERR_DUPLICATE_MUTATION_NODES                            -46
 #define MSP_ERR_NONBINARY_MUTATIONS_UNSUPPORTED                     -47

--- a/lib/hapgen.c
+++ b/lib/hapgen.c
@@ -174,6 +174,7 @@ hapgen_alloc(hapgen_t *self, tree_sequence_t *tree_sequence)
     int ret = 0;
     size_t j, k;
     site_t site;
+    node_id_t *samples;
 
     assert(tree_sequence != NULL);
     memset(self, 0, sizeof(hapgen_t));
@@ -181,6 +182,18 @@ hapgen_alloc(hapgen_t *self, tree_sequence_t *tree_sequence)
     self->sequence_length = tree_sequence_get_sequence_length(tree_sequence);
     self->num_sites = tree_sequence_get_num_sites(tree_sequence);
     self->tree_sequence = tree_sequence;
+
+    ret = tree_sequence_get_samples(tree_sequence, &samples);
+    if (ret != 0) {
+        goto out;
+    }
+    /* Check for non simple samples */
+    for (j = 0; j < self->sample_size; j++) {
+        if (samples[j] != (node_id_t) j) {
+            ret = MSP_ERR_UNSUPPORTED_OPERATION;
+            goto out;
+        }
+    }
 
     self->binary = tree_sequence_get_alphabet(tree_sequence) == MSP_ALPHABET_BINARY;
     ret = sparse_tree_alloc(&self->tree, tree_sequence, MSP_LEAF_LISTS);

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -136,9 +136,6 @@ msp_strerror(int err)
         case MSP_ERR_INSUFFICIENT_SAMPLES:
             ret = "At least two samples needed.";
             break;
-        case MSP_ERR_SAMPLES_NOT_CONTIGUOUS:
-            ret = "Samples must be nodes 0, ..., n - 1";
-            break;
         case MSP_ERR_BAD_EDGESET_NONMATCHING_RIGHT:
             ret = "Bad edgeset in file: right coordinate not matching any left coordinate.";
             break;

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -501,6 +501,7 @@ typedef struct {
     size_t sample_size;
     size_t num_nodes;
     int flags;
+    node_id_t *samples;
     node_id_t root;
     /* Left and right physical coordinates of the tree */
     double left;
@@ -729,6 +730,7 @@ size_t tree_sequence_get_num_trees(tree_sequence_t *self);
 size_t tree_sequence_get_sample_size(tree_sequence_t *self);
 double tree_sequence_get_sequence_length(tree_sequence_t *self);
 int tree_sequence_get_alphabet(tree_sequence_t *self);
+bool tree_sequence_is_sample(tree_sequence_t *self, node_id_t u);
 
 int tree_sequence_get_node(tree_sequence_t *self, node_id_t index, node_t *node);
 int tree_sequence_get_edgeset(tree_sequence_t *self, size_t index, edgeset_t *edgeset);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -403,6 +403,7 @@ typedef struct {
         list_len_t *name_length;
         char **name;
         char *name_mem;
+        node_id_t *sample_index_map;
     } nodes;
 
     struct {
@@ -563,6 +564,7 @@ typedef struct {
     double sequence_length;
     size_t num_sites;
     tree_sequence_t *tree_sequence;
+    node_id_t *sample_index_map;
     /* The haplotype binary matrix. This is an optimised special case. */
     bool binary;
     size_t words_per_row;
@@ -578,6 +580,7 @@ typedef struct {
     double sequence_length;
     size_t num_sites;
     tree_sequence_t *tree_sequence;
+    node_id_t *sample_index_map;
     size_t tree_site_index;
     int finished;
     sparse_tree_t tree;
@@ -740,6 +743,8 @@ int tree_sequence_get_site(tree_sequence_t *self, site_id_t id, site_t *site);
 int tree_sequence_get_mutation(tree_sequence_t *self, mutation_id_t id,
         mutation_t *mutation);
 int tree_sequence_get_samples(tree_sequence_t *self, node_id_t **samples);
+int tree_sequence_get_sample_index_map(tree_sequence_t *self,
+        node_id_t **sample_index_map);
 
 int tree_sequence_get_provenance_strings(tree_sequence_t *self,
         size_t *num_provenance_strings, char ***provenance_strings);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -386,10 +386,12 @@ typedef struct {
 /* Tree sequences */
 typedef struct {
     uint32_t initialised_magic;
-    size_t sample_size;
     size_t num_trees;
     double sequence_length;
     int alphabet;
+    size_t sample_size;
+    size_t max_sample_size;
+    node_id_t *samples;
     struct {
         size_t num_records;
         size_t max_num_records;
@@ -735,8 +737,7 @@ int tree_sequence_get_migration(tree_sequence_t *self, size_t index,
 int tree_sequence_get_site(tree_sequence_t *self, site_id_t id, site_t *site);
 int tree_sequence_get_mutation(tree_sequence_t *self, mutation_id_t id,
         mutation_t *mutation);
-int tree_sequence_get_site_mutations(tree_sequence_t *self, site_id_t site_id,
-        mutation_t **mutations, list_len_t *mutations_length);
+int tree_sequence_get_samples(tree_sequence_t *self, node_id_t **samples);
 
 int tree_sequence_get_provenance_strings(tree_sequence_t *self,
         size_t *num_provenance_strings, char ***provenance_strings);

--- a/lib/newick.c
+++ b/lib/newick.c
@@ -460,8 +460,13 @@ newick_converter_alloc(newick_converter_t *self,
     int ret = -1;
     uint32_t j;
     avl_node_t *avl_node;
+    node_id_t *samples;
 
     memset(self, 0, sizeof(newick_converter_t));
+    ret = tree_sequence_get_samples(tree_sequence, &samples);
+    if (ret != 0) {
+        goto out;
+    }
     self->sample_size = tree_sequence_get_sample_size(tree_sequence);
     self->sequence_length = tree_sequence_get_sequence_length(tree_sequence);
     self->precision = precision;
@@ -480,6 +485,11 @@ newick_converter_alloc(newick_converter_t *self,
     avl_init_tree(&self->tree, cmp_newick_tree_node, NULL);
     /* Add in the leaf nodes */
     for (j = 0; j < self->sample_size; j++) {
+        /* We don't support arbitrary samples here */
+        if (samples[j] != (node_id_t) j) {
+            ret = MSP_ERR_UNSUPPORTED_OPERATION;
+            goto out;
+        }
         avl_node = newick_converter_alloc_avl_node(self, (node_id_t) j, 0.0);
         if (avl_node == NULL) {
             ret = MSP_ERR_NO_MEMORY;

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -2838,7 +2838,6 @@ test_simplest_general_samples(void)
 
     tree_sequence_t ts, simplified;
     hapgen_t hapgen;
-    vargen_t vargen;
     newick_converter_t nc;
 
     tree_sequence_from_text(&ts, nodes, edgesets, NULL, sites, mutations, NULL);
@@ -2855,14 +2854,18 @@ test_simplest_general_samples(void)
     CU_ASSERT_EQUAL(samples[0], 0);
     CU_ASSERT_EQUAL(samples[1], 2);
 
+    ret = hapgen_alloc(&hapgen, &ts);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    hapgen_print_state(&hapgen, _devnull);
+    for (j = 0; j < 2; j++) {
+        ret = hapgen_get_haplotype(&hapgen, j, &haplotype);
+        CU_ASSERT_EQUAL(ret, 0);
+        CU_ASSERT_STRING_EQUAL(haplotype, haplotypes[j]);
+    }
+    hapgen_free(&hapgen);
+
     /* For now, all these methods fail when we have non 0...n - 1 samples.
      * They are not difficult to fix though. */
-    ret = hapgen_alloc(&hapgen, &ts);
-    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
-    hapgen_free(&hapgen);
-    ret = vargen_alloc(&vargen, &ts, 0);
-    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
-    vargen_free(&vargen);
     ret = newick_converter_alloc(&nc, &ts, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
     newick_converter_free(&nc);
@@ -5211,11 +5214,7 @@ test_hapgen_from_examples(void)
 
     CU_ASSERT_FATAL(examples != NULL);
     for (j = 0; examples[j] != NULL; j++) {
-        if (j == 5) {
-            printf("\nFIXME hapgen general samples\n");
-        } else {
-            verify_hapgen(examples[j]);
-        }
+        verify_hapgen(examples[j]);
         tree_sequence_free(examples[j]);
         free(examples[j]);
     }
@@ -5374,12 +5373,6 @@ test_vargen_from_examples(void)
     for (j = 0; examples[j] != NULL; j++) {
         if (j == 4) {
             printf("\n\nFIXME multiple mutation vargen\n");
-            tree_sequence_free(examples[j]);
-            free(examples[j]);
-            continue;
-        }
-        if (j == 5) {
-            printf("FIXME arbitrary samples vargen\n");
             tree_sequence_free(examples[j]);
             free(examples[j]);
             continue;
@@ -5693,12 +5686,8 @@ test_save_hdf5(void)
             /* FIXME storing migrations */
             verify_tree_sequences_equal(ts1, &ts2, false, true, true);
             tree_sequence_print_state(&ts2, _devnull);
-            if (j == 5) {
-                printf("\nFIXME: vargen/hapgen HDF5 general samples\n");
-            } else {
-                verify_hapgen(&ts2);
-                verify_vargen(&ts2);
-            }
+            verify_hapgen(&ts2);
+            verify_vargen(&ts2);
             tree_sequence_free(&ts2);
         }
         tree_sequence_free(ts1);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -30,6 +30,7 @@
 
 #include <hdf5.h>
 #include <gsl/gsl_math.h>
+#include <gsl/gsl_randist.h>
 #include <CUnit/Basic.h>
 
 /* Global variables used for test in state in the test suite */
@@ -46,6 +47,13 @@ typedef struct {
     uint32_t population_id;
     double parameter;
 } bottleneck_desc_t;
+
+static int
+cmp_node_id_t(const void *a, const void *b) {
+    const node_id_t *ia = (const node_id_t *) a;
+    const node_id_t *ib = (const node_id_t *) b;
+    return (*ia > *ib) - (*ia < *ib);
+}
 
 /* Example tree sequences used in some of the tests. */
 
@@ -540,11 +548,9 @@ verify_stats(tree_sequence_t *ts)
 {
     int ret;
     uint32_t sample_size = tree_sequence_get_sample_size(ts);
-    node_id_t *samples = malloc(sample_size * sizeof(node_id_t));
+    node_id_t *samples;
     uint32_t j;
     double pi;
-
-    CU_ASSERT_FATAL(samples != NULL);
 
     ret = tree_sequence_get_pairwise_diversity(ts, NULL, 0, &pi);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
@@ -553,15 +559,14 @@ verify_stats(tree_sequence_t *ts)
     ret = tree_sequence_get_pairwise_diversity(ts, NULL, sample_size + 1, &pi);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
 
-    for (j = 0; j < sample_size; j++) {
-        samples[j] = j;
-    }
+    ret = tree_sequence_get_samples(ts, &samples);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
     for (j = 2; j < sample_size; j++) {
         ret = tree_sequence_get_pairwise_diversity(ts, samples, j, &pi);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_TRUE(pi >= 0);
     }
-    free(samples);
 }
 
 static void
@@ -672,14 +677,12 @@ verify_simplify(tree_sequence_t *ts)
     uint32_t n = tree_sequence_get_sample_size(ts);
     uint32_t sample_sizes[] = {2, 3, n / 2, n - 1, n};
     size_t j;
-    node_id_t *sample = malloc(n * sizeof(node_id_t));
+    node_id_t *sample;
     tree_sequence_t subset;
     int flags = MSP_FILTER_INVARIANT_SITES;
 
-    CU_ASSERT_FATAL(sample != NULL);
-    for (j = 0; j < n; j++) {
-        sample[j] = j;
-    }
+    ret = tree_sequence_get_samples(ts, &sample);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_initialise(&subset);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     for (j = 0; j < sizeof(sample_sizes) / sizeof(uint32_t); j++) {
@@ -690,7 +693,6 @@ verify_simplify(tree_sequence_t *ts)
         }
     }
     tree_sequence_free(&subset);
-    free(sample);
 }
 
 static void
@@ -1019,6 +1021,94 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     return new_ts;
 }
 
+tree_sequence_t *
+make_permuted_nodes_copy(tree_sequence_t *ts)
+{
+    int ret;
+    size_t j, k;
+    size_t alloc_size = 8192;
+    size_t MAX_CHILDREN = 1024;
+    tree_sequence_t *new_ts = malloc(sizeof(tree_sequence_t));
+    node_table_t nodes;
+    edgeset_table_t edgesets;
+    migration_table_t migrations;
+    mutation_table_t mutations;
+    site_table_t sites;
+    node_id_t *node_map;
+    node_t node;
+    edgeset_t edgeset;
+    node_id_t mapped_children[MAX_CHILDREN];
+    gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
+    size_t num_nodes = tree_sequence_get_num_nodes(ts);
+    char **provenance_strings;
+    size_t num_provenance_strings;
+
+    CU_ASSERT_FATAL(new_ts != NULL);
+    ret = node_table_alloc(&nodes, alloc_size, alloc_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = edgeset_table_alloc(&edgesets, alloc_size, alloc_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = migration_table_alloc(&migrations, alloc_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = site_table_alloc(&sites, alloc_size, alloc_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = mutation_table_alloc(&mutations, alloc_size, alloc_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    node_map = malloc(num_nodes * sizeof(node_id_t));
+    CU_ASSERT_FATAL(node_map != NULL);
+
+    ret = tree_sequence_dump_tables_tmp(ts, &nodes, &edgesets,
+            &migrations, &sites, &mutations, &num_provenance_strings,
+            &provenance_strings);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    for (j = 0; j < num_nodes; j++) {
+        node_map[j] = j;
+    }
+    gsl_rng_set(rng, 1);
+    gsl_ran_shuffle(rng, node_map, num_nodes, sizeof(node_id_t));
+    for (j = 0; j < num_nodes; j++) {
+        ret = tree_sequence_get_node(ts, j, &node);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        nodes.flags[node_map[j]] = node.flags;
+        nodes.time[node_map[j]] = node.time;
+        nodes.population[node_map[j]] = node.population;
+        /* Assume all names are 0 length */
+    }
+    edgeset_table_reset(&edgesets);
+    for (j = 0; j < tree_sequence_get_num_edgesets(ts); j++) {
+        ret = tree_sequence_get_edgeset(ts, j, &edgeset);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_FATAL(edgeset.children_length < MAX_CHILDREN);
+        for (k = 0; k < edgeset.children_length; k++) {
+            mapped_children[k] = node_map[edgeset.children[k]];
+        }
+        qsort(mapped_children, edgeset.children_length, sizeof(node_id_t),
+                cmp_node_id_t);
+        ret = edgeset_table_add_row(&edgesets, edgeset.left, edgeset.right,
+                node_map[edgeset.parent], mapped_children, edgeset.children_length);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+    }
+    for (j = 0; j < mutations.num_rows; j++) {
+        mutations.node[j] = node_map[mutations.node[j]];
+    }
+
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tree_sequence_initialise(new_ts);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tree_sequence_load_tables_tmp(new_ts, &nodes, &edgesets, &migrations,
+            &sites, &mutations, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    node_table_free(&nodes);
+    edgeset_table_free(&edgesets);
+    migration_table_free(&migrations);
+    site_table_free(&sites);
+    mutation_table_free(&mutations);
+    gsl_rng_free(rng);
+    free(node_map);
+    return new_ts;
+}
+
 tree_sequence_t **
 get_example_tree_sequences(int include_nonbinary)
 {
@@ -1037,7 +1127,8 @@ get_example_tree_sequences(int include_nonbinary)
     ret[3] = get_example_tree_sequence(10, 0, UINT32_MAX, 10.0,
             9.31322575049e-08, 10.0, 0, NULL, MSP_ALPHABET_BINARY);
     ret[4] = make_recurrent_and_back_mutations_copy(ret[0]);
-    k = 5;
+    ret[5] = make_permuted_nodes_copy(ret[0]);
+    k = 6;
     if (include_nonbinary) {
         nonbinary = get_example_nonbinary_tree_sequences();
         for (j = 0; nonbinary[j] != NULL; j++) {
@@ -2725,7 +2816,7 @@ test_simplest_back_mutations(void)
 }
 
 static void
-test_simplest_non_contigous_samples(void)
+test_simplest_general_samples(void)
 {
     const char *nodes =
         "1  0   0\n"
@@ -2745,8 +2836,10 @@ test_simplest_non_contigous_samples(void)
     node_id_t *samples;
     int ret;
 
-    tree_sequence_t ts;
+    tree_sequence_t ts, simplified;
     hapgen_t hapgen;
+    vargen_t vargen;
+    newick_converter_t nc;
 
     tree_sequence_from_text(&ts, nodes, edgesets, NULL, sites, mutations, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
@@ -2759,18 +2852,43 @@ test_simplest_non_contigous_samples(void)
     ret = tree_sequence_get_samples(&ts, &samples);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_FATAL(samples != NULL);
+    CU_ASSERT_EQUAL(samples[0], 0);
+    CU_ASSERT_EQUAL(samples[1], 2);
 
+    /* For now, all these methods fail when we have non 0...n - 1 samples.
+     * They are not difficult to fix though. */
     ret = hapgen_alloc(&hapgen, &ts);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+    hapgen_free(&hapgen);
+    ret = vargen_alloc(&vargen, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+    vargen_free(&vargen);
+    ret = newick_converter_alloc(&nc, &ts, 1, 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+    newick_converter_free(&nc);
+
+    ret = tree_sequence_initialise(&simplified);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tree_sequence_simplify(&ts, samples, 2, 0, &simplified);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tree_sequence_get_samples(&simplified, &samples);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_FATAL(samples != NULL);
+    CU_ASSERT_EQUAL(samples[0], 0);
+    CU_ASSERT_EQUAL(samples[1], 1);
+
+    ret = hapgen_alloc(&hapgen, &simplified);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     hapgen_print_state(&hapgen, _devnull);
     for (j = 0; j < 2; j++) {
         ret = hapgen_get_haplotype(&hapgen, j, &haplotype);
-        printf("FIXME: haplotype = %s: %s\n", haplotype, haplotypes[j]);
         CU_ASSERT_EQUAL(ret, 0);
-        /* CU_ASSERT_STRING_EQUAL(haplotype, haplotypes[j]); */
+        CU_ASSERT_STRING_EQUAL(haplotype, haplotypes[j]);
     }
     hapgen_free(&hapgen);
 
+    tree_sequence_free(&simplified);
     tree_sequence_free(&ts);
 }
 
@@ -3402,7 +3520,6 @@ test_single_tree_iter(void)
 static void
 test_single_nonbinary_tree_iter(void)
 {
-
     int ret;
     const char *nodes =
         "1  0   0\n"
@@ -3495,6 +3612,74 @@ test_single_nonbinary_tree_iter(void)
     ret = sparse_tree_get_mrca(&tree, 0, 4, &w);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(w, 9);
+
+    ret = sparse_tree_next(&tree);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    sparse_tree_free(&tree);
+    tree_sequence_free(&ts);
+}
+
+static void
+test_single_tree_general_samples_iter(void)
+{
+    int ret;
+    const char *nodes =
+        "0  3   0\n"
+        "0  2   0\n"
+        "0  1   0\n"
+        "1  0   0\n"
+        "1  0   0\n"
+        "1  0   0\n"
+        "1  0   0\n";
+    const char *edgesets =
+        "0  6   2   3,4\n"
+        "0  6   1   5,6\n"
+        "0  6   0   1,2\n";
+    node_id_t parents[] = {MSP_NULL_NODE, 0, 0, 2, 2, 1, 1};
+    node_id_t *samples;
+    tree_sequence_t ts;
+    sparse_tree_t tree;
+    node_id_t u, v, w;
+    size_t num_leaves;
+    uint32_t num_nodes = 7;
+
+    tree_sequence_from_text(&ts, nodes, edgesets, NULL, NULL, NULL, NULL);
+    ret = tree_sequence_get_samples(&ts, &samples);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(samples[0], 3);
+    CU_ASSERT_EQUAL(samples[1], 4);
+    CU_ASSERT_EQUAL(samples[2], 5);
+    CU_ASSERT_EQUAL(samples[3], 6);
+
+    ret = sparse_tree_alloc(&tree, &ts, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = sparse_tree_first(&tree);
+    CU_ASSERT_EQUAL(ret, 1);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), num_nodes);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_trees(&ts), 1);
+    sparse_tree_print_state(&tree, _devnull);
+
+    for (u = 0; u < num_nodes; u++) {
+        ret = sparse_tree_get_parent(&tree, u, &v);
+        CU_ASSERT_EQUAL(ret, 0);
+        CU_ASSERT_EQUAL(v, parents[u]);
+    }
+    ret = sparse_tree_get_num_leaves(&tree, 3, &num_leaves);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(num_leaves, 1);
+    ret = sparse_tree_get_num_leaves(&tree, 2, &num_leaves);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(num_leaves, 2);
+    ret = sparse_tree_get_num_leaves(&tree, 0, &num_leaves);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(num_leaves, 4);
+    ret = sparse_tree_get_mrca(&tree, 3, 4, &w);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(w, 2);
+    ret = sparse_tree_get_mrca(&tree, 3, 6, &w);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(w, 0);
 
     ret = sparse_tree_next(&tree);
     CU_ASSERT_EQUAL(ret, 0);
@@ -4008,8 +4193,11 @@ verify_trees_consistent(tree_sequence_t *ts)
     node_id_t u, v, root, *children;
     size_t j, k, num_children;
     sparse_tree_t tree;
+    node_id_t *samples;
 
     sample_size = tree_sequence_get_sample_size(ts);
+    ret = tree_sequence_get_samples(ts, &samples);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = sparse_tree_alloc(&tree, ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
 
@@ -4021,7 +4209,7 @@ verify_trees_consistent(tree_sequence_t *ts)
         CU_ASSERT_EQUAL(tree.index, num_trees);
         num_trees++;
         for (j = 0; j < sample_size; j++) {
-            v = j;
+            v = samples[j];
             while (v != MSP_NULL_NODE) {
                 u = v;
                 ret = sparse_tree_get_parent(&tree, u, &v);
@@ -4055,6 +4243,7 @@ test_sparse_tree_errors(void)
     size_t j;
     uint32_t num_nodes = 9;
     uint32_t u;
+    node_t node;
     tree_sequence_t ts, other_ts;
     sparse_tree_t t, other_t;
     node_id_t bad_nodes[] = {num_nodes, num_nodes + 1, -1};
@@ -4088,10 +4277,17 @@ test_sparse_tree_errors(void)
         CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
         ret = sparse_tree_get_leaf_list(&t, u, NULL, NULL);
         CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
+        /* Also check tree sequence methods */
+        ret = tree_sequence_get_node(&ts, u, &node);
+        CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
+        CU_ASSERT(!tree_sequence_is_sample(&ts, u));
     }
 
     tracked_leaves[0] = 0;
     tracked_leaves[1] = tree_sequence_get_sample_size(&ts);
+    ret = sparse_tree_set_tracked_leaves(&t, 2, tracked_leaves);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SAMPLES);
+    tracked_leaves[1] = tree_sequence_get_num_nodes(&ts);
     ret = sparse_tree_set_tracked_leaves(&t, 2, tracked_leaves);
     CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
     tracked_leaves[1] = 0;
@@ -4217,16 +4413,17 @@ typedef struct {
 } leaf_count_test_t;
 
 static void
-verify_leaf_counts(tree_sequence_t *ts, size_t num_tests,
-        leaf_count_test_t *tests)
+verify_leaf_counts(tree_sequence_t *ts, size_t num_tests, leaf_count_test_t *tests)
 {
     int ret;
     size_t j, num_leaves, n, k;
-    node_id_t *tracked_leaves = NULL;
     sparse_tree_t tree;
     leaf_list_node_t *u, *head, *tail;
+    node_id_t *samples;
 
     n = tree_sequence_get_sample_size(ts);
+    ret = tree_sequence_get_samples(ts, &samples);
+    CU_ASSERT_EQUAL(ret, 0);
 
     /* First run without the MSP_LEAF_COUNTS feature */
     ret = sparse_tree_alloc(&tree, ts, 0);
@@ -4305,13 +4502,9 @@ verify_leaf_counts(tree_sequence_t *ts, size_t num_tests,
     sparse_tree_free(&tree);
 
     /* Now use MSP_LEAF_COUNTS|MSP_LEAF_LISTS */
-    tracked_leaves = malloc(n * sizeof(node_id_t));
-    for (j = 0; j < n; j++) {
-        tracked_leaves[j] = j;
-    }
     ret = sparse_tree_alloc(&tree, ts, MSP_LEAF_COUNTS|MSP_LEAF_LISTS);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = sparse_tree_set_tracked_leaves(&tree, n, tracked_leaves);
+    ret = sparse_tree_set_tracked_leaves(&tree, n, samples);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_first(&tree);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -4323,10 +4516,10 @@ verify_leaf_counts(tree_sequence_t *ts, size_t num_tests,
         ret = sparse_tree_get_num_leaves(&tree, tests[j].node, &num_leaves);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_EQUAL(tests[j].count, num_leaves);
+
         /* We're tracking all leaves, so the count should be the same */
-        ret = sparse_tree_get_num_tracked_leaves(&tree, tests[j].node,
-                &num_leaves);
-        CU_ASSERT_EQUAL(ret, 0);
+        ret = sparse_tree_get_num_tracked_leaves(&tree, tests[j].node, &num_leaves);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_EQUAL(tests[j].count, num_leaves);
         ret = sparse_tree_get_leaf_list(&tree, tests[j].node, &head, &tail);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4342,7 +4535,6 @@ verify_leaf_counts(tree_sequence_t *ts, size_t num_tests,
         CU_ASSERT_EQUAL(tests[j].count, k);
     }
     sparse_tree_free(&tree);
-    free(tracked_leaves);
 }
 
 
@@ -4363,7 +4555,7 @@ verify_leaf_sets_for_tree(sparse_tree_t *tree)
     CU_ASSERT_FATAL(stack != NULL);
     CU_ASSERT_FATAL(leaves != NULL);
     for (u = 0; u < num_nodes; u++) {
-        if (tree->num_children[u] == 0 && u >= n) {
+        if (tree->num_children[u] == 0 && !tree_sequence_is_sample(ts, u)) {
             ret = sparse_tree_get_leaf_list(tree, u, &head, &tail);
             CU_ASSERT_EQUAL(ret, 0);
             CU_ASSERT_EQUAL(head, NULL);
@@ -4375,7 +4567,7 @@ verify_leaf_sets_for_tree(sparse_tree_t *tree)
             while (stack_top >= 0) {
                 v = stack[stack_top];
                 stack_top--;
-                if (v < n) {
+                if (tree_sequence_is_sample(ts, v)) {
                     leaves[num_leaves] = v;
                     num_leaves++;
                 }
@@ -4800,6 +4992,7 @@ verify_tree_diffs(tree_sequence_t *ts)
     node_id_t u;
     node_id_t *pi = malloc(num_nodes * sizeof(node_id_t));
     double *tau = malloc(num_nodes * sizeof(double));
+    node_id_t *samples;
     int first_tree;
 
     CU_ASSERT_FATAL(pi != NULL);
@@ -4808,6 +5001,8 @@ verify_tree_diffs(tree_sequence_t *ts)
         pi[j] = MSP_NULL_NODE;
         tau[j] = 0.0;
     }
+    ret = tree_sequence_get_samples(ts, &samples);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_diff_iterator_alloc(&iter, ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = sparse_tree_alloc(&tree, ts, 0);
@@ -4815,9 +5010,8 @@ verify_tree_diffs(tree_sequence_t *ts)
     ret = sparse_tree_first(&tree);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     tree_diff_iterator_print_state(&iter, _devnull);
-    /* FIXME general samples will break this */
     for (j = 0; j < tree_sequence_get_sample_size(ts); j++) {
-        ret = tree_sequence_get_node(ts, j, &node);
+        ret = tree_sequence_get_node(ts, samples[j], &node);
         CU_ASSERT_EQUAL(ret, 0);
         tau[j] = node.time;
     }
@@ -5017,7 +5211,11 @@ test_hapgen_from_examples(void)
 
     CU_ASSERT_FATAL(examples != NULL);
     for (j = 0; examples[j] != NULL; j++) {
-        verify_hapgen(examples[j]);
+        if (j == 5) {
+            printf("\nFIXME hapgen general samples\n");
+        } else {
+            verify_hapgen(examples[j]);
+        }
         tree_sequence_free(examples[j]);
         free(examples[j]);
     }
@@ -5180,6 +5378,12 @@ test_vargen_from_examples(void)
             free(examples[j]);
             continue;
         }
+        if (j == 5) {
+            printf("FIXME arbitrary samples vargen\n");
+            tree_sequence_free(examples[j]);
+            free(examples[j]);
+            continue;
+        }
         verify_vargen(examples[j]);
         tree_sequence_free(examples[j]);
         free(examples[j]);
@@ -5212,22 +5416,33 @@ static void
 verify_simplify_errors(tree_sequence_t *ts)
 {
     int ret;
-    uint32_t n = tree_sequence_get_sample_size(ts);
+    node_id_t *s;
+    node_id_t u;
     tree_sequence_t subset;
-    node_id_t sample[] = {0, 1, 2, 3};
+    node_id_t sample[2] = {};
+
+    ret = tree_sequence_get_samples(ts, &s);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    memcpy(sample, s, 2 * sizeof(node_id_t));
 
     ret = tree_sequence_simplify(ts, sample, 0, 0, &subset);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     ret = tree_sequence_simplify(ts, sample, 1, 0, &subset);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    sample[1] = n;
+    for (u = 0; u < (node_id_t) tree_sequence_get_num_nodes(ts); u++) {
+        if (! tree_sequence_is_sample(ts, u)) {
+            sample[1] = u;
+            ret = tree_sequence_simplify(ts, sample, 2, 0, &subset);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SAMPLES);
+        }
+    }
+    sample[0] = -1;
     ret = tree_sequence_simplify(ts, sample, 2, 0, &subset);
-    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SAMPLES);
-    sample[0] = 0;
-    sample[1] = 0;
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_OUT_OF_BOUNDS);
+    sample[0] = s[0];
+    sample[1] = s[0];
     ret = tree_sequence_simplify(ts, sample, 2, 0, &subset);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_DUPLICATE_SAMPLE);
-
 }
 
 static void
@@ -5279,7 +5494,11 @@ test_newick_from_examples(void)
 
     CU_ASSERT_FATAL(examples != NULL);
     for (j = 0; examples[j] != NULL; j++) {
-        verify_newick(examples[j], false);
+        if (j == 5) {
+            printf("\nFIXME arbitrary sample newick\n");
+        } else {
+            verify_newick(examples[j], false);
+        }
         tree_sequence_free(examples[j]);
         free(examples[j]);
     }
@@ -5474,8 +5693,12 @@ test_save_hdf5(void)
             /* FIXME storing migrations */
             verify_tree_sequences_equal(ts1, &ts2, false, true, true);
             tree_sequence_print_state(&ts2, _devnull);
-            verify_hapgen(&ts2);
-            verify_vargen(&ts2);
+            if (j == 5) {
+                printf("\nFIXME: vargen/hapgen HDF5 general samples\n");
+            } else {
+                verify_hapgen(&ts2);
+                verify_vargen(&ts2);
+            }
             tree_sequence_free(&ts2);
         }
         tree_sequence_free(ts1);
@@ -6241,7 +6464,7 @@ main(int argc, char **argv)
         {"test_simplest_multiple_root_records", test_simplest_multiple_root_records},
         {"test_simplest_root_mutations", test_simplest_root_mutations},
         {"test_simplest_back_mutations", test_simplest_back_mutations},
-        {"test_simplest_non_contigous_samples", test_simplest_non_contigous_samples},
+        {"test_simplest_general_samples", test_simplest_general_samples},
         {"test_simplest_bad_records", test_simplest_bad_records},
         {"test_alphabet_detection", test_alphabet_detection},
         {"test_single_tree_good_records", test_single_tree_good_records},
@@ -6251,6 +6474,7 @@ main(int argc, char **argv)
         {"test_single_tree_good_mutations", test_single_tree_good_mutations},
         {"test_single_tree_bad_mutations", test_single_tree_bad_mutations},
         {"test_single_tree_iter", test_single_tree_iter},
+        {"test_single_tree_general_samples_iter", test_single_tree_general_samples_iter},
         {"test_single_nonbinary_tree_iter", test_single_nonbinary_tree_iter},
         {"test_single_tree_iter_times", test_single_tree_iter_times},
         {"test_single_tree_hapgen_char_alphabet", test_single_tree_hapgen_char_alphabet},

--- a/lib/vargen.c
+++ b/lib/vargen.c
@@ -52,8 +52,6 @@ int
 vargen_alloc(vargen_t *self, tree_sequence_t *tree_sequence, int flags)
 {
     int ret = MSP_ERR_NO_MEMORY;
-    node_id_t *samples;
-    size_t j;
 
     assert(tree_sequence != NULL);
     memset(self, 0, sizeof(vargen_t));
@@ -71,18 +69,11 @@ vargen_alloc(vargen_t *self, tree_sequence_t *tree_sequence, int flags)
     self->num_sites = tree_sequence_get_num_sites(tree_sequence);
     self->tree_sequence = tree_sequence;
     self->flags = flags;
-
-    /* For now, just disallow non {0, ..., n - 1} samples outright */
-    ret = tree_sequence_get_samples(tree_sequence, &samples);
+    ret = tree_sequence_get_sample_index_map(tree_sequence, &self->sample_index_map);
     if (ret != 0) {
         goto out;
     }
-    for (j = 0; j < self->sample_size; j++) {
-        if (samples[j] != (node_id_t) j) {
-            ret = MSP_ERR_UNSUPPORTED_OPERATION;
-            goto out;
-        }
-    }
+
     ret = sparse_tree_alloc(&self->tree, tree_sequence, MSP_LEAF_LISTS);
     if (ret != 0) {
         goto out;
@@ -110,6 +101,7 @@ vargen_apply_tree_site(vargen_t *self, site_t *site, char *genotypes, char state
 {
     int ret = 0;
     leaf_list_node_t *w, *tail;
+    node_id_t sample_index;
     bool not_done;
     list_len_t j;
     char derived;
@@ -126,12 +118,13 @@ vargen_apply_tree_site(vargen_t *self, site_t *site, char *genotypes, char state
             not_done = true;
             while (not_done) {
                 assert(w != NULL);
-                assert(w->node >= 0 && w->node < (node_id_t) self->sample_size);
-                if (genotypes[w->node] == derived) {
+                sample_index = self->sample_index_map[w->node];
+                assert(sample_index >= 0);
+                if (genotypes[sample_index] == derived) {
                     ret = MSP_ERR_INCONSISTENT_MUTATIONS;
                     goto out;
                 }
-                genotypes[w->node] = derived;
+                genotypes[sample_index] = derived;
                 not_done = w != tail;
                 w = w->next;
             }

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -523,13 +523,13 @@ class SparseTree(object):
     def is_leaf(self, u):
         """
         Returns True if the specified node is a leaf. A node :math:`u` is a
-        leaf if :math:`0 \leq u < n` for a sample size :math:`n`.
+        leaf if it has zero children.
 
         :param int u: The node of interest.
         :return: True if u is a leaf node.
         :rtype: bool
         """
-        return 0 <= u < self.get_sample_size()
+        return len(self.children(u)) == 0
 
     @property
     def num_nodes(self):
@@ -2164,7 +2164,7 @@ class TreeSequence(object):
         :rtype: float
         """
         if samples is None:
-            leaves = list(range(self.get_sample_size()))
+            leaves = self.samples()
         else:
             leaves = list(samples)
         return self._ll_tree_sequence.get_pairwise_diversity(leaves)
@@ -2365,7 +2365,7 @@ class TreeSequence(object):
             If None, return samples from all populations.
         :rtype: list
         """
-        samples = list(range(self.get_sample_size()))
+        samples = self._ll_tree_sequence.get_samples()
         if population_id is not None:
             samples = [
                 u for u in samples if self.get_population(u) == population_id]

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -50,7 +50,7 @@ import _msprime
 import tests
 
 
-def get_example_tree_sequences():
+def get_example_tree_sequences(back_mutations=True):
     for n in [2, 3, 10, 100]:
         for m in [1, 2, 32]:
             for rho in [0, 0.1, 0.5]:
@@ -62,7 +62,8 @@ def get_example_tree_sequences():
         yield ts
     ts = msprime.simulate(30, length=20, recombination_rate=1)
     assert ts.num_trees > 1
-    yield make_alternating_back_mutations(ts)
+    if back_mutations:
+        yield make_alternating_back_mutations(ts)
 
 
 def get_bottleneck_examples():
@@ -113,7 +114,7 @@ def get_pairwise_diversity(tree_sequence, samples=None):
     and should return identical results.
     """
     if samples is None:
-        tracked_leaves = list(range(tree_sequence.get_sample_size()))
+        tracked_leaves = tree_sequence.get_samples()
     else:
         tracked_leaves = list(samples)
     if len(tracked_leaves) < 2:
@@ -937,6 +938,12 @@ class TestTreeSequence(HighLevelTestCase):
     def test_sparse_trees(self):
         for ts in get_example_tree_sequences():
             self.verify_sparse_trees(ts)
+
+    def test_mutations(self):
+        # TODO enable the back_mutations here once this has been implemented
+        # for pi and variants.
+        for ts in get_example_tree_sequences(back_mutations=False):
+            self.verify_mutations(ts)
 
     def verify_tree_diffs(self, ts):
         pts = tests.PythonTreeSequence(ts.get_ll_tree_sequence())

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2039,6 +2039,12 @@ class TestTreeSequence(LowLevelTestCase):
         for j in [0, 10, 10**6]:
             self.assertRaises(IndexError, ts.get_migration, num_records + j)
 
+    def test_get_samples(self):
+        ts = self.get_example_migration_tree_sequence()
+        # get_samples takes no arguments.
+        self.assertRaises(TypeError, ts.get_samples, 0)
+        self.assertEqual(list(range(ts.get_sample_size())), ts.get_samples())
+
     def test_migrations(self):
         sim = get_example_simulator(10, num_populations=3, store_migrations=True)
         sim.run()
@@ -2100,7 +2106,6 @@ class TestTreeSequence(LowLevelTestCase):
             pi1 = ts.get_pairwise_diversity(samples)
             self.assertGreaterEqual(pi1, 0)
 
-    @unittest.skip("SKIP simplify")
     def test_simplify(self):
         out = _msprime.TreeSequence()
         for ts in self.get_example_tree_sequences():
@@ -2110,6 +2115,8 @@ class TestTreeSequence(LowLevelTestCase):
             self.assertRaises(ValueError, ts.simplify, out, [])
             self.assertRaises(ValueError, ts.simplify, out, [0])
             self.assertRaises(ValueError, ts.simplify, out, [0, ts.get_sample_size()])
+            self.assertRaises(ValueError, ts.simplify, out, [0, -1])
+            self.assertRaises(ValueError, ts.simplify, out, [0, ts.get_num_nodes()])
             self.assertRaises(_msprime.LibraryError, ts.simplify, out, [0, 0])
             s1 = _msprime.TreeSequence()
             ts.simplify(s1, [0, 1])

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -372,8 +372,10 @@ class TestGeneralSamples(TopologyTestCase):
         t = next(ts.trees())
         self.assertEqual(t.root, 0)
         self.assertEqual(t.parent_dict, {1: 0, 2: 1, 3: 1, 4: 0})
-        self.assertRaises(_msprime.LibraryError, ts.haplotypes)
-        self.assertRaises(_msprime.LibraryError, list, ts.variants())
+        H = list(ts.haplotypes())
+        self.assertEqual(H[0], "1001")
+        self.assertEqual(H[1], "0101")
+        self.assertEqual(H[2], "0010")
         self.assertRaises(_msprime.LibraryError, list, ts.newick_trees())
 
         tss = ts.simplify()
@@ -402,13 +404,16 @@ class TestGeneralSamples(TopologyTestCase):
         node_map = list(range(ts.num_nodes))
         random.shuffle(node_map)
         # Change the permutation so that the relative order of samples is maintained.
-        # Then, we should get back exactly the same tree sequence after simplify.
+        # Then, we should get back exactly the same tree sequence after simplify
+        # and haplotypes and variants are also equal.
         samples = sorted(node_map[:ts.sample_size])
         node_map = samples + node_map[ts.sample_size:]
         permuted = permute_nodes(ts, node_map)
         self.assertEqual(permuted.samples(), samples)
-        self.assertRaises(_msprime.LibraryError, permuted.haplotypes)
-        self.assertRaises(_msprime.LibraryError, list, permuted.variants())
+        self.assertEqual(list(permuted.haplotypes()), list(ts.haplotypes()))
+        self.assertEqual(
+            [v.genotypes for v in permuted.variants(as_bytes=True)],
+            [v.genotypes for v in ts.variants(as_bytes=True)])
         self.assertEqual(ts.num_trees, permuted.num_trees)
         j = 0
         for t1, t2 in zip(ts.trees(), permuted.trees()):

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -22,12 +22,55 @@ Test cases for the supported topological variations and operations.
 from __future__ import print_function
 from __future__ import division
 
+try:
+    # We use the zip as iterator functionality here.
+    from future_builtins import zip
+except ImportError:
+    # This fails for Python 3.x, but that's fine.
+    pass
+
 import unittest
 import itertools
+import random
 import six
 
 import msprime
 import _msprime
+
+
+def permute_nodes(ts, node_map):
+    """
+    Returns a copy of the specified tree sequence such that the nodes are
+    permuted according to the specified map.
+    """
+    # Mapping from nodes in the new tree sequence back to nodes in the original
+    reverse_map = [0 for _ in node_map]
+    for j in range(ts.num_nodes):
+        reverse_map[node_map[j]] = j
+    old_nodes = list(ts.nodes())
+    new_nodes = msprime.NodeTable()
+    for j in range(ts.num_nodes):
+        old_node = old_nodes[reverse_map[j]]
+        new_nodes.add_row(
+            flags=old_node.flags, name=old_node.name,
+            population=old_node.population, time=old_node.time)
+    new_edgesets = msprime.EdgesetTable()
+    for edgeset in ts.edgesets():
+        new_edgesets.add_row(
+            left=edgeset.left, right=edgeset.right, parent=node_map[edgeset.parent],
+            children=tuple(sorted([node_map[c] for c in edgeset.children])))
+    new_sites = msprime.SiteTable()
+    new_mutations = msprime.MutationTable()
+    for site in ts.sites():
+        new_sites.add_row(
+            position=site.position, ancestral_state=site.ancestral_state)
+        for mutation in site.mutations:
+            new_mutations.add_row(
+                site=site.index, derived_state=mutation.derived_state,
+                node=node_map[mutation.node])
+    return msprime.load_tables(
+        nodes=new_nodes, edgesets=new_edgesets, sites=new_sites,
+        mutations=new_mutations)
 
 
 def insert_redundant_breakpoints(ts):
@@ -280,6 +323,138 @@ class TestUnaryNodes(TopologyTestCase):
                 found = True
         self.assertTrue(found)
         self.verify_unary_tree_sequence(ts)
+
+
+class TestGeneralSamples(TopologyTestCase):
+    """
+    Test cases in which we have samples at arbitrary nodes (i.e., not at
+    {0,...,n - 1}).
+    """
+    def test_simple_case(self):
+        # Simple case where we have n = 3 and samples starting at n.
+        nodes = six.StringIO("""\
+        id      is_sample   time
+        0       0           2
+        1       0           1
+        2       1           0
+        3       1           0
+        4       1           0
+        """)
+        edgesets = six.StringIO("""\
+        left    right   parent  children
+        0       1       1       2,3
+        0       1       0       1,4
+        """)
+        sites = six.StringIO("""\
+        position    ancestral_state
+        0.1     0
+        0.2     0
+        0.3     0
+        0.4     0
+        """)
+        mutations = six.StringIO("""\
+        site    node    derived_state
+        0       2       1
+        1       3       1
+        2       4       1
+        3       1       1
+        """)
+        ts = msprime.load_text(
+            nodes=nodes, edgesets=edgesets, sites=sites, mutations=mutations)
+
+        self.assertEqual(ts.sample_size, 3)
+        self.assertEqual(ts.samples(), [2, 3, 4])
+        self.assertEqual(ts.num_nodes, 5)
+        self.assertEqual(ts.num_nodes, 5)
+        self.assertEqual(ts.num_sites, 4)
+        self.assertEqual(ts.num_mutations, 4)
+        self.assertEqual(len(list(ts.diffs())), ts.num_trees)
+        t = next(ts.trees())
+        self.assertEqual(t.root, 0)
+        self.assertEqual(t.parent_dict, {1: 0, 2: 1, 3: 1, 4: 0})
+        self.assertRaises(_msprime.LibraryError, ts.haplotypes)
+        self.assertRaises(_msprime.LibraryError, list, ts.variants())
+        self.assertRaises(_msprime.LibraryError, list, ts.newick_trees())
+
+        tss = ts.simplify()
+        # We should have the same tree sequence just with canonicalised nodes.
+        self.assertEqual(tss.sample_size, 3)
+        self.assertEqual(tss.samples(), [0, 1, 2])
+        self.assertEqual(tss.num_nodes, 5)
+        self.assertEqual(tss.num_trees, 1)
+        self.assertEqual(tss.num_sites, 4)
+        self.assertEqual(tss.num_mutations, 4)
+        self.assertEqual(len(list(ts.diffs())), ts.num_trees)
+        t = next(tss.trees())
+        self.assertEqual(t.root, 4)
+        self.assertEqual(t.parent_dict, {0: 3, 1: 3, 2: 4, 3: 4})
+        H = list(tss.haplotypes())
+        self.assertEqual(H[0], "1001")
+        self.assertEqual(H[1], "0101")
+        self.assertEqual(H[2], "0010")
+
+    def verify_permuted_nodes(self, ts):
+        """
+        Take the specified tree sequence and permute the nodes, verifying that we
+        get back a tree sequence with the correct properties.
+        """
+        # Mapping from the original nodes into nodes in the new tree sequence.
+        node_map = list(range(ts.num_nodes))
+        random.shuffle(node_map)
+        # Change the permutation so that the relative order of samples is maintained.
+        # Then, we should get back exactly the same tree sequence after simplify.
+        samples = sorted(node_map[:ts.sample_size])
+        node_map = samples + node_map[ts.sample_size:]
+        permuted = permute_nodes(ts, node_map)
+        self.assertEqual(permuted.samples(), samples)
+        self.assertRaises(_msprime.LibraryError, permuted.haplotypes)
+        self.assertRaises(_msprime.LibraryError, list, permuted.variants())
+        self.assertEqual(ts.num_trees, permuted.num_trees)
+        j = 0
+        for t1, t2 in zip(ts.trees(), permuted.trees()):
+            t1_dict = {node_map[k]: node_map[v] for k, v in t1.parent_dict.items()}
+            self.assertEqual(node_map[t1.root], t2.root)
+            self.assertEqual(t1_dict, t2.parent_dict)
+            for u1 in t1.nodes():
+                u2 = node_map[u1]
+                self.assertEqual(
+                    sorted([node_map[v] for v in t1.leaves(u1)]),
+                    sorted(list(t2.leaves(u2))))
+            j += 1
+        self.assertEqual(j, ts.num_trees)
+
+        # The simplified version of the permuted tree sequence should be in canonical
+        # form, and identical to the original.
+        simplified = permuted.simplify()
+        self.assertEqual(simplified.samples(), ts.samples())
+        self.assertEqual(list(simplified.nodes()), list(ts.nodes()))
+        self.assertEqual(list(simplified.edgesets()), list(ts.edgesets()))
+        self.assertEqual(list(simplified.sites()), list(ts.sites()))
+        self.assertEqual(list(simplified.haplotypes()), list(ts.haplotypes()))
+        self.assertEqual(
+            list(simplified.variants(as_bytes=True)), list(ts.variants(as_bytes=True)))
+
+    def test_single_tree_permuted_nodes(self):
+        ts = msprime.simulate(10,  mutation_rate=5, random_seed=self.random_seed)
+        self.verify_permuted_nodes(ts)
+
+    def test_binary_tree_sequence_permuted_nodes(self):
+        ts = msprime.simulate(
+            20, recombination_rate=5, mutation_rate=5, random_seed=self.random_seed)
+        self.verify_permuted_nodes(ts)
+
+    def test_nonbinary_tree_sequence_permuted_nodes(self):
+        demographic_events = [
+            msprime.SimpleBottleneck(time=1.0, proportion=0.95)]
+        ts = msprime.simulate(
+            20, recombination_rate=10, mutation_rate=5,
+            demographic_events=demographic_events, random_seed=self.random_seed)
+        found = False
+        for r in ts.records():
+            if len(r.children) > 2:
+                found = True
+        self.assertTrue(found)
+        self.verify_permuted_nodes(ts)
 
 
 class TestNonSampleExternalNodes(TopologyTestCase):


### PR DESCRIPTION
This is a work in progress to allow samples that are not 0, ..., n - 1. The initial impression is that this isn't too bad, but does break some important operations (haplotype generation is what I've found so far). 

The simplest thing may be to allow these types of tree sequences, but to disallow operations like haplotype generation on them. To run these operations you would need to run ``simplify`` to get back a tree sequence of the expected form.

What do you think @petrelharp?