### PR TITLE
Print 'warnings.warn' error on import and in CLIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,14 @@ import subprocess
 import platform
 import os
 import os.path
-
-
-def warn(message):
-    print("Warning:", message)
+from warnings import warn
 
 
 CONDA_PREFIX = os.getenv("MSP_CONDA_PREFIX", None)
 IS_WINDOWS = platform.system() == "Windows"
+
+# NOTE: sadly these warnings won't work to warn users installing with pip
+# https://github.com/pypa/pip/issues/2933
 HAVE_NUMPY = False
 try:
     import numpy as np


### PR DESCRIPTION
@jeromekelleher :

1. How's the form and text of the warning?
2. Any advice/ideas to achieve the goal of not printing in CLIs? it's seeming a bit tricky

relates to #189 