### PR TITLE
added dump samples option to dump_text

### DIFF
--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1753,8 +1753,6 @@ class TreeSequence(object):
         :param stream edgesets: The file-like object to write the EdgesetTable to.
         :param stream sites: The file-like object to write the SiteTable to.
         :param stream mutations: The file-like object to write the MutationTable to.
-        :param stream samples: The file-like object to write the subset of the NodeTable
-            describing the samples to, with an extra column, `id`.
         :param int precision: The number of digits of precision.
         """
 
@@ -1804,18 +1802,27 @@ class TreeSequence(object):
                             derived_state=mutation.derived_state)
                     print(row, file=mutations)
 
-        if samples is not None:
-            print("id", "is_sample", "time", "population", sep="\t", file=samples)
-            for node_id in self.samples():
-                node = self.node(node_id)
-                row = (
-                    "{node_id:d}\t"
-                    "{is_sample:d}\t"
-                    "{time:.{precision}f}\t"
-                    "{population:d}\t").format(
-                        precision=precision, is_sample=node.is_sample(), time=node.time,
-                        population=node.population, node_id=node_id)
-                print(row, file=samples)
+    def dump_samples_text(self, samples, precision=6):
+        """
+        Writes a text representation of the entries in the NodeTable
+        corresponding to samples to the specified connections.
+
+        :param stream samples: The file-like object to write the subset of the NodeTable
+            describing the samples to, with an extra column, `id`.
+        :param int precision: The number of digits of precision.
+        """
+
+        print("id", "is_sample", "time", "population", sep="\t", file=samples)
+        for node_id in self.samples():
+            node = self.node(node_id)
+            row = (
+                "{node_id:d}\t"
+                "{is_sample:d}\t"
+                "{time:.{precision}f}\t"
+                "{population:d}\t").format(
+                    precision=precision, is_sample=node.is_sample(), time=node.time,
+                    population=node.population, node_id=node_id)
+            print(row, file=samples)
 
     @property
     def sample_size(self):

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1742,8 +1742,7 @@ class TreeSequence(object):
             mutations=mutations)
 
     def dump_text(
-            self, nodes=None, edgesets=None, sites=None, mutations=None, samples=None,
-            precision=6):
+            self, nodes=None, edgesets=None, sites=None, mutations=None, precision=6):
         """
         Writes a text representation of the tables underlying the tree sequence
         to the specified connections.

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1819,7 +1819,7 @@ class TreeSequence(object):
                 "{node_id:d}\t"
                 "{is_sample:d}\t"
                 "{time:.{precision}f}\t"
-                "{population:d}\t").format(
+                "{population:d}").format(
                     precision=precision, is_sample=node.is_sample(), time=node.time,
                     population=node.population, node_id=node_id)
             print(row, file=samples)

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1742,10 +1742,22 @@ class TreeSequence(object):
             mutations=mutations)
 
     def dump_text(
-            self, nodes=None, edgesets=None, sites=None, mutations=None, precision=6):
-        # TODO document.
+            self, nodes=None, edgesets=None, sites=None, mutations=None, samples=None,
+            precision=6):
+        """
+        Writes a text representation of the tables underlying the tree sequence
+        to the specified connections.
 
-        # Nodes
+        :param stream nodes: The file-like object (having a .write() method) to write
+            the NodeTable to.
+        :param stream edgesets: The file-like object to write the EdgesetTable to.
+        :param stream sites: The file-like object to write the SiteTable to.
+        :param stream mutations: The file-like object to write the MutationTable to.
+        :param stream samples: The file-like object to write the subset of the NodeTable
+            describing the samples to, with an extra column, `id`.
+        :param int precision: The number of digits of precision.
+        """
+
         if nodes is not None:
             print("is_sample", "time", "population", sep="\t", file=nodes)
             for node in self.nodes():
@@ -1771,7 +1783,6 @@ class TreeSequence(object):
                 print(row, file=edgesets)
 
         if sites is not None:
-            # Sites
             print("position", "ancestral_state", sep="\t", file=sites)
             for site in self.sites():
                 row = (
@@ -1792,6 +1803,19 @@ class TreeSequence(object):
                             site=mutation.site, node=mutation.node,
                             derived_state=mutation.derived_state)
                     print(row, file=mutations)
+
+        if samples is not None:
+            print("id", "is_sample", "time", "population", sep="\t", file=samples)
+            for node_id in self.samples():
+                node = self.node(node_id)
+                row = (
+                    "{node_id:d}\t"
+                    "{is_sample:d}\t"
+                    "{time:.{precision}f}\t"
+                    "{population:d}\t").format(
+                        precision=precision, is_sample=node.is_sample(), time=node.time,
+                        population=node.population, node_id=node_id)
+                print(row, file=samples)
 
     @property
     def sample_size(self):

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1330,7 +1330,7 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             list(output_nodes[0].split()),
             ["id", "is_sample", "time", "population"])
         sample_nodes = [ts.node(x) for x in ts.samples()]
-        for node_id, node, line in zip(sample_nodes, ts.sample_nodes(),
+        for node_id, node, line in zip(ts.samples(), sample_nodes,
                                        output_nodes[1:]):
             splits = line.split("\t")
             self.assertEqual(str(node_id), splits[0])
@@ -1396,20 +1396,25 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
                 edgesets_file = six.StringIO()
                 sites_file = six.StringIO()
                 mutations_file = six.StringIO()
-                samples_file = six.StringIO()
                 ts.dump_text(
                     nodes=nodes_file, edgesets=edgesets_file, sites=sites_file,
-                    mutations=mutations_file, samples=samples_file,
-                    precision=precision)
+                    mutations=mutations_file, precision=precision)
                 nodes_file.seek(0)
                 edgesets_file.seek(0)
                 sites_file.seek(0)
                 mutations_file.seek(0)
-                samples_file.seek(0)
                 self.verify_nodes_format(ts, nodes_file, precision)
                 self.verify_edgesets_format(ts, edgesets_file, precision)
                 self.verify_sites_format(ts, sites_file, precision)
                 self.verify_mutations_format(ts, mutations_file, precision)
+
+    def test_dump_samples_text(self):
+        for ts in get_example_tree_sequences():
+            for precision in [2, 7]:
+                samples_file = six.StringIO()
+                ts.dump_samples_text(samples_file, precision=precision)
+                samples_file.seek(0)
+                self.verify_samples_format(ts, samples_file, precision)
 
     def verify_approximate_equality(self, ts1, ts2):
         """

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1317,6 +1317,27 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             self.assertEqual(convert(node.time), splits[1])
             self.assertEqual(str(node.population), splits[2])
 
+    def verify_samples_format(self, ts, samples_file, precision):
+        """
+        Verifies that the samples we output have the correct form:
+        same as nodes, but with first column equal to 'id'.
+        """
+        def convert(v):
+            return "{:.{}f}".format(v, precision)
+        output_nodes = samples_file.read().splitlines()
+        self.assertEqual(len(output_nodes) - 1, len(ts.samples()))
+        self.assertEqual(
+            list(output_nodes[0].split()),
+            ["id", "is_sample", "time", "population"])
+        sample_nodes = [ts.node(x) for x in ts.samples()]
+        for node_id, node, line in zip(sample_nodes, ts.sample_nodes(),
+                                       output_nodes[1:]):
+            splits = line.split("\t")
+            self.assertEqual(str(node_id), splits[0])
+            self.assertEqual(str(node.is_sample()), splits[1])
+            self.assertEqual(convert(node.time), splits[2])
+            self.assertEqual(str(node.population), splits[3])
+
     def verify_edgesets_format(self, ts, edgesets_file, precision):
         """
         Verifies that the edgesets we output have the correct form.
@@ -1375,13 +1396,16 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
                 edgesets_file = six.StringIO()
                 sites_file = six.StringIO()
                 mutations_file = six.StringIO()
+                samples_file = six.StringIO()
                 ts.dump_text(
                     nodes=nodes_file, edgesets=edgesets_file, sites=sites_file,
-                    mutations=mutations_file, precision=precision)
+                    mutations=mutations_file, samples=samples_file,
+                    precision=precision)
                 nodes_file.seek(0)
                 edgesets_file.seek(0)
                 sites_file.seek(0)
                 mutations_file.seek(0)
+                samples_file.seek(0)
                 self.verify_nodes_format(ts, nodes_file, precision)
                 self.verify_edgesets_format(ts, edgesets_file, precision)
                 self.verify_sites_format(ts, sites_file, precision)


### PR DESCRIPTION
I wanted a way to get the information about the samples out easily, and figured it might be useful to others.  So, I added it as an option to dump_text - output is like dumping the NodeTable except with another column 'id'.