### PR TITLE
Add option to output vcf in compressed format

### DIFF
--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -2853,7 +2853,7 @@ class TreeSequence(object):
                 u for u in samples if self.get_population(u) == population_id]
         return samples
 
-    def write_vcf(self, output, ploidy=1, contig_id="1"):
+    def write_vcf(self, output, ploidy=1, contig_id="1", compresslevel=None):
         """
         Writes a VCF formatted file to the specified file-like object. If a
         ploidy value is supplied, allele values are combined among adjacent
@@ -2875,11 +2875,16 @@ class TreeSequence(object):
         :param int ploidy: The ploidy of the individual samples in the
             VCF. This sample size must be divisible by ploidy.
         :param str contig_id: The value of the CHROM column in the output VCF.
+        :param bool compresslevel: Gzip compression level applied to output.
+            Note that high compression levels can be slow.
         """
         if ploidy < 1:
             raise ValueError("Ploidy must be >= sample size")
         if self.get_sample_size() % ploidy != 0:
             raise ValueError("Sample size must be divisible by ploidy")
+        if compresslevel is not None:
+            output = gzip.GzipFile(fileobj=output, mode='w',
+                                   compresslevel=compresslevel)
         converter = _msprime.VcfConverter(
             self._ll_tree_sequence, ploidy=ploidy, contig_id=contig_id)
         output.write(converter.get_header())


### PR DESCRIPTION
Requested by a member of my lab, and seems it would be generally useful for people who need VCF output as part of a pipeline.