### PR TITLE
Allow ancestral samples

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -3964,7 +3964,7 @@ SparseTree_init(SparseTree *self, PyObject *args, PyObject *kwds)
     TreeSequence *tree_sequence = NULL;
     node_id_t *tracked_leaves = NULL;
     int flags = 0;
-    uint32_t j, n, num_tracked_leaves;
+    uint32_t j, num_tracked_leaves, num_nodes;
     PyObject *item;
 
     self->sparse_tree = NULL;
@@ -3978,7 +3978,7 @@ SparseTree_init(SparseTree *self, PyObject *args, PyObject *kwds)
     if (TreeSequence_check_tree_sequence(tree_sequence) != 0) {
         goto out;
     }
-    n = tree_sequence_get_sample_size(tree_sequence->tree_sequence);
+	num_nodes = tree_sequence_get_num_nodes(tree_sequence->tree_sequence);
     num_tracked_leaves = 0;
     if (py_tracked_leaves != NULL) {
         if (!flags & MSP_LEAF_COUNTS) {
@@ -4000,8 +4000,8 @@ SparseTree_init(SparseTree *self, PyObject *args, PyObject *kwds)
             goto out;
         }
         tracked_leaves[j] = (node_id_t) PyLong_AsLong(item);
-        if (tracked_leaves[j] >= n) {
-            PyErr_SetString(PyExc_ValueError, "leaves must be < sample_size");
+        if (tracked_leaves[j] >= num_nodes) {
+            PyErr_SetString(PyExc_ValueError, "leaves must be valid nodes");
             goto out;
         }
     }

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -3978,7 +3978,7 @@ SparseTree_init(SparseTree *self, PyObject *args, PyObject *kwds)
     if (TreeSequence_check_tree_sequence(tree_sequence) != 0) {
         goto out;
     }
-	num_nodes = tree_sequence_get_num_nodes(tree_sequence->tree_sequence);
+    num_nodes = tree_sequence_get_num_nodes(tree_sequence->tree_sequence);
     num_tracked_leaves = 0;
     if (py_tracked_leaves != NULL) {
         if (!flags & MSP_LEAF_COUNTS) {

--- a/lib/err.h
+++ b/lib/err.h
@@ -91,6 +91,5 @@
 #define MSP_ERR_BAD_SITE_POSITION                                   -61
 #define MSP_ERR_UNSORTED_MUTATIONS                                  -62
 #define MSP_ERR_UNDEFINED_MULTIPLE_MERGER_COALESCENT                -63
-#define MSP_ERR_NODE_SAMPLE_INTERNAL                                -64
 
 #endif /*__ERR_H__*/

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -136,9 +136,6 @@ msp_strerror(int err)
         case MSP_ERR_INSUFFICIENT_SAMPLES:
             ret = "At least two samples needed.";
             break;
-        case MSP_ERR_NODE_SAMPLE_INTERNAL:
-            ret = "Cannot sample internal nodes.";
-            break;
         case MSP_ERR_BAD_EDGESET_NONMATCHING_RIGHT:
             ret = "Bad edgeset in file: right coordinate not matching any left coordinate.";
             break;

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -4915,12 +4915,12 @@ test_internal_sample_leaf_sets(void)
 {
     leaf_count_test_t tests[] = {
         {0, 0, 1}, {0, 5, 4}, {0, 4, 2}, {0, 7, 5},
-        {1, 4, 2}, {1, 5, 4}, {1, 8, 5}, 
+        {1, 4, 2}, {1, 5, 4}, {1, 8, 5},
         {2, 5, 4}, {2, 6, 5}};
     uint32_t num_tests = 9;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, internal_sample_ex_nodes, internal_sample_ex_edgesets, 
+    tree_sequence_from_text(&ts, internal_sample_ex_nodes, internal_sample_ex_edgesets,
             NULL, NULL, NULL, NULL);
     verify_leaf_counts(&ts, num_tests, tests);
     verify_leaf_sets(&ts);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -4537,7 +4537,6 @@ verify_leaf_counts(tree_sequence_t *ts, size_t num_tests, leaf_count_test_t *tes
         /* all operations depending on tracked leaves should fail. */
         ret = sparse_tree_get_num_tracked_leaves(&tree, 0, &num_leaves);
         CU_ASSERT_EQUAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
-        /* Getting leaf lists should still fail, as it's not enabled. */
         ret = sparse_tree_get_leaf_list(&tree, tests[j].node, &head, &tail);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         u = head;
@@ -4910,6 +4909,25 @@ test_nonbinary_leaf_sets(void)
 
     tree_sequence_free(&ts);
 }
+
+static void
+test_internal_sample_leaf_sets(void)
+{
+    leaf_count_test_t tests[] = {
+        {0, 0, 1}, {0, 5, 4}, {0, 4, 2}, {0, 7, 5},
+        {1, 4, 2}, {1, 5, 4}, {1, 8, 5}, 
+        {2, 5, 4}, {2, 6, 5}};
+    uint32_t num_tests = 9;
+    tree_sequence_t ts;
+
+    tree_sequence_from_text(&ts, internal_sample_ex_nodes, internal_sample_ex_edgesets, 
+            NULL, NULL, NULL, NULL);
+    verify_leaf_counts(&ts, num_tests, tests);
+    verify_leaf_sets(&ts);
+
+    tree_sequence_free(&ts);
+}
+
 
 static void
 test_tree_sequence_bad_records(void)
@@ -6737,6 +6755,7 @@ main(int argc, char **argv)
         {"test_tree_sequence_iter", test_tree_sequence_iter},
         {"test_leaf_sets", test_leaf_sets},
         {"test_nonbinary_leaf_sets", test_nonbinary_leaf_sets},
+        {"test_internal_sample_leaf_sets", test_internal_sample_leaf_sets},
         {"test_nonbinary_tree_sequence_iter", test_nonbinary_tree_sequence_iter},
         {"test_unary_tree_sequence_iter", test_unary_tree_sequence_iter},
         {"test_internal_sample_tree_sequence_iter", test_internal_sample_tree_sequence_iter},

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -768,7 +768,6 @@ static int
 tree_sequence_init_edgesets(tree_sequence_t *self)
 {
     int ret = 0;
-    node_id_t u;
     size_t j, offset;
 
     offset = 0;
@@ -781,12 +780,6 @@ tree_sequence_init_edgesets(tree_sequence_t *self)
         }
         self->edgesets.children[j] = self->edgesets.children_mem + offset;
         offset += (size_t) self->edgesets.children_length[j];
-        /* Check that no sampled nodes are internal. */
-        u = self->edgesets.parent[j];
-        if (u >= 0 && self->nodes.flags[u] & MSP_NODE_IS_SAMPLE) {
-            ret = MSP_ERR_NODE_SAMPLE_INTERNAL;
-            goto out;
-        }
     }
 out:
     return ret;
@@ -3641,7 +3634,6 @@ sparse_tree_check_state(sparse_tree_t *self)
     for (j = 0; j < self->sample_size; j++) {
         u = self->samples[j];
         assert(self->time[u] >= 0.0);
-        assert(self->num_children[u] == 0);
         while (self->parent[u] != MSP_NULL_NODE) {
             v = self->parent[u];
             found = 0;

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -3786,8 +3786,12 @@ sparse_tree_update_leaf_lists(sparse_tree_t *self, node_id_t node)
 
     u = node;
     while (u != MSP_NULL_NODE) {
-        head[u] = NULL;
-        tail[u] = NULL;
+        if (self->tree_sequence->nodes.flags[u] & MSP_NODE_IS_SAMPLE) {
+            tail[u] = head[u];
+        } else {
+            head[u] = NULL;
+            tail[u] = NULL;
+        }
         for (c = 0; c < self->num_children[u]; c++) {
             v = self->children[u][c];
             if (head[v] != NULL) {

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2653,7 +2653,7 @@ class TestSparseTree(LowLevelTestCase):
             self.assertRaises(
                 TypeError, _msprime.SparseTree, ts, flags=flags,
                 tracked_leaves=[1, bad_type])
-        for bad_leaf in [ts.get_sample_size(), 10**6, -1e6]:
+        for bad_leaf in [10**6, -1e6]:
             self.assertRaises(
                 ValueError, _msprime.SparseTree, ts, flags=flags,
                 tracked_leaves=[bad_leaf])

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -109,7 +109,7 @@ class TopologyTestCase(unittest.TestCase):
     def check_num_leaves(self, ts, x):
         """
         Compare against x, a list of tuples of the form
-            (tree number, parent, number of leaves)
+        `(tree number, parent, number of leaves)`.
         """
         k = 0
         tss = ts.trees(leaf_counts=True)
@@ -124,18 +124,16 @@ class TopologyTestCase(unittest.TestCase):
         k = 0
         tss = ts.trees(leaf_counts=True, tracked_leaves=tracked_leaves)
         t = next(tss)
-        print(tracked_leaves)
         for j, node, nl in x:
             while k < j:
                 t = next(tss)
                 k += 1
-            print(j, node, nl, t.num_tracked_leaves(node))
             self.assertEqual(nl, t.num_tracked_leaves(node))
 
     def check_leaf_iterator(self, ts, x):
         """
         Compare against x, a list of tuples of the form
-            (tree number, node, leaf ID list)
+        `(tree number, node, leaf ID list)`.
         """
         k = 0
         tss = ts.trees(leaf_lists=True)
@@ -145,7 +143,6 @@ class TopologyTestCase(unittest.TestCase):
                 t = next(tss)
                 k += 1
             for u, v in zip(leaves, t.leaves(node)):
-                print(u, v)
                 self.assertEqual(u, v)
 
 
@@ -1570,7 +1567,6 @@ class TestWithVisuals(TopologyTestCase):
         self.assertEqual(t.is_leaf(0), True)
         self.assertEqual(t.is_internal(1), False)
         self.assertEqual(t.is_leaf(1), True)
-        # this may NOT be what we want?
         self.assertEqual(t.is_internal(5), True)
         self.assertEqual(t.is_leaf(5), False)
         self.assertEqual(t.is_internal(4), True)


### PR DESCRIPTION
I've removed checks for internal samples and added some tests.

The only thing I've encountered so far that needs fixing is `leaf_lists`.  I've made a change that (hopefully) makes it so `leaves()` returns a list of all *samples* below (and, including) the node.  But, maybe this should have a different name, then?  Grrr.  What do you think, @jeromekelleher?

Still needs some more tests.