### PR TITLE
Adds checks for bad trees to iterator.

### DIFF
--- a/lib/err.h
+++ b/lib/err.h
@@ -91,5 +91,7 @@
 #define MSP_ERR_UNSORTED_MUTATIONS                                  -61
 #define MSP_ERR_UNDEFINED_MULTIPLE_MERGER_COALESCENT                -62
 #define MSP_ERR_EDGESETS_FOR_PARENT_NOT_ADJACENT                    -63
+#define MSP_ERR_BAD_EDGESET_CONTRADICTORY_CHILDREN                  -64
+#define MSP_ERR_BAD_EDGESET_OVERLAPPING_PARENT                      -65
 
 #endif /*__ERR_H__*/

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -250,6 +250,13 @@ msp_strerror(int err)
         case MSP_ERR_EDGESETS_FOR_PARENT_NOT_ADJACENT:
             ret = "All edgesets for a given parent must be adjacent.";
             break;
+        case MSP_ERR_BAD_EDGESET_CONTRADICTORY_CHILDREN:
+            ret = "Bad edgesets: contradictory children for a given parent over "
+                "an interval.";
+            break;
+        case MSP_ERR_BAD_EDGESET_OVERLAPPING_PARENT:
+            ret = "Bad edgesets: multiple definitions of a given parent over an interval";
+            break;
         case MSP_ERR_IO:
             if (errno != 0) {
                 ret = strerror(errno);

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1094,7 +1094,7 @@ class TestTreeSequence(HighLevelTestCase):
                 ts = msprime.load_text(
                     nodes=nodes, edgesets=edgesets, sites=sites, mutations=mutations)
             # print("nodes_file = ", nodes_file)
-            samples = list(range(ts.sample_size))
+            samples = list(ts.samples())
             self.verify_simplify_equality(ts, samples)
             self.verify_simplify_topology(ts, samples)
             self.verify_simplify_mutations(ts, samples)
@@ -1376,13 +1376,10 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         edgesets_file = six.StringIO("left\tright\tparent\tchildren\n")
         sites_file = six.StringIO("position\tancestral_state\n")
         mutations_file = six.StringIO("site\tnode\tderived_state\n")
-        ts = msprime.load_text(
+        self.assertRaises(
+            _msprime.LibraryError, msprime.load_text,
             nodes=nodes_file, edgesets=edgesets_file, sites=sites_file,
             mutations=mutations_file)
-        self.assertEqual(ts.num_nodes, 0)
-        self.assertEqual(ts.num_edgesets, 0)
-        self.assertEqual(ts.num_sites, 0)
-        self.assertEqual(ts.num_mutations, 0)
 
 
 class TestSparseTree(HighLevelTestCase):

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1894,6 +1894,77 @@ class TestWithVisuals(TopologyTestCase):
         self.assertEqual(t.sample_size, 4)
 
 
+class TestBadTrees(unittest.TestCase):
+    """
+    Tests for bad tree sequence topologies that can only be detected when we
+    try to create trees.
+    """
+
+    def test_simplest_fully_overlapping_parent(self):
+        nodes = six.StringIO("""\
+        id      is_sample   time
+        0       1           0
+        1       1           0
+        2       0           1
+        3       0           2
+        """)
+        edgesets = six.StringIO("""\
+        left    right   parent  children
+        0.0     1.0     2       0
+        0.0     1.0     2       1
+        """)
+        ts = msprime.load_text(nodes=nodes, edgesets=edgesets)
+        self.assertRaises(_msprime.LibraryError, list, ts.trees())
+
+    def test_simplest_paritially_overlapping_parent(self):
+        nodes = six.StringIO("""\
+        id      is_sample   time
+        0       1           0
+        1       1           0
+        2       0           1
+        3       0           2
+        """)
+        edgesets = six.StringIO("""\
+        left    right   parent  children
+        0.0     1.0     2       0
+        0.5     1.0     2       1
+        """)
+        ts = msprime.load_text(nodes=nodes, edgesets=edgesets)
+        self.assertRaises(_msprime.LibraryError, list, ts.trees())
+
+    def test_simplest_contradictory_children(self):
+        nodes = six.StringIO("""\
+        id      is_sample   time
+        0       1           0
+        1       1           0
+        2       0           1
+        3       0           2
+        """)
+        edgesets = six.StringIO("""\
+        left    right   parent  children
+        0.0     1.0     2       0
+        0.0     1.0     3       0
+        """)
+        ts = msprime.load_text(nodes=nodes, edgesets=edgesets)
+        self.assertRaises(_msprime.LibraryError, list, ts.trees())
+
+    def test_partial_overlap_contradictory_children(self):
+        nodes = six.StringIO("""\
+        id      is_sample   time
+        0       1           0
+        1       1           0
+        2       0           1
+        3       0           2
+        """)
+        edgesets = six.StringIO("""\
+        left    right   parent  children
+        0.0     1.0     2       0,1
+        0.5     1.0     3       0
+        """)
+        ts = msprime.load_text(nodes=nodes, edgesets=edgesets)
+        self.assertRaises(_msprime.LibraryError, list, ts.trees())
+
+
 def do_simplify(ts, sample=None):
     """
     Runs the Python test implementation of simplify.


### PR DESCRIPTION
Some topological properties can only be checked at run time while we are generating the trees. This adds support for these checks.

I _think_ this should be comprehensive, but I'd like to get a second opinion here. Would you mind taking a look over this and reviewing please @petrelharp? I'm not at all sure about the terminology I've chosen here to describe the different errors, so please suggest something else if you can improve them.

There were a couple of incidental changes here also:

1. I added a check to make sure num_samples > 1. There's no deep reason for this, but I got some segfaults when I accidentally put in < 2 samples in an example. If we relax this assumption we need to track down these problems.

2. Removed an unnecessary array and sort left over from older checks.