### PR TITLE
Sphinx/IPython integration into docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,18 +20,18 @@ import shlex
 # documentation build on readthedocs, so we mock the module. Follows
 # the recommended pattern at
 # http://docs.readthedocs.org/en/latest/faq.html
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import Mock as MagicMock
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-MOCK_MODULES = ["_msprime"]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+# try:
+#     from unittest.mock import MagicMock
+# except ImportError:
+#     from mock import Mock as MagicMock
+# 
+# class Mock(MagicMock):
+#     @classmethod
+#     def __getattr__(cls, name):
+#         return MagicMock()
+# 
+# MOCK_MODULES = ["_msprime"]
+# sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,8 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+if (os.environ.get('READTHEDOCS') == "True") is False:
+    sys.path.insert(0, os.path.abspath('..'))
 
 import setuptools_scm
 setuptools_scm_version = setuptools_scm.get_version(root="../")
@@ -56,6 +57,9 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
     'sphinxarg.ext',
+    'sphinx.ext.doctest',
+    'IPython.sphinxext.ipython_console_highlighting',
+    'IPython.sphinxext.ipython_directive',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/file-format.rst
+++ b/docs/file-format.rst
@@ -262,7 +262,14 @@ the future, but currently there are two ways to modify tables: ``.add_row()``
 and ``.set_columns()`` (and also ``.reset()``, which empties the table).
 
 The example node table above would be constructed using ``.add_row()`` as
-follows::
+follows:
+
+.. ipython:: python
+    :suppress:
+
+    import msprime
+
+.. ipython:: python
 
     n = msprime.NodeTable()
     sv = [True, True, True, False, False, False, False]

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -157,6 +157,7 @@ class NodeTable(_msprime.NodeTable):
         2	0	0		0.0
         3	1	0		0.5
         4	0	2		2.1
+
     Node IDs are *not* recorded; rather the `id` column shows the row index, so
     that the `k`-th row describes the node whose ID is `k`.  `flags` currently
     records whether the node is a sample (=1) or not (=0).  `population` is an
@@ -207,19 +208,24 @@ class EdgesetTable(_msprime.EdgesetTable):
         0.0     0.4     3       0,2
         0.4     1.0     3       0,1,2
         0.0     0.4     4       1,3
+
     These describe the half-open genomic interval affected: `[left, right)`,
     the `parent` and the `children` on that interval.
 
     Requirements: to describe a valid tree sequence, a `EdgesetTable` (and
     corresponding `NodeTable`, to provide birth times) must satisfy:
+
         1. each list of children must be in sorted order,
         2. any two edgesets that share a child must be nonoverlapping, and
         3. the birth times of the `parent` in an edgeset must be strictly
             greater than the birth times of the `children` in that edgeset.
+
     Furthermore, for algorithmic requirements
+
         4. the smallest `left` coordinate must be 0.0,
         5. the the table must be sorted by birth time of the `parent`, and
         6. any two edgesets corresponding to the same `parent` must be nonoverlapping.
+
     It is an additional requirement that the complete ancestry of each sample
     must be specified, but this is harder to verify.
 
@@ -307,9 +313,11 @@ class SiteTable(_msprime.SiteTable):
     """
     Class for tables describing all sites at which mutations have occurred in a
     tree sequence, of the form
+
         id	position	ancestral_state
         0	0.1     	0
         1	0.5     	0
+
     Here ``id`` is not stored directly, but is determined by the row index in
     the table.  ``position`` is the position along the genome, and
     ``ancestral_state`` gives the allele at the root of the tree at that
@@ -349,10 +357,12 @@ class MutationTable(_msprime.MutationTable):
     """
     Class for tables describing all mutations that have occurred in a tree
     sequence, of the form
+    
         site	node	derived_state
         0	4	1
         1	3	1
         1	2	0
+
     Here ``site`` is the index in the SiteTable of the site at which the
     mutation occurred, ``node`` is the index in the NodeTable of the node who
     is the first node inheriting the mutation, and ``derived_state`` is the

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -2,3 +2,4 @@ mock
 six
 setuptools_scm 
 sphinx-argparse
+ipython


### PR DESCRIPTION
Here are some initial commits for #240.  

I tested that "make html" worked on my machine, but have not tested that all the RTD environment stuff works.

The bigger issue is that the msprime objects are mocked, so that "print(n)" in the example displays something like 

```
<MagicMock id='4536862424'>
``` 
instead of the contents of a NodeTable object.