### PR TITLE
add __len__ for *Tables

### DIFF
--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -187,6 +187,9 @@ class NodeTable(_msprime.NodeTable):
                 np.array_equal(self.name_length, other.name_length))
         return ret
 
+    def __len__(self):
+        return self.num_rows
+
     def copy(self):
         """
         Returns a deep copy of this table.
@@ -253,6 +256,9 @@ class EdgesetTable(_msprime.EdgesetTable):
                 np.array_equal(self.children_length, other.children_length))
         return ret
 
+    def __len__(self):
+        return self.num_rows
+
     def copy(self):
         """
         Returns a deep copy of this table.
@@ -289,6 +295,9 @@ class MigrationTable(_msprime.MigrationTable):
                 np.array_equal(self.dest, other.dest) and
                 np.array_equal(self.time, other.time))
         return ret
+
+    def __len__(self):
+        return self.num_rows
 
     def copy(self):
         """
@@ -331,6 +340,9 @@ class SiteTable(_msprime.SiteTable):
                 np.array_equal(
                     self.ancestral_state_length, other.ancestral_state_length))
         return ret
+
+    def __len__(self):
+        return self.num_rows
 
     def copy(self):
         """
@@ -379,6 +391,9 @@ class MutationTable(_msprime.MutationTable):
                 np.array_equal(
                     self.derived_state_length, other.derived_state_length))
         return ret
+
+    def __len__(self):
+        return self.num_rows
 
     def copy(self):
         """

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -177,10 +177,13 @@ class CommonTestsMixin(object):
             with self.assertRaises(AttributeError):
                 setattr(table, col.name, np.zeros(5))
         self.assertEqual(table.num_rows, 0)
+        self.assertEqual(len(table), 0)
+
 
     def test_defaults(self):
         table = self.table_class()
         self.assertEqual(table.num_rows, 0)
+        self.assertEqual(len(table), 0)
         for param, default in self.input_parameters:
             self.assertEqual(getattr(table, param), default)
         for col in self.columns:
@@ -204,6 +207,7 @@ class CommonTestsMixin(object):
                     self.assertTrue(np.all(input_array == output_array))
                 table.reset()
                 self.assertEqual(table.num_rows, 0)
+                self.assertEqual(len(table), 0)
                 for colname in input_data.keys():
                     self.assertEqual(list(getattr(table, colname)), [])
 
@@ -224,6 +228,7 @@ class CommonTestsMixin(object):
                     self.assertEqual(input_array.shape, output_array.shape)
                     self.assertTrue(np.array_equal(input_array, output_array))
                 self.assertEqual(table.num_rows, j * num_rows)
+                self.assertEqual(len(table), j * num_rows)
 
     def test_append_columns_max_rows(self):
         for num_rows in [0, 10, 100, 1000]:
@@ -238,6 +243,7 @@ class CommonTestsMixin(object):
                 for j in range(1, 10):
                     table.append_columns(**input_data)
                     self.assertEqual(table.num_rows, j * num_rows)
+                    self.assertEqual(len(table), j * num_rows)
                     self.assertGreater(table.max_rows, table.num_rows)
                     if table.num_rows < max_rows:
                         self.assertEqual(table.max_rows, max_rows)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -179,7 +179,6 @@ class CommonTestsMixin(object):
         self.assertEqual(table.num_rows, 0)
         self.assertEqual(len(table), 0)
 
-
     def test_defaults(self):
         table = self.table_class()
         self.assertEqual(table.num_rows, 0)


### PR DESCRIPTION
I added \_\_len\_\_() for the tables objects in order to make them a little more "Pythonic".  Plus, I've had countless exceptions raised due to trying to say `len(edges)` :).