### PR TITLE
ASCII trees

### DIFF
--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1120,16 +1120,15 @@ class SparseTree(object):
                 yield stack.pop()
 
     def _inorder_traversal(self, u):
-        stack = [u]
-        k, j = NULL_NODE, NULL_NODE
-        while stack:
-            v = stack.pop()
-            if self.is_internal(v) and v != k and v != j:
-                children = self.get_children(v)
-                j = stack[-1] if stack else NULL_NODE
-                stack.extend([children[1], v, children[0]])
-            else:
-                k = self.get_parent(v)
+        # TODO add a nonrecursive version of the inorder traversal.
+        children = self.get_children(u)
+        mid = len(children) // 2
+        for c in children[:mid]:
+            for v in self._inorder_traversal(c):
+                yield v
+        yield u
+        for c in children[mid:]:
+            for v in self._inorder_traversal(c):
                 yield v
 
     def _levelorder_traversal(self, u):

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -623,6 +623,93 @@ class TreeDrawer(object):
             self._sample_x += 1
 
 
+class AsciiTreeDrawer(object):
+    """
+    Draws an ASCII rendering of a tree.
+    """
+    # TODO this shares much of its functionality with the TreeDrawer above.
+    # Abstract the ideas of x-and-y coordinate finding out into a superclass
+    # and just make these classes responsible for rendering the results on a
+    # particular canvas.
+
+    def __init__(self, tree):
+        self._tree = tree
+        self._width = len(list(self._tree.leaves()))
+        self._height = 0
+        self._node_height = {}
+        # Note this is inefficient as we're going up to root for every node.
+        for u in self._tree.nodes():
+            path_len = 0
+            v = u
+            while v != msprime.NULL_NODE:
+                path_len += 1
+                v = self._tree.parent(v)
+            self._node_height[u] = path_len
+        self._height = max(self._node_height.values())
+
+        self._x_scale = 4
+        self._y_scale = 4
+
+        self._x_coords = {}
+        self._y_coords = {}
+        for u in tree.nodes():
+            self._y_coords[u] = self._node_height[u] * self._y_scale
+        self._sample_x = 1
+        self._assign_x_coordinates(self._tree.get_root())
+
+    def _assign_x_coordinates(self, node):
+        """
+        Assign x coordinates to all nodes underneath this node.
+        """
+        if self._tree.is_internal(node):
+            children = self._tree.get_children(node)
+            for c in children:
+                self._assign_x_coordinates(c)
+            coords = [self._x_coords[c] for c in children]
+            a = min(coords)
+            b = max(coords)
+            self._x_coords[node] = int(round((a + (b - a) / 2)))
+        else:
+            self._x_coords[node] = self._sample_x * self._x_scale
+            self._sample_x += 1
+
+    def draw(self, labels=None):
+
+        # print(self._width, self._height)
+        w = (self._width + 1) * self._x_scale
+        h = (self._height + 1) * self._y_scale
+
+        # Create a width * height canvas of spaces.
+        canvas = bytearray(w * h)
+        for row in range(h):
+            for col in range(w - 1):
+                canvas[row * w + col] = b' '
+            canvas[row * w + w - 1] = b'\n'
+        for u in self._tree.nodes():
+            col = self._x_coords[u]
+            row = self._y_coords[u]
+            j = row * w + col
+            if labels is None or u not in labels:
+                label = b"{}".format(u)
+            else:
+                label = labels[u]
+            n = len(label)
+            canvas[j - n // 2: j + n // 2 + int(n % 2 == 1)] = label
+            if self._tree.is_internal(u):
+                children = self._tree.children(u)
+                row += 1
+                left = min(self._x_coords[v] for v in children)
+                right = max(self._x_coords[v] for v in children)
+                for col in range(left, right):
+                    canvas[row * w + col] = b'-'
+                canvas[row * w + self._x_coords[u]] = b'+'
+                top = row + 1
+                for v in children:
+                    col = self._x_coords[v]
+                    for row in range(top, self._y_coords[v] - 1):
+                        canvas[row * w + col] = b'|'
+        return bytes(canvas).encode()
+
 # TODO:
 # - Pickle and copy support
 class SparseTree(object):
@@ -898,6 +985,10 @@ class SparseTree(object):
         :rtype: int
         """
         return self._ll_sparse_tree.get_sample_size()
+
+    def draw_ascii(self, labels=None):
+        td = AsciiTreeDrawer(self)
+        return td.draw(labels=labels)
 
     def draw(
             self, path=None, width=200, height=200, times=False,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -102,9 +102,12 @@ class PythonSparseTree(object):
 
     def _inorder_nodes(self, u, l):
         if u in self.children:
-            self._inorder_nodes(self.children[u][0], l)
+            mid = len(self.children[u]) // 2
+            for v in self.children[u][:mid]:
+                self._inorder_nodes(v, l)
             l.append(u)
-            self._inorder_nodes(self.children[u][1], l)
+            for v in self.children[u][mid:]:
+                self._inorder_nodes(v, l)
         else:
             l.append(u)
 

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1492,7 +1492,12 @@ class TestSparseTree(HighLevelTestCase):
                 self.assertEqual(t.get_num_samples(u), len(l1))
 
     def test_traversals(self):
-        t1 = self.get_tree()
+        for ts in get_example_tree_sequences():
+            tree = next(ts.trees())
+            self.verify_traversals(tree)
+
+    def verify_traversals(self, tree):
+        t1 = tree
         t2 = tests.PythonSparseTree.from_sparse_tree(t1)
         self.assertEqual(list(t1.nodes()), list(t2.nodes()))
         self.assertEqual(list(t1.nodes()), list(t1.nodes(t1.get_root())))
@@ -1503,6 +1508,9 @@ class TestSparseTree(HighLevelTestCase):
             self.assertEqual(list(t1.nodes(u)), list(t2.nodes(u)))
         orders = ["inorder", "postorder", "levelorder", "breadthfirst"]
         for test_order in orders:
+            self.assertEqual(
+                sorted(list(t1.nodes())),
+                sorted(list(t1.nodes(order=test_order))))
             self.assertEqual(
                 list(t1.nodes(order=test_order)),
                 list(t1.nodes(t1.get_root(), order=test_order)))

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -51,6 +51,44 @@ class TestTreeDraw(unittest.TestCase):
         assert False
 
 
+class TestFormats(TestTreeDraw):
+    """
+    Tests that formats are recognised correctly.
+    """
+    def test_svg_variants(self):
+        t = self.get_binary_tree()
+        for svg in ["svg", "SVG", "sVg"]:
+            output = t.draw(format=svg)
+            root = xml.etree.ElementTree.fromstring(output)
+            self.assertEqual(root.tag, "{http://www.w3.org/2000/svg}svg")
+
+    def test_default(self):
+        # Default is SVG
+        t = self.get_binary_tree()
+        output = t.draw(format=None)
+        root = xml.etree.ElementTree.fromstring(output)
+        self.assertEqual(root.tag, "{http://www.w3.org/2000/svg}svg")
+        output = t.draw()
+        root = xml.etree.ElementTree.fromstring(output)
+        self.assertEqual(root.tag, "{http://www.w3.org/2000/svg}svg")
+
+    def test_ascii_variants(self):
+        t = self.get_binary_tree()
+        for fmt in ["ascii", "ASCII", "AScii"]:
+            output = t.draw(format=fmt)
+            self.assertRaises(
+                xml.etree.ElementTree.ParseError, xml.etree.ElementTree.fromstring,
+                output)
+
+    def test_bad_formats(self):
+        t = self.get_binary_tree()
+        for bad_format in ["", "ASC", "SV", "jpeg"]:
+            self.assertRaises(ValueError, t.draw, format=bad_format)
+
+
+# TODO we should gather some of these tests into a superclass as they are
+# very similar for SVG and ASCII.
+
 class TestDrawAscii(TestTreeDraw):
     """
     Tests the ASCII tree drawing method.
@@ -61,18 +99,18 @@ class TestDrawAscii(TestTreeDraw):
 
     def test_draw_defaults(self):
         t = self.get_binary_tree()
-        text = t.draw_ascii()
+        text = t.draw(format="ASCII")
         self.verify_basic_text(text)
 
     def test_draw_nonbinary(self):
         t = self.get_nonbinary_tree()
-        text = t.draw_ascii()
+        text = t.draw(format="ASCII")
         self.verify_basic_text(text)
 
     def test_labels(self):
         t = self.get_binary_tree()
         labels = {u: "XXX" for u in t.nodes()}
-        text = t.draw_ascii(labels=labels)
+        text = t.draw(format="ASCII", node_label_text=labels)
         self.verify_basic_text(text)
         j = 0
         for _ in t.nodes():
@@ -119,6 +157,16 @@ class TestDrawSvg(TestTreeDraw):
         h = 456
         svg = t.draw(width=w, height=h)
         self.verify_basic_svg(svg, w, h)
+
+    def test_labels(self):
+        t = self.get_binary_tree()
+        labels = {u: "XXX" for u in t.nodes()}
+        svg = t.draw(format="svg", node_label_text=labels)
+        self.verify_basic_svg(svg)
+        j = 0
+        for _ in t.nodes():
+            j = svg[j:].find("XXX")
+            self.assertNotEqual(j, -1)
 
     def test_boolean_flags(self):
         flags = [

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -50,6 +50,40 @@ class TestTreeDraw(unittest.TestCase):
                     return t
         assert False
 
+
+class TestDrawAscii(TestTreeDraw):
+    """
+    Tests the ASCII tree drawing method.
+    """
+    def verify_basic_text(self, text):
+        self.assertTrue(isinstance(text, str))
+        # TODO surely something else we can verify about this...
+
+    def test_draw_defaults(self):
+        t = self.get_binary_tree()
+        text = t.draw_ascii()
+        self.verify_basic_text(text)
+
+    def test_draw_nonbinary(self):
+        t = self.get_nonbinary_tree()
+        text = t.draw_ascii()
+        self.verify_basic_text(text)
+
+    def test_labels(self):
+        t = self.get_binary_tree()
+        labels = {u: "XXX" for u in t.nodes()}
+        text = t.draw_ascii(labels=labels)
+        self.verify_basic_text(text)
+        j = 0
+        for _ in t.nodes():
+            j = text[j:].find("XXX")
+            self.assertNotEqual(j, -1)
+
+
+class TestDrawSvg(TestTreeDraw):
+    """
+    Tests the SVG tree drawing.
+    """
     def verify_basic_svg(self, svg, width=200, height=200):
         root = xml.etree.ElementTree.fromstring(svg)
         self.assertEqual(root.tag, "{http://www.w3.org/2000/svg}svg")


### PR DESCRIPTION
This is a work in progress to render trees in ASCII. The current output looks like this:

```
        8              
    ----+---           
    |       |          
                       
    1       7          
        ----+--        
        |      |       
                       
        3      6       
            ---+--     
            |     |    
                       
            2     5    
                --+-   
                |   |  
                       
                0   4  
```

It turns out to be easy enough to do, and we can reuse the majority of the existing tree layout code.

I think the right thing to do here API wise though is to add a ``format="ascii"`` parameter to the existing ``tree.draw`` method. I guess we can just ignore any arguments that don't make sense for a particular rendering backend.

Any thoughts @petrelharp, @ashander?