### PR TITLE
Disable OSX builds on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ matrix:
       python: 3.5
     - os: linux
       python: 3.6
-    - os: osx
-      language: generic
+    # Disabling OSX on Travis 2016/09/16 as the build times are too long.
+    # - os: osx
+    #   language: generic
 
 install:
   # We do this conditionally because it saves us some downloading if the


### PR DESCRIPTION
Builds are taking too long, so the value of having OSX CI is much reduced.