### PR TITLE
Revert "Adds a edge_start parameter to sort_tables"

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -7402,18 +7402,15 @@ msprime_sort_tables(PyObject *self, PyObject *args, PyObject *kwds)
     migration_table_t *migrations = NULL;
     site_table_t *sites = NULL;
     mutation_table_t *mutations = NULL;
-    Py_ssize_t edge_start = 0;
 
-    static char *kwlist[] = {"nodes", "edges", "migrations", "sites", "mutations",
-        "edge_start", NULL};
+    static char *kwlist[] = {"nodes", "edges", "migrations", "sites", "mutations", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!|O!O!O!n", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!|O!O!O!", kwlist,
             &NodeTableType, &py_nodes,
             &EdgeTableType, &py_edges,
             &MigrationTableType, &py_migrations,
             &SiteTableType, &py_sites,
-            &MutationTableType, &py_mutations,
-            &edge_start)) {
+            &MutationTableType, &py_mutations)) {
         goto out;
     }
     if (NodeTable_check_state(py_nodes) != 0) {
@@ -7446,11 +7443,7 @@ msprime_sort_tables(PyObject *self, PyObject *args, PyObject *kwds)
         PyErr_SetString(PyExc_TypeError, "Must specify both sites and mutation tables");
         goto out;
     }
-    if (edge_start < 0 || edge_start > py_edges->edge_table->num_rows) {
-        PyErr_SetString(PyExc_ValueError,
-                "edge_start must be between 0 and len(edges)");
-    }
-    err = sort_tables(nodes, edges, migrations, sites, mutations, (size_t) edge_start);
+    err = sort_tables(nodes, edges, migrations, sites, mutations);
     if (err != 0) {
         handle_library_error(err);
         goto out;

--- a/docs/file-format.rst
+++ b/docs/file-format.rst
@@ -317,7 +317,7 @@ Tables that are noncontradictory but do not satisfy all algorithmic requirements
 listed above may be converted to a TreeSequence by first sorting, then simplifying
 them (both operate on the tables **in place**):
 
-.. autofunction:: msprime.sort_tables(nodes, edgesets[, migrations, sites, mutations, edge_start])
+.. autofunction:: msprime.sort_tables(nodes, edgesets[, migrations, sites, mutations])
 
 **Note:** the following function is more general than
 ``TreeSequence.simplify()``, since it can be applied to tables not satisfying

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -878,7 +878,7 @@ void mutgen_print_state(mutgen_t *self, FILE *out);
 /* Tables API */
 
 int sort_tables(node_table_t *nodes, edge_table_t *edges, migration_table_t *migrations,
-        site_table_t *sites, mutation_table_t *mutations, size_t edge_start);
+        site_table_t *sites, mutation_table_t *mutations);
 
 int node_table_alloc(node_table_t *self, size_t max_rows_increment,
         size_t max_total_name_length_increment);

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -408,16 +408,15 @@ def sort_tables(*args, **kwargs):
 
     - time of parent, then
     - parent node ID, then
-    - child node ID, then
     - left endpoint.
+
+    For each edge, the ``children`` are sorted by increasing node ID.
 
     Sites are ordered by position, and Mutations are ordered by site.
 
-    If the ``edge_start`` parameter is provided, this specifies the index
-    in the edge table where sorting should start. Only rows with index
-    greater than or equal to ``edge_start`` are sorted; rows before this index
-    are not affected. This parameter is provided to allow for efficient sorting
-    when the user knows that the edges up to a given index are already sorted.
+    Note: for general edge tables this only defines a partial ordering, but
+    for strict tables (namely, those for which edges belonging to a given
+    parent do not overlap) this enforces a complete ordering.
 
     .. todo:: Update this documentation to describe the keyword arguments and
        combinations that are allowed.
@@ -427,7 +426,6 @@ def sort_tables(*args, **kwargs):
     :param MigrationTable migrations:
     :param SiteTable sites:
     :param MutationTable mutations:
-    :param int edge_start: The index in the edge table where sorting starts.
     """
     return _msprime.sort_tables(*args, **kwargs)
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -557,65 +557,19 @@ class TestSortTables(unittest.TestCase):
         self.assertEqual(ts_new.num_sites, ts.num_sites)
         self.assertEqual(ts_new.num_mutations, ts.num_mutations)
 
-    def verify_edge_sort_offset(self, ts):
-        """
-        Verifies the behaviour of the edge_start offset value.
-        """
-        tables = ts.dump_tables()
-        edges = tables.edges
-        starts = [0]
-        if len(edges) > 2:
-            starts = [0, 1, len(edges) // 2,  len(edges) - 2]
-        random.seed(self.random_seed)
-        for start in starts:
-            # Unsort the edges starting from index start
-            all_edges = list(ts.edges())
-            keep = all_edges[:start]
-            reversed_edges = all_edges[start:][::-1]
-            all_edges = keep + reversed_edges
-            new_edges = msprime.EdgeTable()
-            for e in all_edges:
-                new_edges.add_row(e.left, e.right, e.parent, e.child)
-            # Verify that import fails for randomised edges
-            self.assertRaises(
-                _msprime.LibraryError, ts.load_tables, nodes=tables.nodes,
-                edges=new_edges)
-            # If we sort after the start value we should still fail.
-            msprime.sort_tables(
-                tables.nodes, new_edges, sites=tables.sites, mutations=tables.mutations,
-                edge_start=start + 1)
-            self.assertRaises(
-                _msprime.LibraryError, ts.load_tables, nodes=tables.nodes,
-                edges=new_edges)
-            # Sorting from the correct index should give us back the original table.
-            new_edges.reset()
-            for e in all_edges:
-                new_edges.add_row(e.left, e.right, e.parent, e.child)
-            msprime.sort_tables(
-                tables.nodes, new_edges, sites=tables.sites, mutations=tables.mutations,
-                edge_start=start)
-            # Verify the new and old edges are equal.
-            self.assertEqual(list(edges.left), list(new_edges.left))
-            self.assertEqual(list(edges.right), list(new_edges.right))
-            self.assertEqual(list(edges.parent), list(new_edges.parent))
-            self.assertEqual(list(edges.child), list(new_edges.child))
-
     def test_single_tree_no_mutations(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
         self.verify_randomise_tables(ts)
-        self.verify_edge_sort_offset(ts)
 
     def test_many_trees_no_mutations(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=self.random_seed)
         self.assertGreater(ts.num_trees, 2)
         self.verify_randomise_tables(ts)
-        self.verify_edge_sort_offset(ts)
 
     def test_single_tree_mutations(self):
         ts = msprime.simulate(10, mutation_rate=2, random_seed=self.random_seed)
         self.assertGreater(ts.num_sites, 2)
         self.verify_randomise_tables(ts)
-        self.verify_edge_sort_offset(ts)
 
     def test_many_trees_mutations(self):
         ts = msprime.simulate(
@@ -623,7 +577,6 @@ class TestSortTables(unittest.TestCase):
         self.assertGreater(ts.num_trees, 2)
         self.assertGreater(ts.num_sites, 2)
         self.verify_randomise_tables(ts)
-        self.verify_edge_sort_offset(ts)
 
     def get_nonbinary_example(self, mutation_rate):
         ts = msprime.simulate(
@@ -632,9 +585,12 @@ class TestSortTables(unittest.TestCase):
                 msprime.SimpleBottleneck(time=0.5, proportion=1)])
         # Make sure this really has some non-binary nodes
         found = False
-        for e in ts.edgesets():
-            if len(e.children) > 2:
-                found = True
+        for t in ts.trees():
+            for u in t.nodes():
+                if len(t.children(u)) > 2:
+                    found = True
+                    break
+            if found:
                 break
         self.assertTrue(found)
         return ts
@@ -643,14 +599,12 @@ class TestSortTables(unittest.TestCase):
         ts = self.get_nonbinary_example(mutation_rate=0)
         self.assertGreater(ts.num_trees, 2)
         self.verify_randomise_tables(ts)
-        self.verify_edge_sort_offset(ts)
 
     def test_nonbinary_trees_mutations(self):
         ts = self.get_nonbinary_example(mutation_rate=2)
         self.assertGreater(ts.num_trees, 2)
         self.assertGreater(ts.num_sites, 2)
         self.verify_randomise_tables(ts)
-        self.verify_edge_sort_offset(ts)
 
     def test_nonbinary_mutations(self):
         # Test the sorting behaviour when we have ragged entries in the ancestral


### PR DESCRIPTION
Reverts jeromekelleher/msprime#268

It turns out that we don't actually need this for what we thought we needed it for (incrementally updating tables for forward time simulations). Doesn't seem much point in carrying forward this feature then.

@petrelharp what do you think?