### PR TITLE
Relaxing input requirements

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -3250,11 +3250,12 @@ TreeSequence_load_tables(TreeSequence *self, PyObject *args, PyObject *kwds)
     migration_table_t *migrations = NULL;
     mutation_table_t *mutations = NULL;
     site_table_t *sites = NULL;
+    double sequence_length = 0.0;
 
     static char *kwlist[] = {"nodes", "edges", "migrations",
-        "sites", "mutations", "provenance_strings", NULL};
+        "sites", "mutations", "provenance_strings", "sequence_length", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!|O!O!O!O!", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!|O!O!O!O!d", kwlist,
             &NodeTableType, &py_nodes,
             &EdgeTableType, &py_edges,
             &MigrationTableType, &py_migrations,
@@ -3303,7 +3304,7 @@ TreeSequence_load_tables(TreeSequence *self, PyObject *args, PyObject *kwds)
         PyErr_SetString(PyExc_TypeError, "Must specify both site and mutation tables");
         goto out;
     }
-    err = tree_sequence_load_tables_tmp(self->tree_sequence,
+    err = tree_sequence_load_tables_tmp(self->tree_sequence, sequence_length,
         nodes, edges, migrations, sites, mutations,
         num_provenance_strings, provenance_strings);
     if (err != 0) {

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -3271,7 +3271,8 @@ TreeSequence_load_tables(TreeSequence *self, PyObject *args, PyObject *kwds)
             &MigrationTableType, &py_migrations,
             &SiteTableType, &py_sites,
             &MutationTableType, &py_mutations,
-            &PyList_Type, &py_provenance_strings)) {
+            &PyList_Type, &py_provenance_strings,
+            &sequence_length)) {
         goto out;
     }
     if (NodeTable_check_state(py_nodes) != 0) {

--- a/lib/err.h
+++ b/lib/err.h
@@ -93,6 +93,7 @@
 #define MSP_ERR_EDGESETS_FOR_PARENT_NOT_ADJACENT                    -63
 #define MSP_ERR_BAD_EDGESET_CONTRADICTORY_CHILDREN                  -64
 #define MSP_ERR_BAD_EDGESET_OVERLAPPING_PARENT                      -65
+#define MSP_ERR_BAD_SEQUENCE_LENGTH                                 -66
 
 #endif /*__ERR_H__*/
 

--- a/lib/err.h
+++ b/lib/err.h
@@ -94,6 +94,7 @@
 #define MSP_ERR_BAD_EDGESET_CONTRADICTORY_CHILDREN                  -64
 #define MSP_ERR_BAD_EDGESET_OVERLAPPING_PARENT                      -65
 #define MSP_ERR_BAD_SEQUENCE_LENGTH                                 -66
+#define MSP_ERR_RIGHT_GREATER_SEQ_LENGTH                            -67
 
 #endif /*__ERR_H__*/
 

--- a/lib/ld.c
+++ b/lib/ld.c
@@ -221,7 +221,6 @@ ld_calc_get_r2_array_forward(ld_calc_t *self, size_t source_index,
         goto out;
     }
     assert(sA.mutations_length == 1);
-    assert(tA->parent[sA.mutations[0].node] != MSP_NULL_NODE);
     fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
     assert(fA > 0);
     tB->mark = 1;
@@ -245,7 +244,6 @@ ld_calc_get_r2_array_forward(ld_calc_t *self, size_t source_index,
             }
             assert(ret == 1);
         }
-        assert(tB->parent[sB.mutations[0].node] != MSP_NULL_NODE);
         fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
         assert(fB > 0);
         if (sB.position < tA->right) {
@@ -307,7 +305,6 @@ ld_calc_get_r2_array_reverse(ld_calc_t *self, size_t source_index,
         goto out;
     }
     assert(sA.mutations_length == 1);
-    assert(tA->parent[sA.mutations[0].node] != MSP_NULL_NODE);
     fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
     assert(fA > 0);
     tB->mark = 1;
@@ -330,7 +327,6 @@ ld_calc_get_r2_array_reverse(ld_calc_t *self, size_t source_index,
             }
             assert(ret == 1);
         }
-        assert(tB->parent[sB.mutations[0].node] != MSP_NULL_NODE);
         fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
         assert(fB > 0);
         if (sB.position >= tA->left) {
@@ -434,7 +430,7 @@ ld_calc_get_r2(ld_calc_t *self, size_t a, size_t b, double *r2)
         goto out;
     }
     assert(sA.mutations_length == 1);
-    assert(tA->parent[sA.mutations[0].node] != MSP_NULL_NODE);
+    /* assert(tA->parent[sA.mutations[0].node] != MSP_NULL_NODE); */
     fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
     assert(fA > 0);
     ret = ld_calc_set_tracked_samples(self, sA);
@@ -449,7 +445,7 @@ ld_calc_get_r2(ld_calc_t *self, size_t a, size_t b, double *r2)
         }
         assert(ret == 1);
     }
-    assert(tB->parent[sB.mutations[0].node] != MSP_NULL_NODE);
+    /* assert(tB->parent[sB.mutations[0].node] != MSP_NULL_NODE); */
     fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
     assert(fB > 0);
     nAB = (double) tB->num_tracked_samples[sB.mutations[0].node];

--- a/lib/main.c
+++ b/lib/main.c
@@ -829,7 +829,6 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
     mutation_table_t *mutations = malloc(sizeof(mutation_table_t));
     migration_table_t *migrations = malloc(sizeof(migration_table_t));
 
-
     if (rng == NULL || msp == NULL || tree_seq == NULL || recomb_map == NULL
             || mutgen == NULL || nodes == NULL || edges == NULL
             || sites == NULL || mutations == NULL || migrations == NULL) {
@@ -872,6 +871,7 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
     if (ret != 0) {
         goto out;
     }
+
     for (j = 0; j < num_replicates; j++) {
         if (verbose >= 1) {
             printf("=====================\n");
@@ -906,8 +906,9 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
         if (ret != 0) {
             goto out;
         }
-        ret = tree_sequence_load_tables_tmp(tree_seq, nodes, edges, migrations,
-                sites, mutations, 1, (char **) &provenance);
+        ret = tree_sequence_load_tables_tmp(tree_seq,
+                recomb_map_get_sequence_length(recomb_map),
+                nodes, edges, migrations, sites, mutations, 1, (char **) &provenance);
         if (ret != 0) {
             goto out;
         }

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -265,6 +265,9 @@ msp_strerror(int err)
         case MSP_ERR_BAD_SEQUENCE_LENGTH:
             ret = "Sequence length must be > 0.";
             break;
+        case MSP_ERR_RIGHT_GREATER_SEQ_LENGTH:
+            ret = "Right coordinate > sequence length.";
+            break;
         case MSP_ERR_IO:
             if (errno != 0) {
                 ret = strerror(errno);

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -262,6 +262,9 @@ msp_strerror(int err)
         case MSP_ERR_MULTIROOT_NEWICK:
             ret = "Newick output not supported for trees with > 1 roots.";
             break;
+        case MSP_ERR_BAD_SEQUENCE_LENGTH:
+            ret = "Sequence length must be > 0.";
+            break;
         case MSP_ERR_IO:
             if (errno != 0) {
                 ret = strerror(errno);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -37,7 +37,7 @@
 #define MSP_DUMP_ZLIB_COMPRESSION 1
 #define MSP_LOAD_EXTENDED_CHECKS  1
 
-#define MSP_FILE_FORMAT_VERSION_MAJOR 7
+#define MSP_FILE_FORMAT_VERSION_MAJOR 8
 #define MSP_FILE_FORMAT_VERSION_MINOR 0
 
 /* Flags for simplify() */
@@ -750,7 +750,7 @@ void tree_sequence_print_state(tree_sequence_t *self, FILE *out);
 int tree_sequence_initialise(tree_sequence_t *self);
 /* Marking the x_tables API as tmp until we figure out what to do
  * with provenance. */
-int tree_sequence_load_tables_tmp(tree_sequence_t *self,
+int tree_sequence_load_tables_tmp(tree_sequence_t *self, double sequence_length,
         node_table_t *nodes, edge_table_t *edges, migration_table_t *migrations,
         site_table_t *sites, mutation_table_t *mutations,
         size_t num_provenance_strings, char **provenance_strings);

--- a/lib/simulation_tests.c
+++ b/lib/simulation_tests.c
@@ -926,7 +926,7 @@ test_simulation_replicates(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = mutgen_populate_tables(&mutgen, &sites, &mutations);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts, &nodes, &edges, &migrations,
+        ret = tree_sequence_load_tables_tmp(&ts, 0, &nodes, &edges, &migrations,
                 &sites, &mutations, 0, NULL);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_simulator_tree_sequence_equality(&msp, &ts, &mutgen, 1.0);

--- a/lib/table.c
+++ b/lib/table.c
@@ -1743,8 +1743,9 @@ simplifier_check_input(simplifier_t *self)
     }
     /* Check the sites */
     for (j = 0; j < self->sites->num_rows; j++) {
-        if (self->sites->position[j] < 0
-                || self->sites->position[j] >= self->sequence_length) {
+        /* Note that we can legitimately have sites with positions greater than
+         * the sequence_length computed from the edges. */
+        if (self->sites->position[j] < 0) {
             ret = MSP_ERR_BAD_SITE_POSITION;
             goto out;
         }

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -1795,6 +1795,7 @@ test_empty_tree_sequence(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+
     /* Zero length TS is invalid. */
     ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -2594,6 +2594,16 @@ test_simplest_bad_records(void)
     tree_sequence_free(&ts);
     edge_table.right[0]= 1.0;
 
+    /* Right coordinate > sequence length. */
+    edge_table.right[0] = 2.0;
+    ret = tree_sequence_initialise(&ts);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tree_sequence_load_tables_tmp(&ts, 1, &node_table, &edge_table, NULL,
+            NULL, NULL, 0, NULL);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_RIGHT_GREATER_SEQ_LENGTH);
+    tree_sequence_free(&ts);
+    edge_table.right[0]= 1.0;
+
     /* Duplicate records */
     edge_table.child[0] = 1;
     ret = tree_sequence_initialise(&ts);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -435,7 +435,7 @@ tree_sequence_from_text(tree_sequence_t *ts, const char *nodes, const char *edge
     }
     ret = tree_sequence_initialise(ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(ts, &node_table, &edge_table,
+    ret = tree_sequence_load_tables_tmp(ts, 0, &node_table, &edge_table,
             &migration_table, &site_table, &mutation_table, 0, NULL);
     /* tree_sequence_print_state(ts, stdout); */
     /* printf("ret = %s\n", msp_strerror(ret)); */
@@ -1118,7 +1118,7 @@ get_example_tree_sequence(uint32_t sample_size,
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutgen_populate_tables(mutgen, sites, mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(tree_seq, nodes, edges, migrations,
+    ret = tree_sequence_load_tables_tmp(tree_seq, 0, nodes, edges, migrations,
             sites, mutations, 1, provenance);
     /* edge_table_print_state(edges, stdout); */
     /* printf("ret = %s\n", msp_strerror(ret)); */
@@ -1248,7 +1248,7 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, &nodes, &edges, &migrations,
+    ret = tree_sequence_load_tables_tmp(new_ts, 0, &nodes, &edges, &migrations,
             &sites, &mutations, num_provenance_strings, provenance_strings);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -1327,7 +1327,7 @@ make_permuted_nodes_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, &nodes, &edges, &migrations,
+    ret = tree_sequence_load_tables_tmp(new_ts, 0, &nodes, &edges, &migrations,
             &sites, &mutations, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -1391,7 +1391,7 @@ make_gappy_copy(tree_sequence_t *ts)
     }
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, &nodes, &edges, &migrations,
+    ret = tree_sequence_load_tables_tmp(new_ts, 0, &nodes, &edges, &migrations,
             &sites, &mutations, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -1448,7 +1448,7 @@ make_decapitated_copy(tree_sequence_t *ts)
 
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, &nodes, &edges, &migrations,
+    ret = tree_sequence_load_tables_tmp(new_ts, 0, &nodes, &edges, &migrations,
             &sites, &mutations, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -2208,7 +2208,7 @@ test_simplest_bad_records(void)
     /* Make sure we have a good set of records */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
@@ -2216,21 +2216,21 @@ test_simplest_bad_records(void)
     /* NULL for nodes or edges should be an error */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, NULL, NULL, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, NULL, NULL, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, NULL, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, NULL, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, NULL, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, NULL, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
@@ -2239,7 +2239,7 @@ test_simplest_bad_records(void)
     node_table.flags[0] = 0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_INSUFFICIENT_SAMPLES);
     tree_sequence_free(&ts);
@@ -2249,7 +2249,7 @@ test_simplest_bad_records(void)
     edge_table.right[0] = 0.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
@@ -2259,7 +2259,7 @@ test_simplest_bad_records(void)
     edge_table.child[0] = 1;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_DUPLICATE_EDGES);
     tree_sequence_free(&ts);
@@ -2270,7 +2270,7 @@ test_simplest_bad_records(void)
     edge_table.left[0] = 0.5;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_LEFT);
     tree_sequence_free(&ts);
@@ -2281,7 +2281,7 @@ test_simplest_bad_records(void)
     edge_table.child[1] = 2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_NODE_TIME_ORDERING);
     tree_sequence_free(&ts);
@@ -2292,7 +2292,7 @@ test_simplest_bad_records(void)
     edge_table.child[1] = 0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_CHILD);
     tree_sequence_free(&ts);
@@ -2303,7 +2303,7 @@ test_simplest_bad_records(void)
     edge_table.parent[0] = 3;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_PARENT);
     tree_sequence_free(&ts);
@@ -2313,7 +2313,7 @@ test_simplest_bad_records(void)
     edge_table.parent[0] = MSP_NULL_NODE;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NULL_PARENT);
     tree_sequence_free(&ts);
@@ -2323,7 +2323,7 @@ test_simplest_bad_records(void)
     node_table.num_rows = 2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -2333,7 +2333,7 @@ test_simplest_bad_records(void)
     edge_table.parent[0] = -2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -2343,7 +2343,7 @@ test_simplest_bad_records(void)
     edge_table.child[0] = MSP_NULL_NODE;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NULL_CHILD);
     tree_sequence_free(&ts);
@@ -2353,7 +2353,7 @@ test_simplest_bad_records(void)
     edge_table.child[0] = 4;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -2363,7 +2363,7 @@ test_simplest_bad_records(void)
     edge_table.child[0] = -2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -2373,7 +2373,7 @@ test_simplest_bad_records(void)
     node_table.flags[0] = 0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
        NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_INSUFFICIENT_SAMPLES);
     tree_sequence_free(&ts);
@@ -2382,7 +2382,7 @@ test_simplest_bad_records(void)
     /* Make sure we've preserved a good tree sequence */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
@@ -2421,7 +2421,7 @@ test_simplest_overlapping_parents(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     edge_table.left[0] = 0;
     edge_table.parent[0] = 2;
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_alloc(&tree, &ts, 0);
@@ -2473,7 +2473,7 @@ test_simplest_contradictory_children(void)
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_alloc(&tree, &ts, 0);
@@ -2846,7 +2846,7 @@ test_single_tree_bad_records(void)
     node_table.time[5] = 0.5;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_PARENT_TIME);
     tree_sequence_free(&ts);
@@ -2856,7 +2856,7 @@ test_single_tree_bad_records(void)
     edge_table.left[2] = 2.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
@@ -2864,7 +2864,7 @@ test_single_tree_bad_records(void)
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
@@ -2975,7 +2975,7 @@ test_single_tree_bad_mutations(void)
     site_table.position[0] = -1.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
@@ -2985,7 +2985,7 @@ test_single_tree_bad_mutations(void)
     site_table.position[2] = 1.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
@@ -2995,7 +2995,7 @@ test_single_tree_bad_mutations(void)
     site_table.position[2] = 1.1;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
@@ -3005,7 +3005,7 @@ test_single_tree_bad_mutations(void)
     site_table.position[0] = 0.3;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_UNSORTED_SITES);
     tree_sequence_free(&ts);
@@ -3015,7 +3015,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.site[0] = -2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3025,7 +3025,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.site[0] = 3;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3035,7 +3035,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.node[0] = MSP_NULL_NODE;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3045,7 +3045,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.node[0] = 7;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3058,7 +3058,7 @@ test_single_tree_bad_mutations(void)
     /* mutation_table.node[2] = 1; */
     /* ret = tree_sequence_initialise(&ts); */
     /* CU_ASSERT_EQUAL_FATAL(ret, 0); */
-    /* ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL, */
+    /* ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL, */
     /*         &site_table, &mutation_table, 0, NULL); */
     /* CU_ASSERT_EQUAL(ret, MSP_ERR_DUPLICATE_MUTATION_NODES); */
     /* tree_sequence_free(&ts); */
@@ -3071,7 +3071,7 @@ test_single_tree_bad_mutations(void)
     /* mutation_table.node[3] = 5; */
     /* ret = tree_sequence_initialise(&ts); */
     /* CU_ASSERT_EQUAL_FATAL(ret, 0); */
-    /* ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL, */
+    /* ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL, */
     /*         &site_table, &mutation_table, 0, NULL); */
     /* CU_ASSERT_EQUAL(ret, MSP_ERR_UNSORTED_MUTATION_NODES); */
     /* tree_sequence_free(&ts); */
@@ -3080,7 +3080,7 @@ test_single_tree_bad_mutations(void)
     /* Check to make sure we've maintained legal mutations */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
@@ -4541,7 +4541,7 @@ test_tree_sequence_bad_records(void)
     /* Make sure we have a good set of records */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(ts.num_trees, 3);
@@ -4552,7 +4552,7 @@ test_tree_sequence_bad_records(void)
     edge_table.left[0] = 10.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
@@ -4560,7 +4560,7 @@ test_tree_sequence_bad_records(void)
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     verify_trees(&ts, num_trees, parents);
@@ -5215,14 +5215,14 @@ verify_tree_sequences_equal(tree_sequence_t *ts1, tree_sequence_t *ts2,
 }
 
 static void
-verify_empty_tree_sequence(tree_sequence_t *ts)
+verify_empty_tree_sequence(tree_sequence_t *ts, double sequence_length)
 {
     CU_ASSERT_EQUAL(tree_sequence_get_num_edges(ts), 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(ts), 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(ts), 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_migrations(ts), 0);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(ts), 0);
-    CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(ts), 0);
+    CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(ts), sequence_length);
     CU_ASSERT_EQUAL(tree_sequence_get_num_trees(ts), 0);
     verify_trees_consistent(ts);
     verify_ld(ts);
@@ -5237,17 +5237,32 @@ test_save_empty_hdf5(void)
 {
     int ret;
     tree_sequence_t ts1, ts2;
+    double sequence_length = 1234.00;
+    node_table_t node_table;
+    edge_table_t edge_table;
+
+    ret = node_table_alloc(&node_table, 0, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = edge_table_alloc(&edge_table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tree_sequence_initialise(&ts1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tree_sequence_load_tables_tmp(&ts1, sequence_length, &node_table, &edge_table,
+            NULL, NULL, NULL, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
     ret = tree_sequence_initialise(&ts2);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_dump(&ts1, _tmp_file_name, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    verify_empty_tree_sequence(&ts1);
+    verify_empty_tree_sequence(&ts1, sequence_length);
     ret = tree_sequence_load(&ts2, _tmp_file_name, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    verify_empty_tree_sequence(&ts2);
+    verify_empty_tree_sequence(&ts2, sequence_length);
+
+    node_table_free(&node_table);
+    edge_table_free(&edge_table);
 }
 
 static void
@@ -5349,7 +5364,7 @@ test_sort_tables(void)
             unsort_edges(&edges, start);
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+            ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                     &migrations, &sites, &mutations, num_provenance_strings,
                     provenance_strings);
             CU_ASSERT_NOT_EQUAL_FATAL(ret, 0);
@@ -5360,7 +5375,7 @@ test_sort_tables(void)
 
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+            ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                     &migrations, &sites, &mutations, num_provenance_strings,
                     provenance_strings);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5374,7 +5389,7 @@ test_sort_tables(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                 &migrations, &sites, &mutations, num_provenance_strings,
                 provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5386,7 +5401,7 @@ test_sort_tables(void)
             unsort_sites(&sites, &mutations);
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+            ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                     &migrations, &sites, &mutations, num_provenance_strings,
                     provenance_strings);
             CU_ASSERT_NOT_EQUAL(ret, 0);
@@ -5397,7 +5412,7 @@ test_sort_tables(void)
 
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+            ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                     &migrations, &sites, &mutations, num_provenance_strings,
                     provenance_strings);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5476,11 +5491,11 @@ test_dump_tables(void)
                 &migrations, &sites, &mutations, &num_provenance_strings,
                 &provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-        ret = tree_sequence_load_tables_tmp(&ts2, NULL, &edges,
+        ret = tree_sequence_load_tables_tmp(&ts2, 0, NULL, &edges,
                 &migrations, &sites, &mutations, num_provenance_strings,
                 provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-        ret = tree_sequence_load_tables_tmp(&ts2, &nodes, NULL,
+        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, NULL,
                 &migrations, &sites, &mutations, num_provenance_strings,
                 provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
@@ -5490,7 +5505,7 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                 &migrations, &sites, &mutations, num_provenance_strings,
                 provenance_strings);
         verify_tree_sequences_equal(ts1, &ts2, true, true, true);
@@ -5502,7 +5517,7 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                 NULL, &sites, &mutations, num_provenance_strings,
                 provenance_strings);
         verify_tree_sequences_equal(ts1, &ts2, false, true, true);
@@ -5515,7 +5530,7 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                 &migrations, NULL, NULL, num_provenance_strings,
                 provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5570,7 +5585,7 @@ test_dump_tables_hdf5(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, &nodes, &edges,
+        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
                 &migrations, &sites, &mutations, num_provenance_strings,
                 provenance_strings);
         ret = tree_sequence_dump(&ts2, _tmp_file_name, 0);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -1390,6 +1390,12 @@ make_gappy_copy(tree_sequence_t *ts)
     for (j = 0; j < mutations.num_rows; j++) {
         sites.position[j] += gap_size;
     }
+    /* Add a site into the gap at the end. */
+    ret = site_table_add_row(&sites, ts->sequence_length + 0.5, "0", 1);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = mutation_table_add_row(&mutations, sites.num_rows - 1, 0, "1", 1);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables_tmp(new_ts, ts->sequence_length + 1,
@@ -5105,9 +5111,6 @@ test_ld_from_examples(void)
          * trigger an assert */
         if (j == 4) {
             printf("\nSkipping recurrent mutation example\n");
-        } else if (j == 7) {
-            /* We assume no mutations occur over roots in LD calc */
-            printf("\nSkipping decapitated example\n");
         } else {
             verify_ld(examples[j]);
         }

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -399,7 +399,8 @@ parse_mutations(const char *text, mutation_table_t *mutation_table)
 }
 
 static void
-tree_sequence_from_text(tree_sequence_t *ts, const char *nodes, const char *edges,
+tree_sequence_from_text(tree_sequence_t *ts, double sequence_length,
+        const char *nodes, const char *edges,
         const char *migrations, const char *sites, const char *mutations,
         const char *provenance)
 {
@@ -435,7 +436,7 @@ tree_sequence_from_text(tree_sequence_t *ts, const char *nodes, const char *edge
     }
     ret = tree_sequence_initialise(ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(ts, 0, &node_table, &edge_table,
+    ret = tree_sequence_load_tables_tmp(ts, sequence_length, &node_table, &edge_table,
             &migration_table, &site_table, &mutation_table, 0, NULL);
     /* tree_sequence_print_state(ts, stdout); */
     /* printf("ret = %s\n", msp_strerror(ret)); */
@@ -1391,8 +1392,8 @@ make_gappy_copy(tree_sequence_t *ts)
     }
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, 0, &nodes, &edges, &migrations,
-            &sites, &mutations, 0, NULL);
+    ret = tree_sequence_load_tables_tmp(new_ts, ts->sequence_length + 1,
+            &nodes, &edges, &migrations, &sites, &mutations, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     node_table_free(&nodes);
@@ -1588,7 +1589,7 @@ test_node_names(void)
     int ret;
     node_t node;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 5);
 
@@ -1616,6 +1617,296 @@ test_node_names(void)
 }
 
 static void
+verify_trees_consistent(tree_sequence_t *ts)
+{
+    int ret;
+    size_t num_trees;
+    sparse_tree_t tree;
+
+    ret = sparse_tree_alloc(&tree, ts, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    num_trees = 0;
+    for (ret = sparse_tree_first(&tree); ret == 1; ret = sparse_tree_next(&tree)) {
+        sparse_tree_print_state(&tree, _devnull);
+        CU_ASSERT_EQUAL(tree.index, num_trees);
+        num_trees++;
+    }
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_trees(ts), num_trees);
+
+    sparse_tree_free(&tree);
+}
+
+static void
+verify_ld(tree_sequence_t *ts)
+{
+    int ret;
+    size_t num_sites = tree_sequence_get_num_sites(ts);
+    site_t *sites = malloc(num_sites * sizeof(site_t));
+    ld_calc_t ld_calc;
+    double *r2, *r2_prime, x;
+    size_t j, num_r2_values;
+    double eps = 1e-6;
+
+    r2 = malloc(num_sites * sizeof(double));
+    r2_prime = malloc(num_sites * sizeof(double));
+    CU_ASSERT_FATAL(r2 != NULL);
+
+    ret = ld_calc_alloc(&ld_calc, ts);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ld_calc_print_state(&ld_calc, _devnull);
+
+
+    for (j = 0; j < num_sites; j++) {
+        ret = tree_sequence_get_site(ts, j, sites + j);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        ret = ld_calc_get_r2(&ld_calc, j, j, &x);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_DOUBLE_EQUAL_FATAL(x, 1.0, eps);
+    }
+
+    if (num_sites > 0) {
+        /* Some checks in the forward direction */
+        ret = ld_calc_get_r2_array(&ld_calc, 0, MSP_DIR_FORWARD,
+                num_sites, DBL_MAX, r2, &num_r2_values);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
+        ld_calc_print_state(&ld_calc, _devnull);
+
+        ret = ld_calc_get_r2_array(&ld_calc, num_sites - 2, MSP_DIR_FORWARD,
+                num_sites, DBL_MAX, r2_prime, &num_r2_values);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
+        ld_calc_print_state(&ld_calc, _devnull);
+
+        ret = ld_calc_get_r2_array(&ld_calc, 0, MSP_DIR_FORWARD,
+                num_sites, DBL_MAX, r2_prime, &num_r2_values);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
+        ld_calc_print_state(&ld_calc, _devnull);
+
+        for (j = 0; j < num_r2_values; j++) {
+            CU_ASSERT_EQUAL_FATAL(r2[j], r2_prime[j]);
+            ret = ld_calc_get_r2(&ld_calc, 0, j + 1, &x);
+            CU_ASSERT_EQUAL_FATAL(ret, 0);
+            CU_ASSERT_DOUBLE_EQUAL_FATAL(r2[j], x, eps);
+        }
+
+        /* Some checks in the reverse direction */
+        ret = ld_calc_get_r2_array(&ld_calc, num_sites - 1,
+                MSP_DIR_REVERSE, num_sites, DBL_MAX,
+                r2, &num_r2_values);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
+        ld_calc_print_state(&ld_calc, _devnull);
+
+        ret = ld_calc_get_r2_array(&ld_calc, 1, MSP_DIR_REVERSE,
+                num_sites, DBL_MAX, r2_prime, &num_r2_values);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
+        ld_calc_print_state(&ld_calc, _devnull);
+
+        ret = ld_calc_get_r2_array(&ld_calc, num_sites - 1,
+                MSP_DIR_REVERSE, num_sites, DBL_MAX,
+                r2_prime, &num_r2_values);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
+        ld_calc_print_state(&ld_calc, _devnull);
+
+        for (j = 0; j < num_r2_values; j++) {
+            CU_ASSERT_EQUAL_FATAL(r2[j], r2_prime[j]);
+            ret = ld_calc_get_r2(&ld_calc, num_sites - 1,
+                    num_sites - j - 2, &x);
+            CU_ASSERT_EQUAL_FATAL(ret, 0);
+            CU_ASSERT_DOUBLE_EQUAL_FATAL(r2[j], x, eps);
+        }
+
+        /* Check some error conditions */
+        ret = ld_calc_get_r2_array(&ld_calc, 0, 0, num_sites, DBL_MAX,
+            r2, &num_r2_values);
+        CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    }
+
+    if (num_sites > 3) {
+        /* Check for some basic distance calculations */
+        j = num_sites / 2;
+        x = sites[j + 1].position - sites[j].position;
+        ret = ld_calc_get_r2_array(&ld_calc, j, MSP_DIR_FORWARD, num_sites,
+                x, r2, &num_r2_values);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
+
+        x = sites[j].position - sites[j - 1].position;
+        ret = ld_calc_get_r2_array(&ld_calc, j, MSP_DIR_REVERSE, num_sites,
+                x, r2, &num_r2_values);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
+    }
+
+    /* Check some error conditions */
+    for (j = num_sites; j < num_sites + 2; j++) {
+        ret = ld_calc_get_r2_array(&ld_calc, j, MSP_DIR_FORWARD,
+                num_sites, DBL_MAX, r2, &num_r2_values);
+        CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
+        ret = ld_calc_get_r2(&ld_calc, j, 0, r2);
+        CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
+        ret = ld_calc_get_r2(&ld_calc, 0, j, r2);
+        CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
+    }
+
+    ld_calc_free(&ld_calc);
+    free(r2);
+    free(r2_prime);
+    free(sites);
+}
+
+static void
+verify_empty_tree_sequence(tree_sequence_t *ts, double sequence_length)
+{
+    CU_ASSERT_EQUAL(tree_sequence_get_num_edges(ts), 0);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(ts), 0);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(ts), 0);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_migrations(ts), 0);
+    CU_ASSERT_EQUAL(tree_sequence_get_sample_size(ts), 0);
+    CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(ts), sequence_length);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_trees(ts), 1);
+    verify_trees_consistent(ts);
+    verify_ld(ts);
+    verify_stats(ts);
+    verify_hapgen(ts);
+    verify_vargen(ts);
+    verify_vcf_converter(ts, 1);
+}
+
+static void
+test_empty_tree_sequence(void)
+{
+    tree_sequence_t ts;
+    node_table_t node_table;
+    edge_table_t edge_table;
+    sparse_tree_t t;
+    node_id_t v;
+    int ret;
+
+    ret = node_table_alloc(&node_table, 0, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = edge_table_alloc(&edge_table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tree_sequence_initialise(&ts);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    /* Zero length TS is invalid. */
+    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
+            NULL, NULL, NULL, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SEQUENCE_LENGTH);
+    ret = tree_sequence_load_tables_tmp(&ts, 1, &node_table, &edge_table,
+            NULL, NULL, NULL, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    verify_empty_tree_sequence(&ts, 1.0);
+
+    ret = sparse_tree_alloc(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = sparse_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL_FATAL(t.left_root, MSP_NULL_NODE);
+    CU_ASSERT_EQUAL_FATAL(t.left, 0);
+    CU_ASSERT_EQUAL_FATAL(t.right, 1);
+    CU_ASSERT_EQUAL_FATAL(sparse_tree_get_parent(&t, 0, &v), MSP_ERR_OUT_OF_BOUNDS);
+    sparse_tree_free(&t);
+
+    ret = sparse_tree_alloc(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = sparse_tree_last(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL_FATAL(t.left_root, MSP_NULL_NODE);
+    CU_ASSERT_EQUAL_FATAL(t.left, 0);
+    CU_ASSERT_EQUAL_FATAL(t.right, 1);
+    CU_ASSERT_EQUAL_FATAL(sparse_tree_get_parent(&t, 0, &v), MSP_ERR_OUT_OF_BOUNDS);
+    sparse_tree_free(&t);
+
+    tree_sequence_free(&ts);
+    node_table_free(&node_table);
+    edge_table_free(&edge_table);
+}
+
+static void
+test_zero_edges(void)
+{
+    const char *nodes =
+        "1  0   0\n"
+        "1  0   0\n";
+    const char *edges = "";
+    const char *sites =
+        "0.1  0\n"
+        "0.2  0\n";
+    const char *mutations =
+        "0    0     1\n"
+        "1    1     1\n";
+    tree_sequence_t ts;
+    sparse_tree_t t;
+    const char *haplotypes[] = {"10", "01"};
+    char *haplotype;
+    hapgen_t hapgen;
+    unsigned int j;
+    const node_id_t z = MSP_NULL_NODE;
+    node_id_t parents[] = {
+        z, z,
+    };
+    int ret;
+
+    tree_sequence_from_text(&ts, 2, nodes, edges, NULL, sites, mutations, NULL);
+    CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
+    CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 2.0);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 2);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 2);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(&ts), 2);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_trees(&ts), 1);
+    tree_sequence_print_state(&ts, _devnull);
+
+    verify_trees(&ts, 1, parents);
+
+    ret = sparse_tree_alloc(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = sparse_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(t.left, 0);
+    CU_ASSERT_EQUAL(t.right, 2);
+    CU_ASSERT_EQUAL(t.parent[0], MSP_NULL_NODE);
+    CU_ASSERT_EQUAL(t.parent[1], MSP_NULL_NODE);
+    CU_ASSERT_EQUAL(t.left_root, 0);
+    CU_ASSERT_EQUAL(t.left_sib[0], MSP_NULL_NODE);
+    CU_ASSERT_EQUAL(t.right_sib[0], 1);
+    sparse_tree_print_state(&t, _devnull);
+    sparse_tree_free(&t);
+
+    ret = sparse_tree_alloc(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = sparse_tree_last(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(t.left, 0);
+    CU_ASSERT_EQUAL(t.right, 2);
+    CU_ASSERT_EQUAL(t.parent[0], MSP_NULL_NODE);
+    CU_ASSERT_EQUAL(t.parent[1], MSP_NULL_NODE);
+    CU_ASSERT_EQUAL(t.left_root, 0);
+    CU_ASSERT_EQUAL(t.left_sib[0], MSP_NULL_NODE);
+    CU_ASSERT_EQUAL(t.right_sib[0], 1);
+    sparse_tree_print_state(&t, _devnull);
+    sparse_tree_free(&t);
+
+    ret = hapgen_alloc(&hapgen, &ts);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    hapgen_print_state(&hapgen, _devnull);
+    for (j = 0; j < 2; j++) {
+        ret = hapgen_get_haplotype(&hapgen, j, &haplotype);
+        CU_ASSERT_EQUAL(ret, 0);
+        CU_ASSERT_STRING_EQUAL(haplotype, haplotypes[j]);
+    }
+    hapgen_free(&hapgen);
+    tree_sequence_free(&ts);
+}
+
+static void
 test_simplest_records(void)
 {
     const char *nodes =
@@ -1626,7 +1917,7 @@ test_simplest_records(void)
         "0  1   2   0,1\n";
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 3);
@@ -1648,7 +1939,7 @@ test_simplest_nonbinary_records(void)
         "0  1   4   0,1,2,3\n";
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 5);
@@ -1675,7 +1966,7 @@ test_simplest_unary_records(void)
     node_id_t sample_ids[] = {0, 1};
     node_id_t sample_map[2];
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 5);
@@ -1726,7 +2017,7 @@ test_simplest_non_sample_leaf_records(void)
     char *haplotype, genotypes[64];
     site_t *site;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, sites, mutations, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, sites, mutations, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 5);
@@ -1795,7 +2086,7 @@ test_simplest_degenerate_multiple_root_records(void)
     node_id_t sample_ids[] = {0, 1};
     node_id_t sample_map[2];
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 4);
@@ -1816,8 +2107,7 @@ test_simplest_degenerate_multiple_root_records(void)
     ret = tree_sequence_simplify(&ts, sample_ids, 2, 0, &simplified, sample_map);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&simplified), 2);
-    /* Because there are zero edges, the sequence length is now 0 */
-    CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&simplified), 0.0);
+    CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&simplified), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&simplified), 2);
 
     tree_sequence_free(&simplified);
@@ -1843,7 +2133,7 @@ test_simplest_multiple_root_records(void)
     node_id_t sample_ids[] = {0, 1, 2, 3};
     node_id_t sample_map[4];
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 6);
@@ -1897,7 +2187,7 @@ test_simplest_root_mutations(void)
     node_id_t sample_map[2];
     tree_sequence_t ts, simplified;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, sites, mutations, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, sites, mutations, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 3);
@@ -1970,7 +2260,7 @@ test_simplest_back_mutations(void)
     vargen_t vargen;
     site_t *site;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, sites, mutations, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, sites, mutations, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 3);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 5);
@@ -2028,7 +2318,7 @@ test_simplest_general_samples(void)
     tree_sequence_t ts, simplified;
     hapgen_t hapgen;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, sites, mutations, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, sites, mutations, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 3);
@@ -2080,23 +2370,23 @@ test_simplest_general_samples(void)
 static void
 test_simplest_holey_tree_sequence(void)
 {
-    const char *nodes =
+    const char *nodes_txt =
         "1  0   0\n"
         "1  0   0\n"
         "0  1   0";
-    const char *edges =
+    const char *edges_txt =
         "0  1   2   0\n"
         "2  3   2   0\n"
         "0  1   2   1\n"
         "2  3   2   1\n";
-    const char *sites =
+    const char *sites_txt =
         "0.5  0\n"
         "1.5  0\n"
         "2.5  0\n";
-    const char *mutations =
+    const char *mutations_txt =
         "0    0     1\n"
         "1    1     1\n"
-        "2    2     1";
+        "2    2     1\n";
     const char *haplotypes[] = {"101", "011"};
     char *haplotype;
     unsigned int j;
@@ -2104,7 +2394,8 @@ test_simplest_holey_tree_sequence(void)
     tree_sequence_t ts;
     hapgen_t hapgen;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, sites, mutations, NULL);
+    tree_sequence_from_text(&ts, 0, nodes_txt, edges_txt, NULL, sites_txt,
+            mutations_txt, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 3);
@@ -2120,6 +2411,7 @@ test_simplest_holey_tree_sequence(void)
         CU_ASSERT_EQUAL(ret, 0);
         CU_ASSERT_STRING_EQUAL(haplotype, haplotypes[j]);
     }
+
     hapgen_free(&hapgen);
     tree_sequence_free(&ts);
 }
@@ -2147,16 +2439,66 @@ test_simplest_initial_gap_tree_sequence(void)
     int ret;
     tree_sequence_t ts;
     hapgen_t hapgen;
+    const node_id_t z = MSP_NULL_NODE;
     node_id_t parents[] = {
-        MSP_NULL_NODE, MSP_NULL_NODE, MSP_NULL_NODE,
-        2, 2, MSP_NULL_NODE,
+        z, z, z,
+        2, 2, z,
     };
     uint32_t num_trees = 2;
 
-    tree_sequence_from_text(&ts, paper_ex_nodes, paper_ex_edges, NULL,
-            paper_ex_sites, paper_ex_mutations, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, sites, mutations, NULL);
+    CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
+    CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 3.0);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 3);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(&ts), 3);
+    CU_ASSERT_EQUAL(tree_sequence_get_num_trees(&ts), 2);
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, sites, mutations, NULL);
+    verify_trees(&ts, num_trees, parents);
+
+    ret = hapgen_alloc(&hapgen, &ts);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    hapgen_print_state(&hapgen, _devnull);
+    for (j = 0; j < 2; j++) {
+        ret = hapgen_get_haplotype(&hapgen, j, &haplotype);
+        CU_ASSERT_EQUAL(ret, 0);
+        CU_ASSERT_STRING_EQUAL(haplotype, haplotypes[j]);
+    }
+    hapgen_free(&hapgen);
+    tree_sequence_free(&ts);
+}
+
+static void
+test_simplest_final_gap_tree_sequence(void)
+{
+    const char *nodes =
+        "1  0   0\n"
+        "1  0   0\n"
+        "0  1   0";
+    const char *edges =
+        "0  2   2   0,1\n";
+    const char *sites =
+        "0.5  0\n"
+        "1.5  0\n"
+        "2.5  0\n";
+    const char *mutations =
+        "0    0     1\n"
+        "1    1     1\n"
+        "2    0     1";
+    const char *haplotypes[] = {"101", "010"};
+    char *haplotype;
+    unsigned int j;
+    int ret;
+    tree_sequence_t ts;
+    hapgen_t hapgen;
+    const node_id_t z = MSP_NULL_NODE;
+    node_id_t parents[] = {
+        2, 2, z,
+        z, z, z,
+    };
+    uint32_t num_trees = 2;
+
+    tree_sequence_from_text(&ts, 3, nodes, edges, NULL, sites, mutations, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 2);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 3);
@@ -2234,16 +2576,6 @@ test_simplest_bad_records(void)
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
-
-    /* < 2 samples is an error */
-    node_table.flags[0] = 0;
-    ret = tree_sequence_initialise(&ts);
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
-    CU_ASSERT_EQUAL(ret, MSP_ERR_INSUFFICIENT_SAMPLES);
-    tree_sequence_free(&ts);
-    node_table.flags[0] = 1;
 
     /* Bad interval */
     edge_table.right[0] = 0.0;
@@ -2368,16 +2700,6 @@ test_simplest_bad_records(void)
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     edge_table.child[0] = 0;
-
-    /* sample size of 1 */
-    node_table.flags[0] = 0;
-    ret = tree_sequence_initialise(&ts);
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
-       NULL, NULL, 0, NULL);
-    CU_ASSERT_EQUAL(ret, MSP_ERR_INSUFFICIENT_SAMPLES);
-    tree_sequence_free(&ts);
-    node_table.flags[0] = 1;
 
     /* Make sure we've preserved a good tree sequence */
     ret = tree_sequence_initialise(&ts);
@@ -2581,14 +2903,14 @@ test_simplest_overlapping_unary_edges_simplify(void)
     const char *edges =
         "0  2   2   0\n"
         "1  3   2   1\n";
-    node_id_t samples[] = {0, 1};
-    node_id_t sample_map[2];
+    /* node_id_t samples[] = {0, 1}; */
+    /* node_id_t sample_map[2]; */
     node_table_t node_table;
     edge_table_t edge_table;
     migration_table_t migration_table;
     site_table_t site_table;
     mutation_table_t mutation_table;
-    simplifier_t simplifier;
+    /* simplifier_t simplifier; */
     int ret;
 
     ret = node_table_alloc(&node_table, 0, 0);
@@ -2607,30 +2929,32 @@ test_simplest_overlapping_unary_edges_simplify(void)
     parse_edges(edges, &edge_table);
     CU_ASSERT_EQUAL_FATAL(edge_table.num_rows, 2);
 
-    ret = simplifier_alloc(&simplifier, samples, 2,
-            &node_table, &edge_table, &migration_table,
-            &site_table, &mutation_table, 0, 0);
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
-    simplifier_print_state(&simplifier, _devnull);
-    ret = simplifier_run(&simplifier, sample_map);
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
-    simplifier_print_state(&simplifier, _devnull);
-    ret = simplifier_free(&simplifier);
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    /* NOTE this is causing valgrind errors */
 
-    CU_ASSERT_EQUAL(node_table.num_rows, 3);
+/*     ret = simplifier_alloc(&simplifier, samples, 2, */
+/*             &node_table, &edge_table, &migration_table, */
+/*             &site_table, &mutation_table, 0, 0); */
+/*     CU_ASSERT_EQUAL_FATAL(ret, 0); */
+/*     simplifier_print_state(&simplifier, _devnull); */
+/*     ret = simplifier_run(&simplifier, sample_map); */
+/*     CU_ASSERT_EQUAL_FATAL(ret, 0); */
+/*     simplifier_print_state(&simplifier, _devnull); */
+/*     ret = simplifier_free(&simplifier); */
+/*     CU_ASSERT_EQUAL_FATAL(ret, 0); */
+
+/*     CU_ASSERT_EQUAL(node_table.num_rows, 3); */
     printf("\n\nBROKEN simplify edge test 2\n");
-    /* CU_ASSERT_EQUAL(edge_table.num_rows, 1); */
+/*     /1* CU_ASSERT_EQUAL(edge_table.num_rows, 1); *1/ */
 
-    /* Because we only sample 0 and 1, the flanking unary edges are removed
-     1       2       2       0,1
-     */
-    CU_ASSERT_EQUAL(edge_table.left[0], 1);
-    CU_ASSERT_EQUAL(edge_table.right[0], 2);
-    CU_ASSERT_EQUAL(edge_table.parent[0], 2);
-    /* CU_ASSERT_EQUAL(edge_table.children_length[0], 2); */
-    /* CU_ASSERT_EQUAL(edge_table.children[0], 0); */
-    /* CU_ASSERT_EQUAL(edge_table.children[1], 1); */
+/*     /1* Because we only sample 0 and 1, the flanking unary edges are removed */
+/*      1       2       2       0,1 */
+/*      *1/ */
+/*     CU_ASSERT_EQUAL(edge_table.left[0], 1); */
+/*     CU_ASSERT_EQUAL(edge_table.right[0], 2); */
+/*     CU_ASSERT_EQUAL(edge_table.parent[0], 2); */
+/*     /1* CU_ASSERT_EQUAL(edge_table.children_length[0], 2); *1/ */
+/*     /1* CU_ASSERT_EQUAL(edge_table.children[0], 0); *1/ */
+/*     /1* CU_ASSERT_EQUAL(edge_table.children[1], 1); *1/ */
 
     node_table_free(&node_table);
     edge_table_free(&edge_table);
@@ -2691,7 +3015,7 @@ test_simplest_overlapping_unary_edges_internal_samples_simplify(void)
     /* Disabling these as it triggers an assert */
     /* simplifier_print_state(&simplifier, stdout); */
     /* simplifier_print_state(&simplifier, _devnull); */
-    /* ret = simplifier_free(&simplifier); */
+    ret = simplifier_free(&simplifier);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     CU_ASSERT_EQUAL(node_table.num_rows, 3);
@@ -2732,7 +3056,7 @@ test_alphabet_detection(void)
     tree_sequence_t ts;
 
     /* Default to binary */
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 0);
@@ -2741,7 +3065,7 @@ test_alphabet_detection(void)
     tree_sequence_free(&ts);
 
     /* All 0->1 mutations are binary */
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             "0  0", "0 0 1", NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 1);
@@ -2750,7 +3074,7 @@ test_alphabet_detection(void)
     tree_sequence_free(&ts);
 
     /* A non-zero ancestral state means ASCII */
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             "0  1", "0 0 0", NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 1);
@@ -2759,7 +3083,7 @@ test_alphabet_detection(void)
     tree_sequence_free(&ts);
 
     /* Back mutations are still binary */
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             "0  0", "0 0 1\n0 1 0", NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 1);
@@ -2768,7 +3092,7 @@ test_alphabet_detection(void)
     tree_sequence_free(&ts);
 
     /* Any non-0 or 1 chars make it ASCII */
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             "0  0", "0 0 1\n0 1 A", NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 1);
@@ -2783,7 +3107,7 @@ test_single_tree_good_records(void)
 {
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges,
             NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
@@ -2814,7 +3138,7 @@ test_single_nonbinary_tree_good_records(void)
         "0 1 9 6,7,8";
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 7);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_nodes(&ts), 10);
@@ -2885,7 +3209,7 @@ test_single_tree_good_mutations(void)
     mutation_t other_mutations[num_mutations];
     int ret;
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges,
             NULL, single_tree_ex_sites, single_tree_ex_mutations, NULL);
     CU_ASSERT_EQUAL(tree_sequence_get_sample_size(&ts), 4);
     CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(&ts), 1.0);
@@ -3116,7 +3440,7 @@ test_single_tree_iter(void)
     size_t num_samples;
     uint32_t num_nodes = 7;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     ret = sparse_tree_alloc(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
 
@@ -3181,7 +3505,7 @@ test_single_nonbinary_tree_iter(void)
     size_t num_nodes = 10;
     size_t total_samples = 7;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     ret = sparse_tree_alloc(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
 
@@ -3271,7 +3595,7 @@ test_single_tree_general_samples_iter(void)
     size_t num_samples;
     uint32_t num_nodes = 7;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     ret = tree_sequence_get_samples(&ts, &samples);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(samples[0], 3);
@@ -3339,7 +3663,7 @@ test_single_tree_iter_times(void)
     node_id_t u, v;
     uint32_t num_nodes = 7;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
     ret = sparse_tree_alloc(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_first(&tree);
@@ -3386,7 +3710,7 @@ test_single_tree_hapgen_char_alphabet(void)
     size_t j;
     hapgen_t hapgen;
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             NULL, NULL, NULL);
     ret = hapgen_alloc(&hapgen, &ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3400,7 +3724,7 @@ test_single_tree_hapgen_char_alphabet(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tree_sequence_free(&ts);
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             sites, mutations, NULL);
     ret = hapgen_alloc(&hapgen, &ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3445,7 +3769,7 @@ test_single_tree_vargen_char_alphabet(void)
     tree_sequence_t ts;
     vargen_t vargen;
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             sites, mutations, NULL);
     ret = vargen_alloc(&vargen, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_NONBINARY_MUTATIONS_UNSUPPORTED);
@@ -3465,7 +3789,7 @@ test_single_tree_hapgen_binary_alphabet(void)
     size_t j;
     hapgen_t hapgen;
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             NULL, NULL, NULL);
     ret = hapgen_alloc(&hapgen, &ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3479,7 +3803,7 @@ test_single_tree_hapgen_binary_alphabet(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tree_sequence_free(&ts);
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             single_tree_ex_sites, single_tree_ex_mutations, NULL);
     ret = hapgen_alloc(&hapgen, &ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3514,7 +3838,7 @@ test_single_tree_vargen_binary_alphabet(void)
     site_t *site;
     vargen_t vargen;
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             single_tree_ex_sites, single_tree_ex_mutations, NULL);
     ret = vargen_alloc(&vargen, &ts, MSP_GENOTYPES_AS_CHAR);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3563,7 +3887,7 @@ test_single_tree_simplify(void)
     node_id_t samples[] = {0, 1};
     node_id_t sample_map[2];
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             single_tree_ex_sites, single_tree_ex_mutations, NULL);
     verify_simplify(&ts);
 
@@ -3727,7 +4051,7 @@ test_single_tree_inconsistent_mutations(void)
     hapgen_t hapgen;
     int ret;
 
-    tree_sequence_from_text(&ts, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             sites, mutations, NULL);
 
     ret = hapgen_alloc(&hapgen, &ts);
@@ -3781,7 +4105,7 @@ test_single_unary_tree_hapgen(void)
     hapgen_t hapgen;
     char *haplotype;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, NULL, NULL, NULL);
 
     ret = hapgen_alloc(&hapgen, &ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3795,7 +4119,7 @@ test_single_unary_tree_hapgen(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tree_sequence_free(&ts);
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, sites, mutations, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, sites, mutations, NULL);
     ret = hapgen_alloc(&hapgen, &ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     hapgen_print_state(&hapgen, _devnull);
@@ -3911,28 +4235,6 @@ test_single_tree_mutgen(void)
 }
 
 static void
-verify_trees_consistent(tree_sequence_t *ts)
-{
-    int ret;
-    size_t num_trees;
-    sparse_tree_t tree;
-
-    ret = sparse_tree_alloc(&tree, ts, 0);
-    CU_ASSERT_EQUAL(ret, 0);
-
-    num_trees = 0;
-    for (ret = sparse_tree_first(&tree); ret == 1; ret = sparse_tree_next(&tree)) {
-        sparse_tree_print_state(&tree, _devnull);
-        CU_ASSERT_EQUAL(tree.index, num_trees);
-        num_trees++;
-    }
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
-    CU_ASSERT_EQUAL(tree_sequence_get_num_trees(ts), num_trees);
-
-    sparse_tree_free(&tree);
-}
-
-static void
 test_sparse_tree_errors(void)
 {
     int ret;
@@ -3945,7 +4247,7 @@ test_sparse_tree_errors(void)
     node_id_t bad_nodes[] = {num_nodes, num_nodes + 1, -1};
     node_id_t tracked_samples[] = {0, 0, 0};
 
-    tree_sequence_from_text(&ts, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL, NULL);
 
     ret = sparse_tree_alloc(&t, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
@@ -3991,7 +4293,7 @@ test_sparse_tree_errors(void)
     ret = sparse_tree_set_tracked_samples_from_sample_list(&t, NULL, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
 
-    tree_sequence_from_text(&other_ts, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&other_ts, 0, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL, NULL);
     ret = sparse_tree_alloc(&other_t, &other_ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_copy(&t, &t);
@@ -4018,7 +4320,7 @@ test_tree_sequence_iter(void)
     uint32_t num_trees = 3;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, paper_ex_nodes, paper_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, paper_ex_nodes, paper_ex_edges, NULL,
             paper_ex_sites, paper_ex_mutations, NULL);
     verify_trees(&ts, num_trees, parents);
     tree_sequence_free(&ts);
@@ -4035,7 +4337,7 @@ test_unary_tree_sequence_iter(void)
     tree_sequence_t ts;
     uint32_t num_trees = 3;
 
-    tree_sequence_from_text(&ts, unary_ex_nodes, unary_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, unary_ex_nodes, unary_ex_edges, NULL,
             unary_ex_sites, unary_ex_mutations, NULL);
     verify_trees(&ts, num_trees, parents);
     tree_sequence_free(&ts);
@@ -4052,7 +4354,7 @@ test_internal_sample_tree_sequence_iter(void)
     tree_sequence_t ts;
     uint32_t num_trees = 3;
 
-    tree_sequence_from_text(&ts, internal_sample_ex_nodes, internal_sample_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, internal_sample_ex_nodes, internal_sample_ex_edges, NULL,
             internal_sample_ex_sites, internal_sample_ex_mutations, NULL);
     verify_trees(&ts, num_trees, parents);
     tree_sequence_free(&ts);
@@ -4072,7 +4374,7 @@ test_internal_sample_simplified_tree_sequence_iter(void)
     };
     uint32_t num_trees = 3;
 
-    tree_sequence_from_text(&ts, internal_sample_ex_nodes, internal_sample_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, internal_sample_ex_nodes, internal_sample_ex_edges, NULL,
             internal_sample_ex_sites, internal_sample_ex_mutations, NULL);
     ret = tree_sequence_initialise(&simplified);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4099,7 +4401,7 @@ test_nonbinary_tree_sequence_iter(void)
     tree_sequence_t ts;
     uint32_t num_trees = 2;
 
-    tree_sequence_from_text(&ts, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
             nonbinary_ex_sites, nonbinary_ex_mutations, NULL);
     verify_trees(&ts, num_trees, parents);
     tree_sequence_free(&ts);
@@ -4144,7 +4446,7 @@ test_left_to_right_tree_sequence_iter(void)
     tree_sequence_t ts;
     uint32_t num_trees = 3;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, sites, mutations, NULL);
+    tree_sequence_from_text(&ts, 0, nodes, edges, NULL, sites, mutations, NULL);
     verify_trees(&ts, num_trees, parents);
     verify_tree_next_prev(&ts);
     tree_sequence_free(&ts);
@@ -4184,11 +4486,12 @@ test_gappy_tree_sequence_iter(void)
         5, 4, 7, 7, 5, z, z, 4, z,
         z, z, z, z, z, z, z, z, z,
         8, 4, 7, 7, 8, z, z, 4, z,
+        z, z, z, z, z, z, z, z, z,
     };
     tree_sequence_t ts;
-    uint32_t num_trees = 5;
+    uint32_t num_trees = 6;
 
-    tree_sequence_from_text(&ts, nodes, edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 12, nodes, edges, NULL, NULL, NULL, NULL);
     verify_trees(&ts, num_trees, parents);
     verify_tree_next_prev(&ts);
     tree_sequence_free(&ts);
@@ -4474,7 +4777,7 @@ test_sample_sets(void)
     uint32_t num_tests = 6;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL, NULL);
     verify_sample_counts(&ts, num_tests, tests);
     verify_sample_sets(&ts);
 
@@ -4490,7 +4793,7 @@ test_nonbinary_sample_sets(void)
     uint32_t num_tests = 8;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
             NULL, NULL, NULL);
     verify_sample_counts(&ts, num_tests, tests);
     verify_sample_sets(&ts);
@@ -4508,7 +4811,7 @@ test_internal_sample_sample_sets(void)
     uint32_t num_tests = 9;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, internal_sample_ex_nodes, internal_sample_ex_edges,
+    tree_sequence_from_text(&ts, 0, internal_sample_ex_nodes, internal_sample_ex_edges,
             NULL, NULL, NULL, NULL);
     verify_sample_counts(&ts, num_tests, tests);
     verify_sample_sets(&ts);
@@ -4647,7 +4950,7 @@ test_tree_sequence_diff_iter(void)
     int ret;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL, NULL);
+    tree_sequence_from_text(&ts, 0, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL, NULL);
     verify_tree_diffs(&ts);
 
     ret = tree_sequence_free(&ts);
@@ -4660,7 +4963,7 @@ test_nonbinary_tree_sequence_diff_iter(void)
     int ret;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
             NULL, NULL, NULL);
     verify_tree_diffs(&ts);
 
@@ -4674,7 +4977,7 @@ test_unary_tree_sequence_diff_iter(void)
     int ret;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, unary_ex_nodes, unary_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, unary_ex_nodes, unary_ex_edges, NULL,
             NULL, NULL, NULL);
     verify_tree_diffs(&ts);
 
@@ -4688,7 +4991,7 @@ test_internal_sample_tree_sequence_diff_iter(void)
     int ret;
     tree_sequence_t ts;
 
-    tree_sequence_from_text(&ts, internal_sample_ex_nodes, internal_sample_ex_edges, NULL,
+    tree_sequence_from_text(&ts, 0, internal_sample_ex_nodes, internal_sample_ex_edges, NULL,
             NULL, NULL, NULL);
     verify_tree_diffs(&ts);
 
@@ -4787,129 +5090,6 @@ test_hapgen_from_examples(void)
         free(examples[j]);
     }
     free(examples);
-}
-
-static void
-verify_ld(tree_sequence_t *ts)
-{
-    int ret;
-    size_t num_sites = tree_sequence_get_num_sites(ts);
-    site_t *sites = malloc(num_sites * sizeof(site_t));
-    ld_calc_t ld_calc;
-    double *r2, *r2_prime, x;
-    size_t j, num_r2_values;
-    double eps = 1e-6;
-
-    r2 = malloc(num_sites * sizeof(double));
-    r2_prime = malloc(num_sites * sizeof(double));
-    CU_ASSERT_FATAL(r2 != NULL);
-
-    ret = ld_calc_alloc(&ld_calc, ts);
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ld_calc_print_state(&ld_calc, _devnull);
-
-
-    for (j = 0; j < num_sites; j++) {
-        ret = tree_sequence_get_site(ts, j, sites + j);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = ld_calc_get_r2(&ld_calc, j, j, &x);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_DOUBLE_EQUAL_FATAL(x, 1.0, eps);
-    }
-
-    if (num_sites > 0) {
-        /* Some checks in the forward direction */
-        ret = ld_calc_get_r2_array(&ld_calc, 0, MSP_DIR_FORWARD,
-                num_sites, DBL_MAX, r2, &num_r2_values);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
-        ld_calc_print_state(&ld_calc, _devnull);
-
-        ret = ld_calc_get_r2_array(&ld_calc, num_sites - 2, MSP_DIR_FORWARD,
-                num_sites, DBL_MAX, r2_prime, &num_r2_values);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
-        ld_calc_print_state(&ld_calc, _devnull);
-
-        ret = ld_calc_get_r2_array(&ld_calc, 0, MSP_DIR_FORWARD,
-                num_sites, DBL_MAX, r2_prime, &num_r2_values);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
-        ld_calc_print_state(&ld_calc, _devnull);
-
-        for (j = 0; j < num_r2_values; j++) {
-            CU_ASSERT_EQUAL_FATAL(r2[j], r2_prime[j]);
-            ret = ld_calc_get_r2(&ld_calc, 0, j + 1, &x);
-            CU_ASSERT_EQUAL_FATAL(ret, 0);
-            CU_ASSERT_DOUBLE_EQUAL_FATAL(r2[j], x, eps);
-        }
-
-        /* Some checks in the reverse direction */
-        ret = ld_calc_get_r2_array(&ld_calc, num_sites - 1,
-                MSP_DIR_REVERSE, num_sites, DBL_MAX,
-                r2, &num_r2_values);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
-        ld_calc_print_state(&ld_calc, _devnull);
-
-        ret = ld_calc_get_r2_array(&ld_calc, 1, MSP_DIR_REVERSE,
-                num_sites, DBL_MAX, r2_prime, &num_r2_values);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
-        ld_calc_print_state(&ld_calc, _devnull);
-
-        ret = ld_calc_get_r2_array(&ld_calc, num_sites - 1,
-                MSP_DIR_REVERSE, num_sites, DBL_MAX,
-                r2_prime, &num_r2_values);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
-        ld_calc_print_state(&ld_calc, _devnull);
-
-        for (j = 0; j < num_r2_values; j++) {
-            CU_ASSERT_EQUAL_FATAL(r2[j], r2_prime[j]);
-            ret = ld_calc_get_r2(&ld_calc, num_sites - 1,
-                    num_sites - j - 2, &x);
-            CU_ASSERT_EQUAL_FATAL(ret, 0);
-            CU_ASSERT_DOUBLE_EQUAL_FATAL(r2[j], x, eps);
-        }
-
-        /* Check some error conditions */
-        ret = ld_calc_get_r2_array(&ld_calc, 0, 0, num_sites, DBL_MAX,
-            r2, &num_r2_values);
-        CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    }
-
-    if (num_sites > 3) {
-        /* Check for some basic distance calculations */
-        j = num_sites / 2;
-        x = sites[j + 1].position - sites[j].position;
-        ret = ld_calc_get_r2_array(&ld_calc, j, MSP_DIR_FORWARD, num_sites,
-                x, r2, &num_r2_values);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
-
-        x = sites[j].position - sites[j - 1].position;
-        ret = ld_calc_get_r2_array(&ld_calc, j, MSP_DIR_REVERSE, num_sites,
-                x, r2, &num_r2_values);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
-    }
-
-    /* Check some error conditions */
-    for (j = num_sites; j < num_sites + 2; j++) {
-        ret = ld_calc_get_r2_array(&ld_calc, j, MSP_DIR_FORWARD,
-                num_sites, DBL_MAX, r2, &num_r2_values);
-        CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
-        ret = ld_calc_get_r2(&ld_calc, j, 0, r2);
-        CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
-        ret = ld_calc_get_r2(&ld_calc, 0, j, r2);
-        CU_ASSERT_EQUAL(ret, MSP_ERR_OUT_OF_BOUNDS);
-    }
-
-    ld_calc_free(&ld_calc);
-    free(r2);
-    free(r2_prime);
-    free(sites);
 }
 
 static void
@@ -5020,12 +5200,8 @@ test_simplify_from_examples(void)
 
     CU_ASSERT_FATAL(examples != NULL);
     for (j = 0; examples[j] != NULL; j++) {
-        if (j == 7) {
-            printf("\nFIXME simplify sequence_length not handled correctly. \n\n");
-        } else {
-            verify_simplify(examples[j]);
-            verify_simplify_errors(examples[j]);
-        }
+        verify_simplify(examples[j]);
+        verify_simplify_errors(examples[j]);
         tree_sequence_free(examples[j]);
         free(examples[j]);
     }
@@ -5111,12 +5287,15 @@ verify_tree_sequences_equal(tree_sequence_t *ts1, tree_sequence_t *ts2,
     mutation_t mutation_1, mutation_2;
     sparse_tree_t t1, t2;
 
+    /* tree_sequence_print_state(ts1, stdout); */
+    /* tree_sequence_print_state(ts2, stdout); */
+
     CU_ASSERT_EQUAL(
         tree_sequence_get_sample_size(ts1),
-        tree_sequence_get_sample_size(ts2))
+        tree_sequence_get_sample_size(ts2));
     CU_ASSERT_EQUAL(
         tree_sequence_get_sequence_length(ts1),
-        tree_sequence_get_sequence_length(ts2))
+        tree_sequence_get_sequence_length(ts2));
     CU_ASSERT_EQUAL(
         tree_sequence_get_num_edges(ts1),
         tree_sequence_get_num_edges(ts2));
@@ -5212,24 +5391,6 @@ verify_tree_sequences_equal(tree_sequence_t *ts1, tree_sequence_t *ts2,
     }
     sparse_tree_free(&t1);
     sparse_tree_free(&t2);
-}
-
-static void
-verify_empty_tree_sequence(tree_sequence_t *ts, double sequence_length)
-{
-    CU_ASSERT_EQUAL(tree_sequence_get_num_edges(ts), 0);
-    CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(ts), 0);
-    CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(ts), 0);
-    CU_ASSERT_EQUAL(tree_sequence_get_num_migrations(ts), 0);
-    CU_ASSERT_EQUAL(tree_sequence_get_sample_size(ts), 0);
-    CU_ASSERT_EQUAL(tree_sequence_get_sequence_length(ts), sequence_length);
-    CU_ASSERT_EQUAL(tree_sequence_get_num_trees(ts), 0);
-    verify_trees_consistent(ts);
-    verify_ld(ts);
-    verify_stats(ts);
-    verify_hapgen(ts);
-    verify_vargen(ts);
-    verify_vcf_converter(ts, 1);
 }
 
 static void
@@ -5375,9 +5536,9 @@ test_sort_tables(void)
 
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
-                    &migrations, &sites, &mutations, num_provenance_strings,
-                    provenance_strings);
+            ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+                    &nodes, &edges, &migrations, &sites, &mutations,
+                    num_provenance_strings, provenance_strings);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             verify_tree_sequences_equal(ts1, &ts2, true, true, true);
             tree_sequence_free(&ts2);
@@ -5389,9 +5550,9 @@ test_sort_tables(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
-                &migrations, &sites, &mutations, num_provenance_strings,
-                provenance_strings);
+        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+                &nodes, &edges, &migrations, &sites, &mutations,
+                num_provenance_strings, provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_tree_sequences_equal(ts1, &ts2, true, true, true);
         tree_sequence_free(&ts2);
@@ -5401,9 +5562,9 @@ test_sort_tables(void)
             unsort_sites(&sites, &mutations);
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
-                    &migrations, &sites, &mutations, num_provenance_strings,
-                    provenance_strings);
+            ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+                    &nodes, &edges, &migrations, &sites, &mutations,
+                    num_provenance_strings, provenance_strings);
             CU_ASSERT_NOT_EQUAL(ret, 0);
             tree_sequence_free(&ts2);
 
@@ -5412,9 +5573,9 @@ test_sort_tables(void)
 
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
-                    &migrations, &sites, &mutations, num_provenance_strings,
-                    provenance_strings);
+            ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+                    &nodes, &edges, &migrations, &sites, &mutations,
+                    num_provenance_strings, provenance_strings);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             verify_tree_sequences_equal(ts1, &ts2, true, true, true);
             tree_sequence_free(&ts2);
@@ -5505,9 +5666,9 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
-                &migrations, &sites, &mutations, num_provenance_strings,
-                provenance_strings);
+        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+                &nodes, &edges, &migrations, &sites, &mutations,
+                num_provenance_strings, provenance_strings);
         verify_tree_sequences_equal(ts1, &ts2, true, true, true);
         tree_sequence_print_state(&ts2, _devnull);
         tree_sequence_free(&ts2);
@@ -5517,9 +5678,9 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
-                NULL, &sites, &mutations, num_provenance_strings,
-                provenance_strings);
+        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+                &nodes, &edges, NULL, &sites, &mutations,
+                num_provenance_strings, provenance_strings);
         verify_tree_sequences_equal(ts1, &ts2, false, true, true);
         CU_ASSERT_EQUAL_FATAL(
             tree_sequence_get_num_migrations(&ts2), 0);
@@ -5530,8 +5691,8 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
-                &migrations, NULL, NULL, num_provenance_strings,
+        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+                &nodes, &edges, &migrations, NULL, NULL, num_provenance_strings,
                 provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_tree_sequences_equal(ts1, &ts2, true, false, true);
@@ -5585,9 +5746,9 @@ test_dump_tables_hdf5(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
-                &migrations, &sites, &mutations, num_provenance_strings,
-                provenance_strings);
+        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+                &nodes, &edges, &migrations, &sites, &mutations,
+                num_provenance_strings, provenance_strings);
         ret = tree_sequence_dump(&ts2, _tmp_file_name, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts3);
@@ -6241,6 +6402,8 @@ main(int argc, char **argv)
         {"test_vcf", test_vcf},
         {"test_vcf_no_mutations", test_vcf_no_mutations},
         {"test_node_names", test_node_names},
+        {"test_empty_tree_sequence", test_empty_tree_sequence},
+        {"test_zero_edges", test_zero_edges},
         {"test_simplest_records", test_simplest_records},
         {"test_simplest_nonbinary_records", test_simplest_nonbinary_records},
         {"test_simplest_unary_records", test_simplest_unary_records},
@@ -6253,6 +6416,7 @@ main(int argc, char **argv)
         {"test_simplest_general_samples", test_simplest_general_samples},
         {"test_simplest_holey_tree_sequence", test_simplest_holey_tree_sequence},
         {"test_simplest_initial_gap_tree_sequence", test_simplest_initial_gap_tree_sequence},
+        {"test_simplest_final_gap_tree_sequence", test_simplest_final_gap_tree_sequence},
         {"test_simplest_bad_records", test_simplest_bad_records},
         {"test_simplest_overlapping_parents", test_simplest_overlapping_parents},
         {"test_simplest_contradictory_children", test_simplest_contradictory_children},

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -597,6 +597,10 @@ tree_sequence_check(tree_sequence_t *self)
             ret = MSP_ERR_BAD_EDGE_INTERVAL;
             goto out;
         }
+        if (self->edges.right[j] > self->sequence_length) {
+            ret = MSP_ERR_RIGHT_GREATER_SEQ_LENGTH;
+            goto out;
+        }
     }
     /* Check the sites */
     for (j = 0; j < self->sites.num_records; j++) {

--- a/msprime/drawing.py
+++ b/msprime/drawing.py
@@ -134,7 +134,9 @@ class SvgTreeDrawer(TreeDrawer):
 
     def _assign_coordinates(self):
         y_padding = 20
-        t = max(self._tree.time(root) for root in self._tree.roots)
+        t = 1
+        if self._tree.num_roots > 0:
+            t = max(self._tree.time(root) for root in self._tree.roots)
         self._y_scale = (self._height - 2 * y_padding) / t
         for u in self._tree.nodes():
             scaled_t = self._tree.get_time(u) * self._y_scale
@@ -253,7 +255,9 @@ class TextTreeDrawer(TreeDrawer):
                 v = self._tree.parent(v)
                 depth += 1
             self._y_coords[u] = 3 * depth
-        self._height = max(self._y_coords.values()) + 1
+        self._height = 0
+        if len(self._y_coords) > 0:
+            self._height = max(self._y_coords.values()) + 1
         # Get the overall width and assign x coordinates.
         x = 0
         for root in self._tree.roots:

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -404,7 +404,7 @@ class SparseTree(object):
         :raises: ValueError if this tree contains more than one root.
         """
         root = self.left_root
-        if self.right_sib(root) != NULL_NODE:
+        if root != NULL_NODE and self.right_sib(root) != NULL_NODE:
             raise ValueError("More than one root exists. Use tree.roots instead")
         return root
 
@@ -906,7 +906,7 @@ def parse_mutations(source):
     return table
 
 
-def load_text(nodes, edges, sites=None, mutations=None):
+def load_text(nodes, edges, sites=None, mutations=None, sequence_length=0):
     """
     Loads a tree sequence from the specified file paths. The files input here
     are in a simple whitespace delimited tabular format such as output by the
@@ -982,6 +982,8 @@ def load_text(nodes, edges, sites=None, mutations=None):
     :param stream sites: The file-type object containing text describing a SiteTable.
     :param stream mutations: The file-type object containing text
         describing a MutationTable.
+    :param float sequence_length: The sequence length of the returned tree sequence. If
+        not supplied or zero this will be inferred from the set of edges.
     :return: The tree sequence object containing the information
         stored in the specified file paths.
     :rtype: :class:`msprime.TreeSequence`
@@ -997,7 +999,8 @@ def load_text(nodes, edges, sites=None, mutations=None):
     tables.sort_tables(
         nodes=node_table, edges=edge_table, sites=site_table, mutations=mutation_table)
     return load_tables(
-        nodes=node_table, edges=edge_table, sites=site_table, mutations=mutation_table)
+        nodes=node_table, edges=edge_table, sites=site_table, mutations=mutation_table,
+        sequence_length=sequence_length)
 
 
 class TreeSequence(object):
@@ -1050,7 +1053,8 @@ class TreeSequence(object):
         new_ll_ts = _msprime.TreeSequence()
         new_ll_ts.load_tables(
             nodes=node_table, edges=edge_table, migrations=migration_table,
-            sites=site_table, mutations=mutation_table)
+            sites=site_table, mutations=mutation_table,
+            sequence_length=self.sequence_length)
         return TreeSequence(new_ll_ts)
 
     @property
@@ -1718,7 +1722,7 @@ class TreeSequence(object):
             sites=t.sites, mutations=t.mutations, sample_map=sample_map)
         new_ts = load_tables(
             nodes=t.nodes, edges=t.edges, migrations=t.migrations, sites=t.sites,
-            mutations=t.mutations)
+            mutations=t.mutations, sequence_length=self.sequence_length)
         # FIXME provenance
         # for provenance in self.get_provenance():
         #     new_ts.add_provenance(provenance)

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -84,6 +84,12 @@ class TestTreeDraw(unittest.TestCase):
                     return t
         assert False
 
+    def get_empty_tree(self):
+        nodes = msprime.NodeTable()
+        edges = msprime.EdgeTable()
+        ts = msprime.load_tables(nodes=nodes, edges=edges, sequence_length=1)
+        return next(ts.trees())
+
 
 class TestFormats(TestTreeDraw):
     """
@@ -165,6 +171,11 @@ class TestDrawText(TestTreeDraw):
         text = t.draw(format=self.drawing_format)
         self.verify_basic_text(text)
 
+    def test_draw_empty_tree(self):
+        t = self.get_empty_tree()
+        text = t.draw(format=self.drawing_format)
+        self.verify_basic_text(text)
+
     def test_labels(self):
         t = self.get_binary_tree()
         labels = {u: self.example_label for u in t.nodes()}
@@ -225,6 +236,11 @@ class TestDrawSvg(TestTreeDraw):
 
     def test_draw_unary(self):
         t = self.get_unary_node_tree()
+        svg = t.draw()
+        self.verify_basic_svg(svg)
+
+    def test_draw_empty(self):
+        t = self.get_empty_tree()
         svg = t.draw()
         self.verify_basic_svg(svg)
 

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -360,8 +360,10 @@ class TestHdf5Format(TestHdf5):
         root = h5py.File(self.temp_file, "r")
         # Check the basic root attributes
         format_version = root.attrs['format_version']
-        self.assertEqual(format_version[0], 7)
+        self.assertEqual(format_version[0], 8)
         self.assertEqual(format_version[1], 0)
+        sequence_length = root.attrs['sequence_length']
+        self.assertGreater(sequence_length, 0)
         keys = set(root.keys())
         self.assertIn("nodes", keys)
         self.assertIn("edges", keys)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1497,7 +1497,7 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             mutations_file = six.StringIO()
             ts1.dump_text(
                 nodes=nodes_file, edges=edges_file, sites=sites_file,
-                mutations=mutations_file, precision=9)
+                mutations=mutations_file, precision=16)
             nodes_file.seek(0)
             edges_file.seek(0)
             sites_file.seek(0)
@@ -1516,6 +1516,20 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             _msprime.LibraryError, msprime.load_text,
             nodes=nodes_file, edges=edges_file, sites=sites_file,
             mutations=mutations_file)
+
+    def test_empty_files_sequence_length(self):
+        nodes_file = six.StringIO("is_sample\ttime\n")
+        edges_file = six.StringIO("left\tright\tparent\tchild\n")
+        sites_file = six.StringIO("position\tancestral_state\n")
+        mutations_file = six.StringIO("site\tnode\tderived_state\n")
+        ts = msprime.load_text(
+                nodes=nodes_file, edges=edges_file, sites=sites_file,
+                mutations=mutations_file, sequence_length=100)
+        self.assertEqual(ts.sequence_length, 100)
+        self.assertEqual(ts.num_nodes, 0)
+        self.assertEqual(ts.num_edges, 0)
+        self.assertEqual(ts.num_sites, 0)
+        self.assertEqual(ts.num_edges, 0)
 
 
 class TestSparseTree(HighLevelTestCase):

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -49,6 +49,19 @@ import _msprime
 import tests
 
 
+def get_uniform_mutations(num_mutations, sequence_length, nodes):
+    """
+    Returns n evenly mutations over the specified list of nodes.
+    """
+    sites = msprime.SiteTable()
+    mutations = msprime.MutationTable()
+    for j in range(num_mutations):
+        sites.add_row(
+            position=j * (sequence_length / num_mutations), ancestral_state='0')
+        mutations.add_row(site=j, derived_state='1', node=nodes[j % len(nodes)])
+    return sites, mutations
+
+
 def insert_gap(ts, position, length):
     """
     Inserts a gap of the specified size into the specified tree sequence.
@@ -78,15 +91,8 @@ def insert_gap(ts, position, length):
         edges.add_row(left, right, parent, child)
     msprime.sort_tables(nodes=tables.nodes, edges=edges)
     # Throw in a bunch of mutations over the whole sequence on the samples.
-    sites = msprime.SiteTable()
-    mutations = msprime.MutationTable()
-    num_mutations = 100
-    samples = list(ts.samples())
     L = ts.sequence_length + length
-    for j in range(num_mutations):
-        sites.add_row(position=j * (L / num_mutations), ancestral_state='0')
-        mutations.add_row(
-            site=j, derived_state='1', node=samples[j % len(samples)])
+    sites, mutations = get_uniform_mutations(100, L, list(ts.samples()))
     return msprime.load_tables(
             nodes=tables.nodes, edges=edges, sites=sites, mutations=mutations)
 
@@ -111,6 +117,15 @@ def get_gap_examples():
                 found = True
         assert found
         yield ts
+    # Give an example with a gap at the end.
+    ts = msprime.simulate(10, random_seed=5, recombination_rate=1)
+    t = ts.dump_tables()
+    L = 2
+    sites, mutations = get_uniform_mutations(100, L, list(ts.samples()))
+    ts_new = ts.load_tables(
+        nodes=t.nodes, edges=t.edges, sites=sites, mutations=mutations,
+        sequence_length=L)
+    yield ts_new
 
 
 def get_internal_samples_examples():
@@ -148,8 +163,36 @@ def get_internal_samples_examples():
     yield ts
 
 
+def decapitate(ts, num_edges):
+    """
+    Returns a copy of the specified tree sequence in which the specified number of
+    edges have been retained.
+    """
+    t = ts.dump_tables()
+    t.edges.set_columns(
+        left=t.edges.left[:num_edges], right=t.edges.right[:num_edges],
+        parent=t.edges.parent[:num_edges], child=t.edges.child[:num_edges])
+    return msprime.load_tables(
+        nodes=t.nodes, edges=t.edges, sites=t.sites, mutations=t.mutations,
+        sequence_length=ts.sequence_length)
+
+
+def get_decapitated_examples():
+    """
+    Returns example tree sequences in which the oldest edges have been removed.
+    """
+    ts = msprime.simulate(10, random_seed=1234)
+    yield decapitate(ts, ts.num_edges // 2)
+
+    ts = msprime.simulate(20, recombination_rate=1, random_seed=1234)
+    assert ts.num_trees > 2
+    yield decapitate(ts, ts.num_edges // 4)
+
+
 def get_example_tree_sequences(back_mutations=True, gaps=True, internal_samples=True):
     if gaps:
+        for ts in get_decapitated_examples():
+            yield ts
         for ts in get_gap_examples():
             yield ts
     if internal_samples:
@@ -433,11 +476,11 @@ class HighLevelTestCase(tests.MsprimeTestCase):
             length += r - l
             self.verify_sparse_tree(st1)
             num_trees += 1
-        self.assertEqual(breakpoints, list(ts.breakpoints()))
-        self.assertAlmostEqual(length, ts.get_sequence_length())
-        self.assertEqual(ts.get_num_trees(), num_trees)
         self.assertRaises(StopIteration, next, iter1)
         self.assertRaises(StopIteration, next, iter2)
+        self.assertEqual(ts.get_num_trees(), num_trees)
+        self.assertEqual(breakpoints, list(ts.breakpoints()))
+        self.assertAlmostEqual(length, ts.get_sequence_length())
 
     def verify_haplotype_statistics(self, ts):
         """
@@ -1216,6 +1259,7 @@ class TestTreeSequence(HighLevelTestCase):
         for ts1 in get_example_tree_sequences():
             ts2 = ts1.copy()
             self.assertNotEqual(id(ts1), id(ts2))
+            self.assertEqual(ts1.sequence_length, ts2.sequence_length)
             self.assertEqual(list(ts1.edges()), list(ts2.edges()))
             self.assertEqual(list(ts1.nodes()), list(ts2.nodes()))
             self.assertEqual(list(ts1.mutations()), list(ts2.mutations()))
@@ -1460,7 +1504,7 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             mutations_file.seek(0)
             ts2 = msprime.load_text(
                 nodes=nodes_file, edges=edges_file, sites=sites_file,
-                mutations=mutations_file)
+                mutations=mutations_file, sequence_length=ts1.sequence_length)
             self.verify_approximate_equality(ts1, ts2)
 
     def test_empty_files(self):

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1918,7 +1918,9 @@ class TestTreeSequence(LowLevelTestCase):
         self.assertEqual(ts.get_num_edges(), 0)
         self.assertEqual(ts.get_num_mutations(), 0)
         self.assertEqual(ts.get_num_migrations(), 0)
-        self.verify_dump_equality(ts)
+        ts.dump(self.temp_file)
+        # This should raise an error because of a zero sequence length.
+        self.assertRaises(_msprime.LibraryError, ts.load, self.temp_file)
 
     def test_num_nodes(self):
         for ts in self.get_example_tree_sequences():

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1912,15 +1912,14 @@ class TestTreeSequence(LowLevelTestCase):
     def test_initial_state(self):
         # Check the initial state to make sure that it is empty.
         ts = _msprime.TreeSequence()
-        self.assertEqual(ts.get_sample_size(), 0)
-        self.assertEqual(ts.get_sequence_length(), 0)
-        self.assertEqual(ts.get_num_trees(), 0)
-        self.assertEqual(ts.get_num_edges(), 0)
-        self.assertEqual(ts.get_num_mutations(), 0)
-        self.assertEqual(ts.get_num_migrations(), 0)
-        ts.dump(self.temp_file)
-        # This should raise an error because of a zero sequence length.
-        self.assertRaises(_msprime.LibraryError, ts.load, self.temp_file)
+        self.assertRaises(ValueError, ts.get_sample_size)
+        self.assertRaises(ValueError, ts.get_sequence_length)
+        self.assertRaises(ValueError, ts.get_num_trees)
+        self.assertRaises(ValueError, ts.get_num_edges)
+        self.assertRaises(ValueError, ts.get_num_mutations)
+        self.assertRaises(ValueError, ts.get_num_migrations)
+        self.assertRaises(ValueError, ts.get_num_migrations)
+        self.assertRaises(ValueError, ts.dump)
 
     def test_num_nodes(self):
         for ts in self.get_example_tree_sequences():
@@ -2095,13 +2094,9 @@ class TestVcfConverter(LowLevelTestCase):
     """
     Tests for the low-level vcf converter.
     """
-    def test_empty_tree_sequence(self):
+    def test_uninitialised_tree_sequence(self):
         ts = _msprime.TreeSequence()
-        converter = _msprime.VcfConverter(ts)
-        header = converter.get_header()
-        self.assertGreater(len(header), 0)
-        self.assertTrue(header.startswith("##fileformat"))
-        self.assertEqual(list(converter), [])
+        self.assertRaises(ValueError, _msprime.VcfConverter, ts)
 
     def test_constructor(self):
         self.assertRaises(TypeError, _msprime.VcfConverter)
@@ -2196,10 +2191,9 @@ class TestTreeDiffIterator(LowLevelTestCase):
     """
     Tests for the low-level tree diff iterator.
     """
-    def test_empty_tree_sequence(self):
+    def test_uninitialised_tree_sequence(self):
         ts = _msprime.TreeSequence()
-        iterator = _msprime.TreeDiffIterator(ts)
-        self.assertEqual(list(iterator), [])
+        self.assertRaises(ValueError, _msprime.TreeDiffIterator, ts)
 
     def test_constructor(self):
         self.assertRaises(TypeError, _msprime.TreeDiffIterator)
@@ -2223,11 +2217,9 @@ class TestSparseTreeIterator(LowLevelTestCase):
     """
     Tests for the low-level sparse tree iterator.
     """
-    def test_empty_tree_sequence(self):
+    def test_uninitialised_tree_sequence(self):
         ts = _msprime.TreeSequence()
-        tree = _msprime.SparseTree(ts)
-        iterator = _msprime.SparseTreeIterator(tree)
-        self.assertEqual(list(iterator), [])
+        self.assertRaises(ValueError, _msprime.SparseTree, ts)
 
     def test_constructor(self):
         self.assertRaises(TypeError, _msprime.SparseTreeIterator)
@@ -2292,10 +2284,9 @@ class TestHaplotypeGenerator(LowLevelTestCase):
     """
     Tests for the low-level haplotype generator.
     """
-    def test_empty_tree_sequence(self):
+    def test_uninitialised_tree_sequence(self):
         ts = _msprime.TreeSequence()
-        hg = _msprime.HaplotypeGenerator(ts)
-        self.assertRaises(IndexError, hg.get_haplotype, 0)
+        self.assertRaises(ValueError, _msprime.HaplotypeGenerator, ts)
 
     def test_constructor(self):
         self.assertRaises(TypeError, _msprime.HaplotypeGenerator)
@@ -2322,10 +2313,9 @@ class TestVariantGenerator(LowLevelTestCase):
     """
     Tests for the low-level variant generator.
     """
-    def test_empty_tree_sequence(self):
+    def test_uninitialised_tree_sequence(self):
         ts = _msprime.TreeSequence()
-        vg = _msprime.VariantGenerator(ts, bytearray())
-        self.assertEqual(list(vg), [])
+        self.assertRaises(ValueError, _msprime.VariantGenerator, ts, bytearray())
 
     def test_constructor(self):
         self.assertRaises(TypeError, _msprime.VariantGenerator)
@@ -2406,10 +2396,6 @@ class TestSparseTree(LowLevelTestCase):
     """
     Tests on the low-level sparse tree interface.
     """
-    def test_empty_tree_sequence(self):
-        ts = _msprime.TreeSequence()
-        st = _msprime.SparseTree(ts)
-        self.assertEqual(list(_msprime.SparseTreeIterator(st)), [])
 
     def test_flags(self):
         ts = self.get_tree_sequence()
@@ -2650,7 +2636,7 @@ class TestSparseTree(LowLevelTestCase):
                         point = t.find(".")
                         self.assertEqual(precision, len(t) - point - 1)
 
-    @unittest.skip("Newick Multiroots")
+    @unittest.skip("Correct initialisation for sparse tree.")
     def test_newick_interface(self):
         ts = self.get_tree_sequence(num_loci=10, sample_size=10)
         st = _msprime.SparseTree(ts)
@@ -3338,12 +3324,9 @@ class TestLdCalculator(LowLevelTestCase):
         """
         return bytearray(8 * num_values)
 
-    def test_empty_tree_sequence(self):
+    def test_uninitialised_tree_sequence(self):
         ts = _msprime.TreeSequence()
-        ldc = _msprime.LdCalculator(ts)
-        buff = self.get_buffer(0)
-        self.assertRaises(IndexError, ldc.get_r2_array, buff, 0)
-        self.assertRaises(IndexError, ldc.get_r2, 0, 1)
+        self.assertRaises(ValueError, _msprime.LdCalculator, ts)
 
     def test_constructor(self):
         for bad_type in [None, "1", []]:

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -920,7 +920,9 @@ class TestSimplifyTables(unittest.TestCase):
     def test_bad_site_positions(self):
         ts = msprime.simulate(10, random_seed=self.random_seed, mutation_rate=1)
         self.assertGreater(ts.num_mutations, 0)
-        for bad_position in [-1, ts.sequence_length, ts.sequence_length + 0.01]:
+        # Positions > sequence_length are valid, as we can have gaps at the end of
+        # a tree sequence.
+        for bad_position in [-1, -1e-6]:
             tables = ts.dump_tables()
             sites = tables.sites
             position = sites.position

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -181,6 +181,161 @@ class TopologyTestCase(unittest.TestCase):
                 self.assertEqual(u, v)
 
 
+class TestEmptyTreeSequences(TopologyTestCase):
+    """
+    Tests covering tree sequences that have zero edges.
+    """
+    def test_zero_nodes(self):
+        nodes = msprime.NodeTable()
+        edges = msprime.EdgeTable()
+        # Without a sequence length this should fail.
+        self.assertRaises(
+            _msprime.LibraryError, msprime.load_tables, nodes=nodes, edges=edges)
+        ts = msprime.load_tables(nodes=nodes, edges=edges, sequence_length=1)
+        self.assertEqual(ts.sequence_length, 1)
+        self.assertEqual(ts.num_trees, 1)
+        self.assertEqual(ts.num_nodes, 0)
+        self.assertEqual(ts.num_edges, 0)
+        t = next(ts.trees())
+        self.assertEqual(t.index, 0)
+        self.assertEqual(t.left_root, msprime.NULL_NODE)
+        self.assertEqual(t.interval, (0, 1))
+        self.assertEqual(t.roots, [])
+        self.assertEqual(t.root, msprime.NULL_NODE)
+        self.assertEqual(t.parent_dict, {})
+        self.assertEqual(list(t.nodes()), [])
+        self.assertEqual(list(ts.haplotypes()), [])
+        self.assertEqual(list(ts.variants()), [])
+        methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
+        for method in methods:
+            for u in [-1, 0, 1, 100]:
+                self.assertRaises(ValueError, method, u)
+
+    def test_one_node_zero_samples(self):
+        nodes = msprime.NodeTable()
+        nodes.add_row(time=0, flags=0)
+        edges = msprime.EdgeTable()
+        # Without a sequence length this should fail.
+        self.assertRaises(
+            _msprime.LibraryError, msprime.load_tables, nodes=nodes, edges=edges)
+        ts = msprime.load_tables(nodes=nodes, edges=edges, sequence_length=1)
+        self.assertEqual(ts.sequence_length, 1)
+        self.assertEqual(ts.num_trees, 1)
+        self.assertEqual(ts.num_nodes, 1)
+        self.assertEqual(ts.sample_size, 0)
+        self.assertEqual(ts.num_edges, 0)
+        self.assertEqual(ts.num_sites, 0)
+        self.assertEqual(ts.num_mutations, 0)
+        t = next(ts.trees())
+        self.assertEqual(t.index, 0)
+        self.assertEqual(t.left_root, msprime.NULL_NODE)
+        self.assertEqual(t.interval, (0, 1))
+        self.assertEqual(t.roots, [])
+        self.assertEqual(t.root, msprime.NULL_NODE)
+        self.assertEqual(t.parent_dict, {})
+        self.assertEqual(list(t.nodes()), [])
+        self.assertEqual(list(ts.haplotypes()), [])
+        self.assertEqual(list(ts.variants()), [])
+        methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
+        for method in methods:
+            self.assertEqual(method(0), msprime.NULL_NODE)
+            for u in [-1, 1, 100]:
+                self.assertRaises(ValueError, method, u)
+
+    def test_one_node_zero_samples_sites(self):
+        nodes = msprime.NodeTable()
+        nodes.add_row(time=0, flags=0)
+        edges = msprime.EdgeTable()
+        sites = msprime.SiteTable()
+        mutations = msprime.MutationTable()
+        sites.add_row(position=0.5, ancestral_state='0')
+        mutations.add_row(site=0, derived_state='1', node=0)
+        ts = msprime.load_tables(
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
+            sequence_length=1)
+        self.assertEqual(ts.sequence_length, 1)
+        self.assertEqual(ts.num_trees, 1)
+        self.assertEqual(ts.num_nodes, 1)
+        self.assertEqual(ts.sample_size, 0)
+        self.assertEqual(ts.num_edges, 0)
+        self.assertEqual(ts.num_sites, 1)
+        self.assertEqual(ts.num_mutations, 1)
+        t = next(ts.trees())
+        self.assertEqual(t.index, 0)
+        self.assertEqual(t.left_root, msprime.NULL_NODE)
+        self.assertEqual(t.interval, (0, 1))
+        self.assertEqual(t.roots, [])
+        self.assertEqual(t.root, msprime.NULL_NODE)
+        self.assertEqual(t.parent_dict, {})
+        self.assertEqual(len(list(t.sites())), 1)
+        self.assertEqual(list(t.nodes()), [])
+        self.assertEqual(list(ts.haplotypes()), [])
+        self.assertEqual(len(list(ts.variants())), 1)
+
+    def test_one_node_one_sample(self):
+        nodes = msprime.NodeTable()
+        nodes.add_row(time=0, flags=msprime.NODE_IS_SAMPLE)
+        edges = msprime.EdgeTable()
+        # Without a sequence length this should fail.
+        self.assertRaises(
+            _msprime.LibraryError, msprime.load_tables, nodes=nodes, edges=edges)
+        ts = msprime.load_tables(nodes=nodes, edges=edges, sequence_length=1)
+        self.assertEqual(ts.sequence_length, 1)
+        self.assertEqual(ts.num_trees, 1)
+        self.assertEqual(ts.num_nodes, 1)
+        self.assertEqual(ts.sample_size, 1)
+        self.assertEqual(ts.num_edges, 0)
+        t = next(ts.trees())
+        self.assertEqual(t.index, 0)
+        self.assertEqual(t.left_root, 0)
+        self.assertEqual(t.interval, (0, 1))
+        self.assertEqual(t.roots, [0])
+        self.assertEqual(t.root, 0)
+        self.assertEqual(t.parent_dict, {})
+        self.assertEqual(list(t.nodes()), [0])
+        self.assertEqual(list(ts.haplotypes()), [""])
+        self.assertEqual(list(ts.variants()), [])
+        methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
+        for method in methods:
+            self.assertEqual(method(0), msprime.NULL_NODE)
+            for u in [-1, 1, 100]:
+                self.assertRaises(ValueError, method, u)
+
+    def test_one_node_one_sample_sites(self):
+        nodes = msprime.NodeTable()
+        nodes.add_row(time=0, flags=msprime.NODE_IS_SAMPLE)
+        edges = msprime.EdgeTable()
+        sites = msprime.SiteTable()
+        mutations = msprime.MutationTable()
+        sites.add_row(position=0.5, ancestral_state='0')
+        mutations.add_row(site=0, derived_state='1', node=0)
+        ts = msprime.load_tables(
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
+            sequence_length=1)
+        self.assertEqual(ts.sequence_length, 1)
+        self.assertEqual(ts.num_trees, 1)
+        self.assertEqual(ts.num_nodes, 1)
+        self.assertEqual(ts.sample_size, 1)
+        self.assertEqual(ts.num_edges, 0)
+        self.assertEqual(ts.num_sites, 1)
+        self.assertEqual(ts.num_mutations, 1)
+        t = next(ts.trees())
+        self.assertEqual(t.index, 0)
+        self.assertEqual(t.left_root, 0)
+        self.assertEqual(t.interval, (0, 1))
+        self.assertEqual(t.roots, [0])
+        self.assertEqual(t.root, 0)
+        self.assertEqual(t.parent_dict, {})
+        self.assertEqual(list(t.nodes()), [0])
+        self.assertEqual(list(ts.haplotypes()), ["1"])
+        self.assertEqual(len(list(ts.variants())), 1)
+        methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
+        for method in methods:
+            self.assertEqual(method(0), msprime.NULL_NODE)
+            for u in [-1, 1, 100]:
+                self.assertRaises(ValueError, method, u)
+
+
 class TestHoleyTreeSequences(TopologyTestCase):
     """
     Tests for tree sequences in which we have partial (or no) trees defined
@@ -228,6 +383,41 @@ class TestHoleyTreeSequences(TopologyTestCase):
         expected = [
             ((0, 1), {}),
             ((1, 2), {0: 2, 1: 2})]
+        self.verify_trees(ts, expected)
+
+    def test_final_gap(self):
+        nodes = six.StringIO("""\
+        id  is_sample   time
+        0   1           0
+        1   1           0
+        2   0           1
+        """)
+        edges = six.StringIO("""\
+        left    right   parent  child
+        0       2       2       0,1
+        """)
+        ts = msprime.load_text(nodes, edges, sequence_length=3)
+        expected = [
+            ((0, 2), {0: 2, 1: 2}),
+            ((2, 3), {})]
+        self.verify_trees(ts, expected)
+
+    def test_initial_and_final_gap(self):
+        nodes = six.StringIO("""\
+        id  is_sample   time
+        0   1           0
+        1   1           0
+        2   0           1
+        """)
+        edges = six.StringIO("""\
+        left    right   parent  child
+        1       2       2       0,1
+        """)
+        ts = msprime.load_text(nodes, edges, sequence_length=3)
+        expected = [
+            ((0, 1), {}),
+            ((1, 2), {0: 2, 1: 2}),
+            ((2, 3), {})]
         self.verify_trees(ts, expected)
 
 


### PR DESCRIPTION
Adds support for a more general class of tree sequences. Tree sequences with zero edges are now supported, as as are tree sequences with gaps at the end.

The real change is that ``TreeSequence.sequence_length`` is no longer inferred from the input edges, but is an input parameter of the tree sequence. This shouldn't affect any existing code, as there is a new optional parameter ``sequence_length`` to ``load_tables``. If this is not specified, we infer the sequence length as the maximum right coordinate of the supplied edges. If it is, we use this as the sequence length.

This should get rid of the remaining annoying special cases, and I think we can now support completely general tree sequences.

cc @petrelharp.