### PR TITLE
Specific error for recomb maps with nonzero last rate.

### DIFF
--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -668,7 +668,9 @@ class RecombinationMap(object):
                 # Rate is expressed in centimorgans per megabase, which
                 # we convert to per-base rates
                 rates.append(rate * 1e-8)
-            assert rate == 0
+            if rate != 0:
+                raise ValueError(
+                    "The last rate provided in the recombination map must zero")
         finally:
             f.close()
         return cls(positions, rates)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1749,6 +1749,14 @@ class TestRecombinationMap(HighLevelTestCase):
         self.assertEqual(rm.get_positions(), [0, 1, 2])
         self.assertEqual(rm.get_rates(), [0, 5e-8, 0])
 
+    def test_read_hapmap_nonzero_end(self):
+        with open(self.temp_file, "w+") as f:
+            print("HEADER", file=f)
+            print("chr1 0 5 x", file=f)
+            print("s    2 1 x x x", file=f)
+        self.assertRaises(
+            ValueError, msprime.RecombinationMap.read_hapmap, self.temp_file)
+
     def test_read_hapmap_gzipped(self):
         try:
             filename = self.temp_file + ".gz"


### PR DESCRIPTION
Better error for the case where recombination maps are malformed.