### PR TITLE
Full genotype matrix

### DIFF
--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1595,6 +1595,9 @@ class TreeSequence(object):
                     mutations=[Mutation(*mutation) for mutation in mutations])
                 yield Variant(position=pos, site=site, index=index, genotypes=g)
 
+    def genotype_matrix(self):
+        return self._ll_tree_sequence.get_genotype_matrix()
+
     def pairwise_diversity(self, samples=None):
         return self.get_pairwise_diversity(samples)
 

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -2280,8 +2280,6 @@ class TestMutationParent(unittest.TestCase):
                                      multiple_per_node=False, seed=self.seed)
         tabs = mut_ts.dump_tables()
         mp = tsutil.compute_mutation_parent(ts=mut_ts)
-        print(tabs)
-        print("mp:", mp)
         for u, v in zip(mp, tabs.mutations.parent):
             self.assertEqual(u, v)
 
@@ -2293,7 +2291,5 @@ class TestMutationParent(unittest.TestCase):
                                      multiple_per_node=True, seed=self.seed)
         tabs = mut_ts.dump_tables()
         mp = tsutil.compute_mutation_parent(ts=mut_ts)
-        print(tabs)
-        print("mp:", mp)
         for u, v in zip(mp, tabs.mutations.parent):
             self.assertEqual(u, v)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -674,6 +674,13 @@ class TestVariantGenerator(HighLevelTestCase):
         variants = list(ts.variants())
         self.assertEqual(len(variants), 0)
 
+    def test_genotype_matrix(self):
+        ts = self.get_tree_sequence()
+        G = np.empty((ts.num_sites, ts.num_samples), dtype=np.uint8)
+        for v in ts.variants():
+            G[v.index, :] = v.genotypes
+        self.assertTrue(np.array_equal(G, ts.genotype_matrix()))
+
     @unittest.skip("Recurrent mutations")
     def test_recurrent_mutations_over_samples(self):
         ts = self.get_tree_sequence()

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1918,6 +1918,7 @@ class TestTreeSequence(LowLevelTestCase):
         self.assertRaises(ValueError, ts.get_num_mutations)
         self.assertRaises(ValueError, ts.get_num_migrations)
         self.assertRaises(ValueError, ts.get_num_migrations)
+        self.assertRaises(ValueError, ts.get_genotype_matrix)
         self.assertRaises(ValueError, ts.dump)
 
     def test_num_nodes(self):
@@ -1991,6 +1992,13 @@ class TestTreeSequence(LowLevelTestCase):
                 self.assertRaises(IndexError, ts.get_node, num_nodes + j)
             for x in [None, "", {}, []]:
                 self.assertRaises(TypeError, ts.get_node, x)
+
+    def test_get_genotype_matrix_interface(self):
+        for ts in self.get_example_tree_sequences():
+            num_samples = ts.get_num_samples()
+            num_sites = ts.get_num_sites()
+            G = ts.get_genotype_matrix()
+            self.assertEqual(G.shape, (num_sites, num_samples))
 
     def test_get_migration_interface(self):
         ts = self.get_example_migration_tree_sequence()


### PR DESCRIPTION
Issue #306 

Much, much more efficient way of getting all the genotypes out of msprime.

Any thoughts on the terminology here @petrelharp? I've called it ``genotype_matrix`` for consistency with the ``variant.genotypes`` array.  Holding off on documenting this until we finalise the actual semantics of the genotypes/alleles as discussed over in #301.