### PR TITLE
Change ragged column lengths to offsets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@
 
 SRC=_msprimemodule.c
 
+ext3: ${SRC}
+	python3 setup.py build_ext --inplace
+
 ext2: ${SRC}
 	python setup.py build_ext --inplace
 
 ext2-coverage: ${SRC}
 	rm -fR build
 	CFLAGS="-coverage" python setup.py build_ext --inplace
-
-ext3: ${SRC}
-	python3 setup.py build_ext --inplace
 
 figs:
 	cd docs/asy && make 

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -478,7 +478,7 @@ make_mutation(mutation_t *mutation)
     PyObject *ret = NULL;
 
     ret = Py_BuildValue("iis#ii", mutation->site, mutation->node, mutation->derived_state,
-            mutation->derived_state_length, mutation->parent, mutation->id);
+            (Py_ssize_t) mutation->derived_state_length, mutation->parent, mutation->id);
     return ret;
 }
 
@@ -514,7 +514,8 @@ make_node(node_t *r)
     const char *metadata = r->metadata == NULL? "": r->metadata;
 
     ret = Py_BuildValue("Idis#",
-        (unsigned int) r->flags, r->time, (int) r->population, metadata, r->metadata_length);
+        (unsigned int) r->flags, r->time, (int) r->population, metadata,
+        (Py_ssize_t) r->metadata_length);
     return ret;
 }
 
@@ -548,7 +549,8 @@ make_site(site_t *site)
         goto out;
     }
     ret = Py_BuildValue("ds#On", site->position, site->ancestral_state,
-            site->ancestral_state_length, mutations, (Py_ssize_t) site->id);
+            (Py_ssize_t) site->ancestral_state_length, mutations,
+            (Py_ssize_t) site->id);
 out:
     Py_XDECREF(mutations);
     return ret;

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -420,12 +420,27 @@ out:
 }
 
 static PyObject *
+make_metadata(const char *metadata, Py_ssize_t length)
+{
+    const char *m = metadata == NULL? "": metadata;
+    return PyBytes_FromStringAndSize(m, length);
+}
+
+static PyObject *
 make_mutation(mutation_t *mutation)
 {
     PyObject *ret = NULL;
+    PyObject* metadata = NULL;
 
-    ret = Py_BuildValue("iis#ii", mutation->site, mutation->node, mutation->derived_state,
-            (Py_ssize_t) mutation->derived_state_length, mutation->parent, mutation->id);
+    metadata = make_metadata(mutation->metadata, (Py_ssize_t) mutation->metadata_length);
+    if (metadata == NULL) {
+        goto out;
+    }
+    ret = Py_BuildValue("iis#iiO", mutation->site, mutation->node, mutation->derived_state,
+            (Py_ssize_t) mutation->derived_state_length, mutation->parent, mutation->id,
+            metadata);
+out:
+    Py_XDECREF(metadata);
     return ret;
 }
 
@@ -463,13 +478,6 @@ make_provenance(provenance_t *provenance)
             provenance->timestamp, (Py_ssize_t) provenance->timestamp_length,
             provenance->record, (Py_ssize_t) provenance->record_length);
     return ret;
-}
-
-static PyObject *
-make_metadata(const char *metadata, Py_ssize_t length)
-{
-    const char *m = metadata == NULL? "": metadata;
-    return PyBytes_FromStringAndSize(m, length);
 }
 
 static PyObject *

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -477,8 +477,8 @@ make_mutation(mutation_t *mutation)
 {
     PyObject *ret = NULL;
 
-    ret = Py_BuildValue("iisii", mutation->site, mutation->node, mutation->derived_state,
-            mutation->parent, mutation->id);
+    ret = Py_BuildValue("iis#ii", mutation->site, mutation->node, mutation->derived_state,
+            mutation->derived_state_length, mutation->parent, mutation->id);
     return ret;
 }
 
@@ -511,9 +511,10 @@ static PyObject *
 make_node(node_t *r)
 {
     PyObject *ret = NULL;
+    const char *name = r->name == NULL? "": r->name;
 
-    ret = Py_BuildValue("Idis",
-        (unsigned int) r->flags, r->time, (int) r->population, r->name);
+    ret = Py_BuildValue("Idis#",
+        (unsigned int) r->flags, r->time, (int) r->population, name, r->name_length);
     return ret;
 }
 
@@ -546,8 +547,8 @@ make_site(site_t *site)
     if (mutations == NULL) {
         goto out;
     }
-    ret = Py_BuildValue("dsOn", site->position, site->ancestral_state, mutations,
-            (Py_ssize_t) site->id);
+    ret = Py_BuildValue("ds#On", site->position, site->ancestral_state,
+            site->ancestral_state_length, mutations, (Py_ssize_t) site->id);
 out:
     Py_XDECREF(mutations);
     return ret;
@@ -578,25 +579,6 @@ convert_sites(site_t *sites, size_t num_sites)
 out:
     return ret;
 }
-
-#ifdef HAVE_NUMPY
-static int
-verify_column_sum(size_t num_rows, uint32_t *length, size_t total_length)
-{
-    int ret = 0;
-    size_t j;
-    size_t sum = 0;
-
-    for (j = 0; j < num_rows; j++) {
-        sum += length[j];
-    }
-    if (sum != total_length) {
-        PyErr_SetString(PyExc_ValueError, "Sum mismatch in length column");
-        ret = -1;
-    }
-    return ret;
-}
-#endif
 
 /*===================================================================
  * RandomGenerator
@@ -766,6 +748,46 @@ out:
     }
     return ret;
 }
+
+static PyArrayObject *
+table_read_offset_array(PyObject *input, size_t num_rows, size_t length)
+{
+    PyArrayObject *ret = NULL;
+    PyArrayObject *array = NULL;
+    npy_intp *shape;
+    uint32_t *offsets;
+
+    array = (PyArrayObject *) PyArray_FROM_OTF(input, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
+    if (array == NULL) {
+        goto out;
+    }
+    if (PyArray_NDIM(array) != 1) {
+        PyErr_SetString(PyExc_ValueError, "Dim != 1");
+        goto out;
+    }
+    shape = PyArray_DIMS(array);
+    if (shape[0] != num_rows + 1) {
+        PyErr_SetString(PyExc_ValueError, "offset columns must have n + 1 rows.");
+        goto out;
+    }
+    offsets = PyArray_DATA(array);
+    if (offsets[0] != 0) {
+        PyErr_SetString(PyExc_ValueError, "Zeroth element of offsets array must be 0");
+        goto out;
+    }
+    if (offsets[num_rows] != length) {
+        PyErr_SetString(PyExc_ValueError,
+            "Last element of offsets array must be equal to column length");
+        goto out;
+    }
+    ret = array;
+out:
+    if (ret == NULL) {
+        Py_XDECREF(array);
+    }
+    return ret;
+}
+
 #endif
 
 /*===================================================================
@@ -856,7 +878,7 @@ NodeTable_add_row(NodeTable *self, PyObject *args, PyObject *kwds)
         goto out;
     }
     err = node_table_add_row(self->node_table, (uint32_t) flags, time,
-            (population_id_t) population, name);
+            (population_id_t) population, name, name_length);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -874,9 +896,9 @@ NodeTable_set_or_append_columns(NodeTable *self, PyObject *args, PyObject *kwds,
 {
     PyObject *ret = NULL;
     int err;
-    size_t num_rows, total_name_length;
+    size_t num_rows, name_length;
     char *name_data = NULL;
-    uint32_t *name_length_data = NULL;
+    uint32_t *name_offset_data = NULL;
     void *population_data = NULL;
     PyObject *time_input = NULL;
     PyArrayObject *time_array = NULL;
@@ -886,13 +908,13 @@ NodeTable_set_or_append_columns(NodeTable *self, PyObject *args, PyObject *kwds,
     PyArrayObject *population_array = NULL;
     PyObject *name_input = NULL;
     PyArrayObject *name_array = NULL;
-    PyObject *name_length_input = NULL;
-    PyArrayObject *name_length_array = NULL;
-    static char *kwlist[] = {"flags", "time", "population", "name", "name_length", NULL};
+    PyObject *name_offset_input = NULL;
+    PyArrayObject *name_offset_array = NULL;
+    static char *kwlist[] = {"flags", "time", "population", "name", "name_offset", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|OOO", kwlist,
                 &flags_input, &time_input, &population_input, &name_input,
-                &name_length_input)) {
+                &name_offset_input)) {
         goto out;
     }
     if (NodeTable_check_state(self) != 0) {
@@ -914,34 +936,30 @@ NodeTable_set_or_append_columns(NodeTable *self, PyObject *args, PyObject *kwds,
         }
         population_data = PyArray_DATA(population_array);
     }
-    if ((name_input == NULL) != (name_length_input == NULL)) {
-        PyErr_SetString(PyExc_TypeError, "name and name_length must be specified together");
+    if ((name_input == NULL) != (name_offset_input == NULL)) {
+        PyErr_SetString(PyExc_TypeError, "name and name_offset must be specified together");
         goto out;
     }
     if (name_input != NULL) {
-        name_length_array = table_read_column_array(name_length_input, NPY_UINT32, &num_rows,
-                true);
-        if (name_length_array == NULL) {
-            goto out;
-        }
-        name_length_data = PyArray_DATA(name_length_array);
-        name_array = table_read_column_array(name_input, NPY_INT8, &total_name_length, false);
+        name_array = table_read_column_array(name_input, NPY_INT8, &name_length, false);
         if (name_array == NULL) {
             goto out;
         }
         name_data = PyArray_DATA(name_array);
-        if (verify_column_sum(num_rows, name_length_data, total_name_length) != 0) {
+        name_offset_array = table_read_offset_array(name_offset_input, num_rows, name_length);
+        if (name_offset_array == NULL) {
             goto out;
         }
+        name_offset_data = PyArray_DATA(name_offset_array);
     }
     if (method == SET_COLS) {
         err = node_table_set_columns(self->node_table, num_rows,
                 PyArray_DATA(flags_array), PyArray_DATA(time_array), population_data,
-                name_data, name_length_data);
+                name_data, name_offset_data);
     } else if (method == APPEND_COLS) {
         err = node_table_append_columns(self->node_table, num_rows,
                 PyArray_DATA(flags_array), PyArray_DATA(time_array), population_data,
-                name_data, name_length_data);
+                name_data, name_offset_data);
     } else {
         assert(0);
     }
@@ -955,7 +973,7 @@ out:
     Py_XDECREF(time_array);
     Py_XDECREF(population_array);
     Py_XDECREF(name_array);
-    Py_XDECREF(name_length_array);
+    Py_XDECREF(name_offset_array);
     return ret;
 }
 
@@ -1079,22 +1097,22 @@ NodeTable_get_name(NodeTable *self, void *closure)
     if (NodeTable_check_state(self) != 0) {
         goto out;
     }
-    ret = table_get_column_array(self->node_table->total_name_length,
+    ret = table_get_column_array(self->node_table->name_length,
             self->node_table->name, NPY_INT8, sizeof(char));
 out:
     return ret;
 }
 
 static PyObject *
-NodeTable_get_name_length(NodeTable *self, void *closure)
+NodeTable_get_name_offset(NodeTable *self, void *closure)
 {
     PyObject *ret = NULL;
 
     if (NodeTable_check_state(self) != 0) {
         goto out;
     }
-    ret = table_get_column_array(self->node_table->num_rows,
-            self->node_table->name_length, NPY_UINT32, sizeof(uint32_t));
+    ret = table_get_column_array(self->node_table->num_rows + 1,
+            self->node_table->name_offset, NPY_UINT32, sizeof(uint32_t));
 out:
     return ret;
 }
@@ -1112,7 +1130,7 @@ static PyGetSetDef NodeTable_getsetters[] = {
     {"flags", (getter) NodeTable_get_flags, NULL, "The flags array"},
     {"population", (getter) NodeTable_get_population, NULL, "The population array"},
     {"name", (getter) NodeTable_get_name, NULL, "The name array"},
-    {"name_length", (getter) NodeTable_get_name_length, NULL, "The name length array"},
+    {"name_offset", (getter) NodeTable_get_name_offset, NULL, "The name offset array"},
 #endif
     {NULL}  /* Sentinel */
 };
@@ -1938,7 +1956,7 @@ SiteTable_init(SiteTable *self, PyObject *args, PyObject *kwds)
     int ret = -1;
     int err;
     static char *kwlist[] = {"max_rows_increment",
-        "max_total_ancestral_state_length_increment", NULL};
+        "max_ancestral_state_length_increment", NULL};
     Py_ssize_t max_rows_increment = 0;
     Py_ssize_t max_length_increment = 0;
 
@@ -2008,48 +2026,42 @@ SiteTable_set_or_append_columns(SiteTable *self, PyObject *args, PyObject *kwds,
     PyObject *ret = NULL;
     int err;
     size_t num_rows = 0;
-    size_t total_ancestral_state_length;
-    uint32_t *ancestral_state_length;
+    size_t ancestral_state_length;
     PyObject *position_input = NULL;
     PyArrayObject *position_array = NULL;
     PyObject *ancestral_state_input = NULL;
     PyArrayObject *ancestral_state_array = NULL;
-    PyObject *ancestral_state_length_input = NULL;
-    PyArrayObject *ancestral_state_length_array = NULL;
+    PyObject *ancestral_state_offset_input = NULL;
+    PyArrayObject *ancestral_state_offset_array = NULL;
 
-    static char *kwlist[] = {"position", "ancestral_state", "ancestral_state_length", NULL};
+    static char *kwlist[] = {"position", "ancestral_state", "ancestral_state_offset", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOO", kwlist,
-                &position_input, &ancestral_state_input, &ancestral_state_length_input)) {
+                &position_input, &ancestral_state_input, &ancestral_state_offset_input)) {
         goto out;
     }
     position_array = table_read_column_array(position_input, NPY_FLOAT64, &num_rows, false);
     if (position_array == NULL) {
         goto out;
     }
-    ancestral_state_length_array = table_read_column_array(ancestral_state_length_input,
-            NPY_UINT32, &num_rows, true);
-    if (ancestral_state_length_array == NULL) {
-        goto out;
-    }
     ancestral_state_array = table_read_column_array(ancestral_state_input, NPY_INT8,
-            &total_ancestral_state_length, false);
+            &ancestral_state_length, false);
     if (ancestral_state_array == NULL) {
         goto out;
     }
-    ancestral_state_length = PyArray_DATA(ancestral_state_length_array);
-    if (verify_column_sum(num_rows, ancestral_state_length,
-                total_ancestral_state_length) != 0) {
+    ancestral_state_offset_array = table_read_offset_array(ancestral_state_offset_input,
+            num_rows, ancestral_state_length);
+    if (ancestral_state_offset_array == NULL) {
         goto out;
     }
     if (method == SET_COLS) {
         err = site_table_set_columns(self->site_table, num_rows,
             PyArray_DATA(position_array), PyArray_DATA(ancestral_state_array),
-            ancestral_state_length);
+            PyArray_DATA(ancestral_state_offset_array));
     } else if (method == APPEND_COLS) {
         err = site_table_append_columns(self->site_table, num_rows,
             PyArray_DATA(position_array), PyArray_DATA(ancestral_state_array),
-            ancestral_state_length);
+            PyArray_DATA(ancestral_state_offset_array));
     } else {
         assert(0);
     }
@@ -2061,7 +2073,7 @@ SiteTable_set_or_append_columns(SiteTable *self, PyObject *args, PyObject *kwds,
 out:
     Py_XDECREF(position_array);
     Py_XDECREF(ancestral_state_array);
-    Py_XDECREF(ancestral_state_length_array);
+    Py_XDECREF(ancestral_state_offset_array);
     return ret;
 }
 
@@ -2112,14 +2124,14 @@ out:
 }
 
 static PyObject *
-SiteTable_get_max_total_ancestral_state_length_increment(SiteTable *self, void *closure)
+SiteTable_get_max_ancestral_state_length_increment(SiteTable *self, void *closure)
 {
     PyObject *ret = NULL;
     if (SiteTable_check_state(self) != 0) {
         goto out;
     }
     ret = Py_BuildValue("n",
-        (Py_ssize_t) self->site_table->max_total_ancestral_state_length_increment);
+        (Py_ssize_t) self->site_table->max_ancestral_state_length_increment);
 out:
     return ret;
 }
@@ -2173,14 +2185,14 @@ SiteTable_get_ancestral_state(SiteTable *self, void *closure)
         goto out;
     }
     ret = table_get_column_array(
-            self->site_table->total_ancestral_state_length,
+            self->site_table->ancestral_state_length,
             self->site_table->ancestral_state, NPY_INT8, sizeof(char));
 out:
     return ret;
 }
 
 static PyObject *
-SiteTable_get_ancestral_state_length(SiteTable *self, void *closure)
+SiteTable_get_ancestral_state_offset(SiteTable *self, void *closure)
 {
     PyObject *ret = NULL;
 
@@ -2188,8 +2200,8 @@ SiteTable_get_ancestral_state_length(SiteTable *self, void *closure)
         goto out;
     }
     ret = table_get_column_array(
-            self->site_table->num_rows,
-            self->site_table->ancestral_state_length, NPY_UINT32, sizeof(uint32_t));
+            self->site_table->num_rows + 1,
+            self->site_table->ancestral_state_offset, NPY_UINT32, sizeof(uint32_t));
 out:
     return ret;
 }
@@ -2199,8 +2211,8 @@ static PyGetSetDef SiteTable_getsetters[] = {
     {"max_rows_increment",
         (getter) SiteTable_get_max_rows_increment, NULL,
         "The size increment"},
-    {"max_total_ancestral_state_length_increment",
-        (getter) SiteTable_get_max_total_ancestral_state_length_increment, NULL,
+    {"max_ancestral_state_length_increment",
+        (getter) SiteTable_get_max_ancestral_state_length_increment, NULL,
         "The string length increment"},
     {"num_rows",
         (getter) SiteTable_get_num_rows, NULL,
@@ -2213,8 +2225,8 @@ static PyGetSetDef SiteTable_getsetters[] = {
         "The position array."},
     {"ancestral_state", (getter) SiteTable_get_ancestral_state, NULL,
         "The ancestral state array."},
-    {"ancestral_state_length", (getter) SiteTable_get_ancestral_state_length, NULL,
-        "The ancestral state_length array."},
+    {"ancestral_state_offset", (getter) SiteTable_get_ancestral_state_offset, NULL,
+        "The ancestral state offset array."},
 #endif
     {NULL}  /* Sentinel */
 };
@@ -2313,22 +2325,22 @@ MutationTable_init(MutationTable *self, PyObject *args, PyObject *kwds)
     int ret = -1;
     int err;
     static char *kwlist[] = {
-        "max_rows_increment", "max_total_derived_state_length_increment", NULL};
+        "max_rows_increment", "max_derived_state_length_increment", NULL};
     Py_ssize_t max_rows_increment = 0;
-    Py_ssize_t max_total_derived_state_length_increment = 0;
+    Py_ssize_t max_derived_state_length_increment = 0;
 
     self->mutation_table = NULL;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|nn", kwlist,
-                &max_rows_increment, &max_total_derived_state_length_increment)) {
+                &max_rows_increment, &max_derived_state_length_increment)) {
         goto out;
     }
     if (max_rows_increment < 0) {
         PyErr_SetString(PyExc_ValueError, "max_rows_increment must be positive");
         goto out;
     }
-    if (max_total_derived_state_length_increment < 0) {
+    if (max_derived_state_length_increment < 0) {
         PyErr_SetString(PyExc_ValueError,
-                "max_total_derived_state_length_increment must be positive");
+                "max_derived_state_length_increment must be positive");
         goto out;
     }
     self->mutation_table = PyMem_Malloc(sizeof(mutation_table_t));
@@ -2337,7 +2349,7 @@ MutationTable_init(MutationTable *self, PyObject *args, PyObject *kwds)
         goto out;
     }
     err = mutation_table_alloc(self->mutation_table, (size_t) max_rows_increment,
-            (size_t) max_total_derived_state_length_increment);
+            (size_t) max_derived_state_length_increment);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -2388,13 +2400,13 @@ MutationTable_set_or_append_columns(MutationTable *self, PyObject *args, PyObjec
     PyObject *ret = NULL;
     int err;
     size_t num_rows = 0;
-    size_t total_derived_state_length = 0;
+    size_t derived_state_length = 0;
     PyObject *site_input = NULL;
     PyArrayObject *site_array = NULL;
     PyObject *derived_state_input = NULL;
     PyArrayObject *derived_state_array = NULL;
-    PyObject *derived_state_length_input = NULL;
-    PyArrayObject *derived_state_length_array = NULL;
+    PyObject *derived_state_offset_input = NULL;
+    PyArrayObject *derived_state_offset_array = NULL;
     PyObject *node_input = NULL;
     PyArrayObject *node_array = NULL;
     PyObject *parent_input = NULL;
@@ -2402,11 +2414,11 @@ MutationTable_set_or_append_columns(MutationTable *self, PyObject *args, PyObjec
     mutation_id_t *parent_data;
 
     static char *kwlist[] = {"site", "node", "derived_state",
-        "derived_state_length", "parent", NULL};
+        "derived_state_offset", "parent", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOOO|O", kwlist,
                 &site_input, &node_input, &derived_state_input,
-                &derived_state_length_input, &parent_input)) {
+                &derived_state_offset_input, &parent_input)) {
         goto out;
     }
     site_array = table_read_column_array(site_input, NPY_INT32, &num_rows, false);
@@ -2414,13 +2426,13 @@ MutationTable_set_or_append_columns(MutationTable *self, PyObject *args, PyObjec
         goto out;
     }
     derived_state_array = table_read_column_array(derived_state_input, NPY_INT8,
-            &total_derived_state_length, false);
+            &derived_state_length, false);
     if (derived_state_array == NULL) {
         goto out;
     }
-    derived_state_length_array = table_read_column_array(derived_state_length_input,
-            NPY_UINT32, &num_rows, true);
-    if (derived_state_length_array == NULL) {
+    derived_state_offset_array = table_read_offset_array(derived_state_offset_input,
+            num_rows, derived_state_length);
+    if (derived_state_offset_array == NULL) {
         goto out;
     }
     node_array = table_read_column_array(node_input, NPY_INT32, &num_rows, true);
@@ -2439,12 +2451,12 @@ MutationTable_set_or_append_columns(MutationTable *self, PyObject *args, PyObjec
         err = mutation_table_set_columns(self->mutation_table, num_rows,
                 PyArray_DATA(site_array), PyArray_DATA(node_array),
                 parent_data, PyArray_DATA(derived_state_array),
-                PyArray_DATA(derived_state_length_array));
+                PyArray_DATA(derived_state_offset_array));
     } else if (method == APPEND_COLS) {
         err = mutation_table_append_columns(self->mutation_table, num_rows,
                 PyArray_DATA(site_array), PyArray_DATA(node_array),
                 parent_data, PyArray_DATA(derived_state_array),
-                PyArray_DATA(derived_state_length_array));
+                PyArray_DATA(derived_state_offset_array));
     } else {
         assert(0);
     }
@@ -2456,7 +2468,7 @@ MutationTable_set_or_append_columns(MutationTable *self, PyObject *args, PyObjec
 out:
     Py_XDECREF(site_array);
     Py_XDECREF(derived_state_array);
-    Py_XDECREF(derived_state_length_array);
+    Py_XDECREF(derived_state_offset_array);
     Py_XDECREF(node_array);
     Py_XDECREF(parent_array);
     return ret;
@@ -2509,14 +2521,14 @@ out:
 }
 
 static PyObject *
-MutationTable_get_max_total_derived_state_length_increment(MutationTable *self, void *closure)
+MutationTable_get_max_derived_state_length_increment(MutationTable *self, void *closure)
 {
     PyObject *ret = NULL;
     if (MutationTable_check_state(self) != 0) {
         goto out;
     }
     ret = Py_BuildValue("n",
-            (Py_ssize_t) self->mutation_table->max_total_derived_state_length_increment);
+            (Py_ssize_t) self->mutation_table->max_derived_state_length_increment);
 out:
     return ret;
 }
@@ -2600,14 +2612,14 @@ MutationTable_get_derived_state(MutationTable *self, void *closure)
         goto out;
     }
     ret = table_get_column_array(
-            self->mutation_table->total_derived_state_length, self->mutation_table->derived_state,
+            self->mutation_table->derived_state_length, self->mutation_table->derived_state,
             NPY_INT8, sizeof(char));
 out:
     return ret;
 }
 
 static PyObject *
-MutationTable_get_derived_state_length(MutationTable *self, void *closure)
+MutationTable_get_derived_state_offset(MutationTable *self, void *closure)
 {
     PyObject *ret = NULL;
 
@@ -2615,7 +2627,7 @@ MutationTable_get_derived_state_length(MutationTable *self, void *closure)
         goto out;
     }
     ret = table_get_column_array(
-            self->mutation_table->num_rows, self->mutation_table->derived_state_length,
+            self->mutation_table->num_rows + 1, self->mutation_table->derived_state_offset,
             NPY_UINT32, sizeof(uint32_t));
 out:
     return ret;
@@ -2626,8 +2638,8 @@ static PyGetSetDef MutationTable_getsetters[] = {
     {"max_rows_increment",
         (getter) MutationTable_get_max_rows_increment, NULL,
         "The size increment"},
-    {"max_total_derived_state_length_increment",
-        (getter) MutationTable_get_max_total_derived_state_length_increment, NULL,
+    {"max_derived_state_length_increment",
+        (getter) MutationTable_get_max_derived_state_length_increment, NULL,
         "The total derived_state increment"},
     {"num_rows",
         (getter) MutationTable_get_num_rows, NULL,
@@ -2641,8 +2653,8 @@ static PyGetSetDef MutationTable_getsetters[] = {
     {"parent", (getter) MutationTable_get_parent, NULL, "The parent array"},
     {"derived_state", (getter) MutationTable_get_derived_state, NULL,
         "The derived_state array"},
-    {"derived_state_length", (getter) MutationTable_get_derived_state_length, NULL,
-        "The derived_state_length array"},
+    {"derived_state_offset", (getter) MutationTable_get_derived_state_offset, NULL,
+        "The derived_state_offset array"},
 #endif
     {NULL}  /* Sentinel */
 };

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -13,7 +13,8 @@ HEADERS=msprime.h err.h
 COMPILED=msprime.o fenwick.o tree_sequence.o object_heap.o newick.o \
     hapgen.o recomb_map.o mutgen.o vargen.o vcf.o ld.o avl.o table.o
 
-all: main tests simulation_tests
+# all: main tests simulation_tests
+all: main
 
 # We need a seperate rule for avl.c as it won't pass the strict checks.
 avl.o: avl.c

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -13,8 +13,7 @@ HEADERS=msprime.h err.h
 COMPILED=msprime.o fenwick.o tree_sequence.o object_heap.o newick.o \
     hapgen.o recomb_map.o mutgen.o vargen.o vcf.o ld.o avl.o table.o
 
-# all: main tests simulation_tests
-all: main
+all: main tests simulation_tests
 
 # We need a seperate rule for avl.c as it won't pass the strict checks.
 avl.o: avl.c

--- a/lib/err.h
+++ b/lib/err.h
@@ -72,6 +72,7 @@
 #define MSP_ERR_BAD_EDGE_INTERVAL                                   -41
 #define MSP_ERR_DUPLICATE_EDGES                                     -42
 #define MSP_ERR_NOT_INITIALISED                                     -43
+#define MSP_ERR_BAD_OFFSET                                          -44
 
 #define MSP_ERR_DUPLICATE_MUTATION_NODES                            -46
 #define MSP_ERR_NONBINARY_MUTATIONS_UNSUPPORTED                     -47

--- a/lib/hapgen.c
+++ b/lib/hapgen.c
@@ -115,7 +115,7 @@ hapgen_apply_tree_site(hapgen_t *self, site_t *site)
     int ret = 0;
     node_list_t *w, *tail;
     bool not_done;
-    list_len_t j;
+    table_size_t j;
     const char *derived_state;
 
     for (j = 0; j < site->mutations_length; j++) {
@@ -149,8 +149,8 @@ static int
 hapgen_generate_all_haplotypes(hapgen_t *self)
 {
     int ret = 0;
-    list_len_t j;
-    list_len_t num_sites = 0;
+    table_size_t j;
+    table_size_t num_sites = 0;
     site_t *sites = NULL;
     sparse_tree_t *t = &self->tree;
 

--- a/lib/main.c
+++ b/lib/main.c
@@ -607,8 +607,8 @@ print_variants(tree_sequence_t *ts)
     j = 0;
     while ((ret = vargen_next(&vg, &site, genotypes)) == 1) {
         assert(site->mutations_length == 1);
-        printf("%d\t%f\t%s\t%s\t", j, site->position, site->ancestral_state,
-                site->mutations[0].derived_state);
+        printf("%d\t%f\t%c\t%c\t", j, site->position, site->ancestral_state[0],
+                site->mutations[0].derived_state[0]);
         for (k = 0; k < tree_sequence_get_num_samples(ts); k++) {
             printf("%d", genotypes[k]);
         }

--- a/lib/main.c
+++ b/lib/main.c
@@ -871,7 +871,7 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
     if (ret != 0) {
         goto out;
     }
-    ret = site_table_alloc(sites, 0, 0);
+    ret = site_table_alloc(sites, 0, 0, 0);
     if (ret != 0) {
         goto out;
     }

--- a/lib/main.c
+++ b/lib/main.c
@@ -875,7 +875,7 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
     if (ret != 0) {
         goto out;
     }
-    ret = mutation_table_alloc(mutations, 0, 0);
+    ret = mutation_table_alloc(mutations, 0, 0, 0);
     if (ret != 0) {
         goto out;
     }

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -273,6 +273,9 @@ msp_strerror(int err)
         case MSP_ERR_MUTATION_PARENT_AFTER_CHILD:
             ret = "Parent mutation ID must be < current ID.";
             break;
+        case MSP_ERR_BAD_OFFSET:
+            ret = "Bad offset provided in input array.";
+            break;
         case MSP_ERR_IO:
             if (errno != 0) {
                 ret = strerror(errno);
@@ -1508,6 +1511,7 @@ msp_store_node(msp_t *self, uint32_t flags, double time, population_id_t populat
     node->population = population_id;
     node->time = time;
     node->name = NULL;
+    node->name_length = 0;
     self->num_nodes++;
     /* Check for overflow */
     assert(self->num_nodes < INT32_MAX);
@@ -2732,7 +2736,8 @@ msp_populate_tables(msp_t *self, recomb_map_t *recomb_map, node_table_t *nodes,
     for (j = 0; j < self->num_nodes; j++) {
         node = self->nodes + j;
         scaled_time = self->model.model_time_to_generations(&self->model, node->time);
-        ret = node_table_add_row(nodes, node->flags, scaled_time, node->population, "");
+        ret = node_table_add_row(nodes, node->flags, scaled_time, node->population,
+                NULL, 0);
         if (ret != 0) {
             goto out;
         }

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -1510,8 +1510,8 @@ msp_store_node(msp_t *self, uint32_t flags, double time, population_id_t populat
     node->flags = flags;
     node->population = population_id;
     node->time = time;
-    node->name = NULL;
-    node->name_length = 0;
+    node->metadata = NULL;
+    node->metadata_length = 0;
     self->num_nodes++;
     /* Check for overflow */
     assert(self->num_nodes < INT32_MAX);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -215,6 +215,7 @@ typedef struct {
 } migration_t;
 
 typedef struct {
+    list_len_t id;
     const char *timestamp;
     list_len_t timestamp_length;
     const char *record;

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -509,7 +509,7 @@ typedef struct {
         list_len_t *timestamp_offset;
         char *record;
         list_len_t *record_offset;
-    } provenance;
+    } provenances;
 
 } tree_sequence_t;
 

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -143,6 +143,22 @@ typedef struct {
     double *time;
 } migration_table_t;
 
+typedef struct {
+    list_len_t num_rows;
+    list_len_t max_rows;
+    list_len_t max_rows_increment;
+    list_len_t timestamp_length;
+    list_len_t max_timestamp_length;
+    list_len_t max_timestamp_length_increment;
+    list_len_t provenance_length;
+    list_len_t max_provenance_length;
+    list_len_t max_provenance_length_increment;
+    char *timestamp;
+    list_len_t *timestamp_offset;
+    char *provenance;
+    list_len_t *provenance_offset;
+} provenance_table_t;
+
 typedef struct segment_t_t {
     population_id_t population_id;
     /* During simulation we use genetic coordinates */
@@ -991,6 +1007,23 @@ int simplifier_alloc(simplifier_t *self, double sequence_length,
 int simplifier_free(simplifier_t *self);
 int simplifier_run(simplifier_t *self, node_id_t *node_map);
 void simplifier_print_state(simplifier_t *self, FILE *out);
+
+int provenance_table_alloc(provenance_table_t *self, size_t max_rows_increment,
+        size_t max_timestamp_length_increment, 
+        size_t max_provenance_length_increment);
+int provenance_table_add_row(provenance_table_t *self, 
+        const char *timestamp, size_t timestamp_length,
+        const char *provenance, size_t provenance_length);
+int provenance_table_set_columns(provenance_table_t *self, size_t num_rows, 
+       char *timestamp, list_len_t *timestamp_offset,
+       char *provenance, list_len_t *provenance_offset);
+int provenance_table_append_columns(provenance_table_t *self, size_t num_rows, 
+        char *timestamp, list_len_t *timestamp_offset,
+        char *provenance, list_len_t *provenance_offset);
+int provenance_table_reset(provenance_table_t *self);
+int provenance_table_free(provenance_table_t *self);
+void provenance_table_print_state(provenance_table_t *self, FILE *out);
+bool provenance_table_equal(provenance_table_t *self, provenance_table_t *other);
 
 int squash_edges(edge_t *edges, size_t num_edges, size_t *num_output_edges);
 const char * msp_strerror(int err);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -215,6 +215,13 @@ typedef struct {
 } migration_t;
 
 typedef struct {
+    const char *timestamp;
+    list_len_t timestamp_length;
+    const char *record;
+    list_len_t record_length;
+} provenance_t;
+
+typedef struct {
     uint32_t left; /* TODO CHANGE THIS - not a good name! */
     uint32_t value;
 } node_mapping_t;
@@ -810,11 +817,11 @@ int tree_sequence_dump(tree_sequence_t *self, const char *filename, int flags);
 int tree_sequence_free(tree_sequence_t *self);
 
 size_t tree_sequence_get_num_nodes(tree_sequence_t *self);
-size_t tree_sequence_get_num_migrations(tree_sequence_t *self);
 size_t tree_sequence_get_num_edges(tree_sequence_t *self);
 size_t tree_sequence_get_num_migrations(tree_sequence_t *self);
 size_t tree_sequence_get_num_sites(tree_sequence_t *self);
 size_t tree_sequence_get_num_mutations(tree_sequence_t *self);
+size_t tree_sequence_get_num_provenances(tree_sequence_t *self);
 size_t tree_sequence_get_num_trees(tree_sequence_t *self);
 size_t tree_sequence_get_num_samples(tree_sequence_t *self);
 double tree_sequence_get_sequence_length(tree_sequence_t *self);
@@ -828,12 +835,12 @@ int tree_sequence_get_migration(tree_sequence_t *self, size_t index,
 int tree_sequence_get_site(tree_sequence_t *self, site_id_t id, site_t *site);
 int tree_sequence_get_mutation(tree_sequence_t *self, mutation_id_t id,
         mutation_t *mutation);
+int tree_sequence_get_provenance(tree_sequence_t *self, size_t index,
+        provenance_t *provenance);
 int tree_sequence_get_samples(tree_sequence_t *self, node_id_t **samples);
 int tree_sequence_get_sample_index_map(tree_sequence_t *self,
         node_id_t **sample_index_map);
 
-int tree_sequence_get_provenance_strings(tree_sequence_t *self,
-        size_t *num_provenance_strings, char ***provenance_strings);
 int tree_sequence_simplify(tree_sequence_t *self, node_id_t *samples,
         size_t num_samples, int flags, tree_sequence_t *output,
         node_id_t *node_map);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -104,11 +104,16 @@ typedef struct {
     table_size_t derived_state_length;
     table_size_t max_derived_state_length;
     table_size_t max_derived_state_length_increment;
+    table_size_t metadata_length;
+    table_size_t max_metadata_length;
+    table_size_t max_metadata_length_increment;
     node_id_t *node;
     site_id_t *site;
     mutation_id_t *parent;
     char *derived_state;
     table_size_t *derived_state_offset;
+    char *metadata;
+    table_size_t *metadata_offset;
 } mutation_table_t;
 
 typedef struct {
@@ -196,6 +201,8 @@ typedef struct _mutation_t {
     mutation_id_t parent;
     const char *derived_state;
     table_size_t derived_state_length;
+    const char *metadata;
+    table_size_t metadata_length;
     // TODO remove this and change to ID?
     size_t index;
 } mutation_t;
@@ -490,12 +497,16 @@ typedef struct {
         size_t num_records;
         size_t max_num_records;
         size_t derived_state_length;
+        char *derived_state;
+        table_size_t *derived_state_offset;
         size_t max_derived_state_length;
+        size_t metadata_length;
+        size_t max_metadata_length;
+        char *metadata;
+        table_size_t *metadata_offset;
         node_id_t *node;
         site_id_t *site;
         mutation_id_t *parent;
-        char *derived_state;
-        table_size_t *derived_state_offset;
     } mutations;
 
     struct {
@@ -1005,15 +1016,20 @@ void site_table_print_state(site_table_t *self, FILE *out);
 
 void mutation_table_print_state(mutation_table_t *self, FILE *out);
 int mutation_table_alloc(mutation_table_t *self, size_t max_rows_increment,
-        size_t max_total_derived_state_length_increment);
+        size_t max_total_derived_state_length_increment,
+        size_t max_total_metadata_length_increment);
 int mutation_table_add_row(mutation_table_t *self, site_id_t site, node_id_t node,
-        mutation_id_t parent, const char *derived_state, table_size_t derived_state_length);
+        mutation_id_t parent,
+        const char *derived_state, table_size_t derived_state_length,
+        const char *metadata, table_size_t metadata_length);
 int mutation_table_set_columns(mutation_table_t *self, size_t num_rows,
         site_id_t *site, node_id_t *node, mutation_id_t *parent,
-        const char *derived_state, table_size_t *derived_state_length);
+        const char *derived_state, table_size_t *derived_state_length,
+        const char *metadata, table_size_t *metadata_length);
 int mutation_table_append_columns(mutation_table_t *self, size_t num_rows,
         site_id_t *site, node_id_t *node, mutation_id_t *parent,
-        const char *derived_state, table_size_t *derived_state_length);
+        const char *derived_state, table_size_t *derived_state_length,
+        const char *metadata, table_size_t *metadata_length);
 bool mutation_table_equal(mutation_table_t *self, mutation_table_t *other);
 int mutation_table_reset(mutation_table_t *self);
 int mutation_table_free(mutation_table_t *self);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -150,13 +150,13 @@ typedef struct {
     list_len_t timestamp_length;
     list_len_t max_timestamp_length;
     list_len_t max_timestamp_length_increment;
-    list_len_t provenance_length;
-    list_len_t max_provenance_length;
-    list_len_t max_provenance_length_increment;
+    list_len_t record_length;
+    list_len_t max_record_length;
+    list_len_t max_record_length_increment;
     char *timestamp;
     list_len_t *timestamp_offset;
-    char *provenance;
-    list_len_t *provenance_offset;
+    char *record;
+    list_len_t *record_offset;
 } provenance_table_t;
 
 typedef struct segment_t_t {
@@ -496,12 +496,12 @@ typedef struct {
         size_t max_num_records;
         size_t timestamp_length;
         size_t max_timestamp_length;
-        size_t provenance_length;
-        size_t max_provenance_length;
+        size_t record_length;
+        size_t max_record_length;
         char *timestamp;
         list_len_t *timestamp_offset;
-        char *provenance;
-        list_len_t *provenance_offset;
+        char *record;
+        list_len_t *record_offset;
     } provenance;
 
 } tree_sequence_t;
@@ -1023,13 +1023,13 @@ int provenance_table_alloc(provenance_table_t *self, size_t max_rows_increment,
         size_t max_provenance_length_increment);
 int provenance_table_add_row(provenance_table_t *self,
         const char *timestamp, size_t timestamp_length,
-        const char *provenance, size_t provenance_length);
+        const char *record, size_t record_length);
 int provenance_table_set_columns(provenance_table_t *self, size_t num_rows,
        char *timestamp, list_len_t *timestamp_offset,
-       char *provenance, list_len_t *provenance_offset);
+       char *record, list_len_t *record_offset);
 int provenance_table_append_columns(provenance_table_t *self, size_t num_rows,
         char *timestamp, list_len_t *timestamp_offset,
-        char *provenance, list_len_t *provenance_offset);
+        char *record, list_len_t *record_offset);
 int provenance_table_reset(provenance_table_t *self);
 int provenance_table_free(provenance_table_t *self);
 void provenance_table_print_state(provenance_table_t *self, FILE *out);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -37,7 +37,7 @@
 #define MSP_DUMP_ZLIB_COMPRESSION 1
 #define MSP_LOAD_EXTENDED_CHECKS  1
 
-#define MSP_FILE_FORMAT_VERSION_MAJOR 9
+#define MSP_FILE_FORMAT_VERSION_MAJOR 10
 #define MSP_FILE_FORMAT_VERSION_MINOR 0
 
 /* Flags for simplify() */
@@ -78,46 +78,47 @@ typedef int32_t node_id_t;
 typedef int32_t population_id_t;
 typedef int32_t site_id_t;
 typedef int32_t mutation_id_t;
+/* TODO change list_len_t to table_size_t */
 typedef uint32_t list_len_t;
 
 typedef struct {
-    size_t num_rows;
-    size_t max_rows;
-    size_t max_rows_increment;
-    size_t total_ancestral_state_length;
-    size_t max_total_ancestral_state_length;
-    size_t max_total_ancestral_state_length_increment;
+    list_len_t num_rows;
+    list_len_t max_rows;
+    list_len_t max_rows_increment;
+    list_len_t ancestral_state_length;
+    list_len_t max_ancestral_state_length;
+    list_len_t max_ancestral_state_length_increment;
     char *ancestral_state;
-    list_len_t *ancestral_state_length;
+    list_len_t *ancestral_state_offset;
     double *position;
 } site_table_t;
 
 typedef struct {
-    size_t num_rows;
-    size_t max_rows;
-    size_t max_rows_increment;
-    size_t total_derived_state_length;
-    size_t max_total_derived_state_length;
-    size_t max_total_derived_state_length_increment;
+    list_len_t num_rows;
+    list_len_t max_rows;
+    list_len_t max_rows_increment;
+    list_len_t derived_state_length;
+    list_len_t max_derived_state_length;
+    list_len_t max_derived_state_length_increment;
     node_id_t *node;
     site_id_t *site;
     mutation_id_t *parent;
     char *derived_state;
-    list_len_t *derived_state_length;
+    list_len_t *derived_state_offset;
 } mutation_table_t;
 
 typedef struct {
-    size_t num_rows;
-    size_t max_rows;
-    size_t max_rows_increment;
-    size_t total_name_length;
-    size_t max_total_name_length;
-    size_t max_total_name_length_increment;
+    list_len_t num_rows;
+    list_len_t max_rows;
+    list_len_t max_rows_increment;
+    list_len_t name_length;
+    list_len_t max_name_length;
+    list_len_t max_name_length_increment;
     uint32_t *flags;
     double *time;
     population_id_t *population;
     char *name;
-    list_len_t *name_length;
+    list_len_t *name_offset;
 } node_table_t;
 
 typedef struct {
@@ -157,7 +158,8 @@ typedef struct {
     uint32_t flags;
     double time;
     population_id_t population;
-    char *name;
+    const char *name;
+    list_len_t name_length;
 } node_t;
 
 typedef struct {
@@ -410,14 +412,13 @@ typedef struct {
     struct {
         size_t num_records;
         size_t max_num_records;
-        size_t total_name_length;
-        size_t max_total_name_length;
+        size_t name_length;
+        size_t max_name_length;
         uint32_t *flags;
         population_id_t *population;
         double *time;
-        list_len_t *name_length;
-        char **name;
-        char *name_mem;
+        char *name;
+        list_len_t *name_offset;
         node_id_t *sample_index_map;
     } nodes;
 
@@ -437,11 +438,10 @@ typedef struct {
     struct {
         size_t num_records;
         size_t max_num_records;
-        size_t total_ancestral_state_length;
-        size_t max_total_ancestral_state_length;
-        char **ancestral_state;
-        char *ancestral_state_mem;
-        list_len_t *ancestral_state_length;
+        size_t ancestral_state_length;
+        size_t max_ancestral_state_length;
+        char *ancestral_state;
+        list_len_t *ancestral_state_offset;
         double *position;
         site_t *tree_sites_mem;
         site_t **tree_sites;
@@ -454,14 +454,13 @@ typedef struct {
     struct {
         size_t num_records;
         size_t max_num_records;
-        size_t total_derived_state_length;
-        size_t max_total_derived_state_length;
+        size_t derived_state_length;
+        size_t max_derived_state_length;
         node_id_t *node;
         site_id_t *site;
         mutation_id_t *parent;
-        char **derived_state;
-        char *derived_state_mem;
-        list_len_t *derived_state_length;
+        char *derived_state;
+        list_len_t *derived_state_offset;
     } mutations;
 
     struct {
@@ -918,9 +917,9 @@ int sort_tables(node_table_t *nodes, edge_table_t *edges, migration_table_t *mig
         site_table_t *sites, mutation_table_t *mutations, size_t edge_start);
 
 int node_table_alloc(node_table_t *self, size_t max_rows_increment,
-        size_t max_total_name_length_increment);
+        size_t max_name_length_increment);
 int node_table_add_row(node_table_t *self, uint32_t flags, double time,
-        population_id_t population, const char *name);
+        population_id_t population, const char *name, size_t name_length);
 int node_table_set_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
         population_id_t *population, char *name, list_len_t *name_length);
 int node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -425,6 +425,7 @@ typedef struct {
     size_t num_samples;
     size_t max_num_samples;
     node_id_t *samples;
+
     struct {
         size_t num_records;
         size_t max_num_records;
@@ -490,9 +491,19 @@ typedef struct {
         double *time;
     } migrations;
 
-    char **provenance_strings;
-    size_t num_provenance_strings;
-    size_t max_num_provenance_strings;
+    struct {
+        size_t num_records;
+        size_t max_num_records;
+        size_t timestamp_length;
+        size_t max_timestamp_length;
+        size_t provenance_length;
+        size_t max_provenance_length;
+        char *timestamp;
+        list_len_t *timestamp_offset;
+        char *provenance;
+        list_len_t *provenance_offset;
+    } provenance;
+
 } tree_sequence_t;
 
 typedef struct _edge_list_t {
@@ -785,16 +796,15 @@ size_t msp_get_num_recombination_events(msp_t *self);
 
 void tree_sequence_print_state(tree_sequence_t *self, FILE *out);
 int tree_sequence_initialise(tree_sequence_t *self);
-/* Marking the x_tables API as tmp until we figure out what to do
- * with provenance. */
-int tree_sequence_load_tables_tmp(tree_sequence_t *self, double sequence_length,
+
+int tree_sequence_load_tables(tree_sequence_t *self, double sequence_length,
         node_table_t *nodes, edge_table_t *edges, migration_table_t *migrations,
         site_table_t *sites, mutation_table_t *mutations,
-        size_t num_provenance_strings, char **provenance_strings);
-int tree_sequence_dump_tables_tmp(tree_sequence_t *self, node_table_t *node_table,
+        provenance_table_t *provenance, int flags);
+int tree_sequence_dump_tables(tree_sequence_t *self, node_table_t *node_table,
         edge_table_t *edge_table, migration_table_t *migration_table,
         site_table_t *sites, mutation_table_t *mutations,
-        size_t *num_provenance_strings, char ***provenance_strings);
+        provenance_table_t *provenance, int flags);
 int tree_sequence_load(tree_sequence_t *self, const char *filename, int flags);
 int tree_sequence_dump(tree_sequence_t *self, const char *filename, int flags);
 int tree_sequence_free(tree_sequence_t *self);
@@ -1009,15 +1019,15 @@ int simplifier_run(simplifier_t *self, node_id_t *node_map);
 void simplifier_print_state(simplifier_t *self, FILE *out);
 
 int provenance_table_alloc(provenance_table_t *self, size_t max_rows_increment,
-        size_t max_timestamp_length_increment, 
+        size_t max_timestamp_length_increment,
         size_t max_provenance_length_increment);
-int provenance_table_add_row(provenance_table_t *self, 
+int provenance_table_add_row(provenance_table_t *self,
         const char *timestamp, size_t timestamp_length,
         const char *provenance, size_t provenance_length);
-int provenance_table_set_columns(provenance_table_t *self, size_t num_rows, 
+int provenance_table_set_columns(provenance_table_t *self, size_t num_rows,
        char *timestamp, list_len_t *timestamp_offset,
        char *provenance, list_len_t *provenance_offset);
-int provenance_table_append_columns(provenance_table_t *self, size_t num_rows, 
+int provenance_table_append_columns(provenance_table_t *self, size_t num_rows,
         char *timestamp, list_len_t *timestamp_offset,
         char *provenance, list_len_t *provenance_offset);
 int provenance_table_reset(provenance_table_t *self);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -78,47 +78,47 @@ typedef int32_t node_id_t;
 typedef int32_t population_id_t;
 typedef int32_t site_id_t;
 typedef int32_t mutation_id_t;
-/* TODO change list_len_t to table_size_t */
-typedef uint32_t list_len_t;
+/* TODO change table_size_t to table_size_t */
+typedef uint32_t table_size_t;
 
 typedef struct {
-    list_len_t num_rows;
-    list_len_t max_rows;
-    list_len_t max_rows_increment;
-    list_len_t ancestral_state_length;
-    list_len_t max_ancestral_state_length;
-    list_len_t max_ancestral_state_length_increment;
+    table_size_t num_rows;
+    table_size_t max_rows;
+    table_size_t max_rows_increment;
+    table_size_t ancestral_state_length;
+    table_size_t max_ancestral_state_length;
+    table_size_t max_ancestral_state_length_increment;
     char *ancestral_state;
-    list_len_t *ancestral_state_offset;
+    table_size_t *ancestral_state_offset;
     double *position;
 } site_table_t;
 
 typedef struct {
-    list_len_t num_rows;
-    list_len_t max_rows;
-    list_len_t max_rows_increment;
-    list_len_t derived_state_length;
-    list_len_t max_derived_state_length;
-    list_len_t max_derived_state_length_increment;
+    table_size_t num_rows;
+    table_size_t max_rows;
+    table_size_t max_rows_increment;
+    table_size_t derived_state_length;
+    table_size_t max_derived_state_length;
+    table_size_t max_derived_state_length_increment;
     node_id_t *node;
     site_id_t *site;
     mutation_id_t *parent;
     char *derived_state;
-    list_len_t *derived_state_offset;
+    table_size_t *derived_state_offset;
 } mutation_table_t;
 
 typedef struct {
-    list_len_t num_rows;
-    list_len_t max_rows;
-    list_len_t max_rows_increment;
-    list_len_t metadata_length;
-    list_len_t max_metadata_length;
-    list_len_t max_metadata_length_increment;
+    table_size_t num_rows;
+    table_size_t max_rows;
+    table_size_t max_rows_increment;
+    table_size_t metadata_length;
+    table_size_t max_metadata_length;
+    table_size_t max_metadata_length_increment;
     uint32_t *flags;
     double *time;
     population_id_t *population;
     char *metadata;
-    list_len_t *metadata_offset;
+    table_size_t *metadata_offset;
 } node_table_t;
 
 typedef struct {
@@ -144,19 +144,19 @@ typedef struct {
 } migration_table_t;
 
 typedef struct {
-    list_len_t num_rows;
-    list_len_t max_rows;
-    list_len_t max_rows_increment;
-    list_len_t timestamp_length;
-    list_len_t max_timestamp_length;
-    list_len_t max_timestamp_length_increment;
-    list_len_t record_length;
-    list_len_t max_record_length;
-    list_len_t max_record_length_increment;
+    table_size_t num_rows;
+    table_size_t max_rows;
+    table_size_t max_rows_increment;
+    table_size_t timestamp_length;
+    table_size_t max_timestamp_length;
+    table_size_t max_timestamp_length_increment;
+    table_size_t record_length;
+    table_size_t max_record_length;
+    table_size_t max_record_length_increment;
     char *timestamp;
-    list_len_t *timestamp_offset;
+    table_size_t *timestamp_offset;
     char *record;
-    list_len_t *record_offset;
+    table_size_t *record_offset;
 } provenance_table_t;
 
 typedef struct segment_t_t {
@@ -175,7 +175,7 @@ typedef struct {
     double time;
     population_id_t population;
     const char *metadata;
-    list_len_t metadata_length;
+    table_size_t metadata_length;
 } node_t;
 
 typedef struct {
@@ -191,7 +191,7 @@ typedef struct _mutation_t {
     node_id_t node;
     mutation_id_t parent;
     const char *derived_state;
-    list_len_t derived_state_length;
+    table_size_t derived_state_length;
     // TODO remove this and change to ID?
     size_t index;
 } mutation_t;
@@ -200,9 +200,9 @@ typedef struct {
     site_id_t id;
     double position;
     const char *ancestral_state;
-    list_len_t ancestral_state_length;
+    table_size_t ancestral_state_length;
     mutation_t *mutations;
-    list_len_t mutations_length;
+    table_size_t mutations_length;
 } site_t;
 
 typedef struct {
@@ -215,11 +215,11 @@ typedef struct {
 } migration_t;
 
 typedef struct {
-    list_len_t id;
+    table_size_t id;
     const char *timestamp;
-    list_len_t timestamp_length;
+    table_size_t timestamp_length;
     const char *record;
-    list_len_t record_length;
+    table_size_t record_length;
 } provenance_t;
 
 typedef struct {
@@ -443,7 +443,7 @@ typedef struct {
         population_id_t *population;
         double *time;
         char *metadata;
-        list_len_t *metadata_offset;
+        table_size_t *metadata_offset;
         node_id_t *sample_index_map;
     } nodes;
 
@@ -466,14 +466,14 @@ typedef struct {
         size_t ancestral_state_length;
         size_t max_ancestral_state_length;
         char *ancestral_state;
-        list_len_t *ancestral_state_offset;
+        table_size_t *ancestral_state_offset;
         double *position;
         site_t *tree_sites_mem;
         site_t **tree_sites;
-        list_len_t *tree_sites_length;
+        table_size_t *tree_sites_length;
         mutation_t *site_mutations_mem;
         mutation_t **site_mutations;
-        list_len_t *site_mutations_length;
+        table_size_t *site_mutations_length;
     } sites;
 
     struct {
@@ -485,7 +485,7 @@ typedef struct {
         site_id_t *site;
         mutation_id_t *parent;
         char *derived_state;
-        list_len_t *derived_state_offset;
+        table_size_t *derived_state_offset;
     } mutations;
 
     struct {
@@ -507,9 +507,9 @@ typedef struct {
         size_t record_length;
         size_t max_record_length;
         char *timestamp;
-        list_len_t *timestamp_offset;
+        table_size_t *timestamp_offset;
         char *record;
-        list_len_t *record_offset;
+        table_size_t *record_offset;
     } provenances;
 
 } tree_sequence_t;
@@ -571,7 +571,7 @@ typedef struct {
     node_id_t *stack2;
     /* The sites on this tree */
     site_t *sites;
-    list_len_t sites_length;
+    table_size_t sites_length;
     /* Counters needed for next() and prev() transformations. */
     int direction;
     node_id_t left_index;
@@ -876,7 +876,7 @@ int sparse_tree_get_num_tracked_samples(sparse_tree_t *self, node_id_t u,
         size_t *num_tracked_samples);
 int sparse_tree_get_sample_list(sparse_tree_t *self, node_id_t u,
         node_list_t **head, node_list_t **tail);
-int sparse_tree_get_sites(sparse_tree_t *self, site_t **sites, list_len_t *sites_length);
+int sparse_tree_get_sites(sparse_tree_t *self, site_t **sites, table_size_t *sites_length);
 int sparse_tree_get_newick(sparse_tree_t *self, size_t precision, double time_scale,
         int flags, size_t buffer_size, char *newick_buffer);
 void sparse_tree_print_state(sparse_tree_t *self, FILE *out);
@@ -955,9 +955,9 @@ int node_table_alloc(node_table_t *self, size_t max_rows_increment,
 int node_table_add_row(node_table_t *self, uint32_t flags, double time,
         population_id_t population, const char *name, size_t name_length);
 int node_table_set_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, char *name, list_len_t *name_length);
+        population_id_t *population, char *name, table_size_t *name_length);
 int node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, char *name, list_len_t *name_length);
+        population_id_t *population, char *name, table_size_t *name_length);
 int node_table_reset(node_table_t *self);
 int node_table_free(node_table_t *self);
 void node_table_print_state(node_table_t *self, FILE *out);
@@ -978,11 +978,11 @@ bool edge_table_equal(edge_table_t *self, edge_table_t *other);
 int site_table_alloc(site_table_t *self, size_t max_rows_increment,
         size_t max_total_ancestral_state_length_increment);
 int site_table_add_row(site_table_t *self, double position, const char *ancestral_state,
-        list_len_t ancestral_state_length);
+        table_size_t ancestral_state_length);
 int site_table_set_columns(site_table_t *self, size_t num_rows,
-        double *position, const char *ancestral_state, list_len_t *ancestral_state_length);
+        double *position, const char *ancestral_state, table_size_t *ancestral_state_length);
 int site_table_append_columns(site_table_t *self, size_t num_rows,
-        double *position, const char *ancestral_state, list_len_t *ancestral_state_length);
+        double *position, const char *ancestral_state, table_size_t *ancestral_state_length);
 bool site_table_equal(site_table_t *self, site_table_t *other);
 int site_table_reset(site_table_t *self);
 int site_table_free(site_table_t *self);
@@ -992,13 +992,13 @@ void mutation_table_print_state(mutation_table_t *self, FILE *out);
 int mutation_table_alloc(mutation_table_t *self, size_t max_rows_increment,
         size_t max_total_derived_state_length_increment);
 int mutation_table_add_row(mutation_table_t *self, site_id_t site, node_id_t node,
-        mutation_id_t parent, const char *derived_state, list_len_t derived_state_length);
+        mutation_id_t parent, const char *derived_state, table_size_t derived_state_length);
 int mutation_table_set_columns(mutation_table_t *self, size_t num_rows,
         site_id_t *site, node_id_t *node, mutation_id_t *parent,
-        const char *derived_state, list_len_t *derived_state_length);
+        const char *derived_state, table_size_t *derived_state_length);
 int mutation_table_append_columns(mutation_table_t *self, size_t num_rows,
         site_id_t *site, node_id_t *node, mutation_id_t *parent,
-        const char *derived_state, list_len_t *derived_state_length);
+        const char *derived_state, table_size_t *derived_state_length);
 bool mutation_table_equal(mutation_table_t *self, mutation_table_t *other);
 int mutation_table_reset(mutation_table_t *self);
 int mutation_table_free(mutation_table_t *self);
@@ -1033,11 +1033,11 @@ int provenance_table_add_row(provenance_table_t *self,
         const char *timestamp, size_t timestamp_length,
         const char *record, size_t record_length);
 int provenance_table_set_columns(provenance_table_t *self, size_t num_rows,
-       char *timestamp, list_len_t *timestamp_offset,
-       char *record, list_len_t *record_offset);
+       char *timestamp, table_size_t *timestamp_offset,
+       char *record, table_size_t *record_offset);
 int provenance_table_append_columns(provenance_table_t *self, size_t num_rows,
-        char *timestamp, list_len_t *timestamp_offset,
-        char *record, list_len_t *record_offset);
+        char *timestamp, table_size_t *timestamp_offset,
+        char *record, table_size_t *record_offset);
 int provenance_table_reset(provenance_table_t *self);
 int provenance_table_free(provenance_table_t *self);
 void provenance_table_print_state(provenance_table_t *self, FILE *out);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -111,14 +111,14 @@ typedef struct {
     list_len_t num_rows;
     list_len_t max_rows;
     list_len_t max_rows_increment;
-    list_len_t name_length;
-    list_len_t max_name_length;
-    list_len_t max_name_length_increment;
+    list_len_t metadata_length;
+    list_len_t max_metadata_length;
+    list_len_t max_metadata_length_increment;
     uint32_t *flags;
     double *time;
     population_id_t *population;
-    char *name;
-    list_len_t *name_offset;
+    char *metadata;
+    list_len_t *metadata_offset;
 } node_table_t;
 
 typedef struct {
@@ -158,8 +158,8 @@ typedef struct {
     uint32_t flags;
     double time;
     population_id_t population;
-    const char *name;
-    list_len_t name_length;
+    const char *metadata;
+    list_len_t metadata_length;
 } node_t;
 
 typedef struct {
@@ -412,13 +412,13 @@ typedef struct {
     struct {
         size_t num_records;
         size_t max_num_records;
-        size_t name_length;
-        size_t max_name_length;
+        size_t metadata_length;
+        size_t max_metadata_length;
         uint32_t *flags;
         population_id_t *population;
         double *time;
-        char *name;
-        list_len_t *name_offset;
+        char *metadata;
+        list_len_t *metadata_offset;
         node_id_t *sample_index_map;
     } nodes;
 

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -78,7 +78,6 @@ typedef int32_t node_id_t;
 typedef int32_t population_id_t;
 typedef int32_t site_id_t;
 typedef int32_t mutation_id_t;
-/* TODO change table_size_t to table_size_t */
 typedef uint32_t table_size_t;
 
 typedef struct {
@@ -88,9 +87,14 @@ typedef struct {
     table_size_t ancestral_state_length;
     table_size_t max_ancestral_state_length;
     table_size_t max_ancestral_state_length_increment;
+    table_size_t metadata_length;
+    table_size_t max_metadata_length;
+    table_size_t max_metadata_length_increment;
+    double *position;
     char *ancestral_state;
     table_size_t *ancestral_state_offset;
-    double *position;
+    char *metadata;
+    table_size_t *metadata_offset;
 } site_table_t;
 
 typedef struct {
@@ -201,6 +205,8 @@ typedef struct {
     double position;
     const char *ancestral_state;
     table_size_t ancestral_state_length;
+    const char *metadata;
+    table_size_t metadata_length;
     mutation_t *mutations;
     table_size_t mutations_length;
 } site_t;
@@ -467,6 +473,10 @@ typedef struct {
         size_t max_ancestral_state_length;
         char *ancestral_state;
         table_size_t *ancestral_state_offset;
+        size_t metadata_length;
+        size_t max_metadata_length;
+        char *metadata;
+        table_size_t *metadata_offset;
         double *position;
         site_t *tree_sites_mem;
         site_t **tree_sites;
@@ -976,13 +986,18 @@ void edge_table_print_state(edge_table_t *self, FILE *out);
 bool edge_table_equal(edge_table_t *self, edge_table_t *other);
 
 int site_table_alloc(site_table_t *self, size_t max_rows_increment,
-        size_t max_total_ancestral_state_length_increment);
-int site_table_add_row(site_table_t *self, double position, const char *ancestral_state,
-        table_size_t ancestral_state_length);
-int site_table_set_columns(site_table_t *self, size_t num_rows,
-        double *position, const char *ancestral_state, table_size_t *ancestral_state_length);
-int site_table_append_columns(site_table_t *self, size_t num_rows,
-        double *position, const char *ancestral_state, table_size_t *ancestral_state_length);
+        size_t max_ancestral_state_length_increment,
+        size_t max_metadata_length_increment);
+int site_table_add_row(site_table_t *self, double position,
+        const char *ancestral_state, table_size_t ancestral_state_length,
+        const char *metadata, table_size_t metadata_length);
+
+int site_table_set_columns(site_table_t *self, size_t num_rows, double *position,
+        const char *ancestral_state, table_size_t *ancestral_state_length,
+        const char *metadata, table_size_t *metadata_length);
+int site_table_append_columns(site_table_t *self, size_t num_rows, double *position,
+        const char *ancestral_state, table_size_t *ancestral_state_length,
+        const char *metadata, table_size_t *metadata_length);
 bool site_table_equal(site_table_t *self, site_table_t *other);
 int site_table_reset(site_table_t *self);
 int site_table_free(site_table_t *self);

--- a/lib/mutgen.c
+++ b/lib/mutgen.c
@@ -280,7 +280,7 @@ mutgen_populate_tables(mutgen_t *self, site_table_t *sites, mutation_table_t *mu
             goto out;
         }
         ret = mutation_table_add_row(mutations, (site_id_t) j, mut->node,
-                MSP_NULL_MUTATION, mut->derived_state, 1);
+                MSP_NULL_MUTATION, mut->derived_state, 1, NULL, 0);
         if (ret != 0) {
             goto out;
         }

--- a/lib/mutgen.c
+++ b/lib/mutgen.c
@@ -275,7 +275,7 @@ mutgen_populate_tables(mutgen_t *self, site_table_t *sites, mutation_table_t *mu
     }
     for (j = 0; j < self->num_mutations; j++) {
         mut = self->mutations + j;
-        ret = site_table_add_row(sites, mut->position, mut->ancestral_state, 1);
+        ret = site_table_add_row(sites, mut->position, mut->ancestral_state, 1, NULL, 0);
         if (ret != 0) {
             goto out;
         }

--- a/lib/simulation_tests.c
+++ b/lib/simulation_tests.c
@@ -1101,7 +1101,7 @@ test_simulation_replicates(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = edge_table_alloc(&edges, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 1, 1);
+    ret = site_table_alloc(&sites, 1, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/lib/simulation_tests.c
+++ b/lib/simulation_tests.c
@@ -1103,7 +1103,7 @@ test_simulation_replicates(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 1, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 1, 1);
+    ret = mutation_table_alloc(&mutations, 1, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migrations, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/lib/simulation_tests.c
+++ b/lib/simulation_tests.c
@@ -1152,8 +1152,8 @@ test_simulation_replicates(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = mutgen_populate_tables(&mutgen, &sites, &mutations);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts, 0, &nodes, &edges, &migrations,
-                &sites, &mutations, 0, NULL);
+        ret = tree_sequence_load_tables(&ts, 0, &nodes, &edges, &migrations,
+                &sites, &mutations, NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_simulator_tree_sequence_equality(&msp, &ts, &mutgen, 1.0);
         tree_sequence_print_state(&ts, _devnull);

--- a/lib/table.c
+++ b/lib/table.c
@@ -1390,12 +1390,16 @@ provenance_table_print_state(provenance_table_t *self, FILE *out)
     fprintf(out, "provenance_table: %p:\n", (void *) self);
     fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
             (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "timestamp_length = %d\tmax= %d\tincrement = %d)\n",
+    fprintf(out, "timestamp_length  = %d\tmax= %d\tincrement = %d)\n",
             (int) self->timestamp_length,
             (int) self->max_timestamp_length,
             (int) self->max_timestamp_length_increment);
+    fprintf(out, "provenance_length = %d\tmax= %d\tincrement = %d)\n",
+            (int) self->provenance_length,
+            (int) self->max_provenance_length,
+            (int) self->max_provenance_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tttimestamp_offset\ttimestamp\tprovenance_offset\tprovenance\n");
+    fprintf(out, "index\ttimestamp_offset\ttimestamp\tprovenance_offset\tprovenance\n");
     for (j = 0; j < self->num_rows; j++) {
         fprintf(out, "%d\t%d\t", (int) j, self->timestamp_offset[j]);
         for (k = self->timestamp_offset[j]; k < self->timestamp_offset[j + 1]; k++) {

--- a/lib/table.c
+++ b/lib/table.c
@@ -34,6 +34,26 @@
 #define TABLE_SEP "-----------------------------------------\n"
 
 
+/* Checks that the specified list of offsets is well-formed. */
+static int
+check_offsets(size_t num_rows, list_len_t *offsets)
+{
+    int ret = MSP_ERR_BAD_OFFSET;
+    size_t j;
+
+    if (offsets[0] != 0) {
+        goto out;
+    }
+    for (j = 0; j < num_rows; j++) {
+        if (offsets[j] > offsets[j + 1]) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
 static int
 expand_column(void **column, size_t new_max_rows, size_t element_size)
 {
@@ -55,11 +75,11 @@ out:
  *************************/
 
 static int
-node_table_expand_main_columns(node_table_t *self, size_t additional_rows)
+node_table_expand_main_columns(node_table_t *self, list_len_t additional_rows)
 {
     int ret = 0;
-    size_t increment = GSL_MAX(additional_rows, self->max_rows_increment);
-    size_t new_size = self->max_rows + increment;
+    list_len_t increment = GSL_MAX(additional_rows, self->max_rows_increment);
+    list_len_t new_size = self->max_rows + increment;
 
     if ((self->num_rows + additional_rows) > self->max_rows) {
         ret = expand_column((void **) &self->flags, new_size, sizeof(uint32_t));
@@ -70,12 +90,12 @@ node_table_expand_main_columns(node_table_t *self, size_t additional_rows)
         if (ret != 0) {
             goto out;
         }
-        ret = expand_column((void **) &self->population, new_size,
-                sizeof(population_id_t));
+        ret = expand_column((void **) &self->population, new_size, sizeof(population_id_t));
         if (ret != 0) {
             goto out;
         }
-        ret = expand_column((void **) &self->name_length, new_size, sizeof(uint32_t));
+        ret = expand_column((void **) &self->name_offset, new_size + 1,
+                sizeof(list_len_t));
         if (ret != 0) {
             goto out;
         }
@@ -86,19 +106,19 @@ out:
 }
 
 static int
-node_table_expand_name(node_table_t *self, size_t additional_length)
+node_table_expand_name(node_table_t *self, list_len_t additional_length)
 {
     int ret = 0;
-    size_t increment = GSL_MAX(additional_length,
-            self->max_total_name_length_increment);
-    size_t new_size = self->max_total_name_length + increment;
+    list_len_t increment = GSL_MAX(additional_length,
+            self->max_name_length_increment);
+    list_len_t new_size = self->max_name_length + increment;
 
-    if ((self->total_name_length + additional_length) > self->max_total_name_length) {
+    if ((self->name_length + additional_length) > self->max_name_length) {
         ret = expand_column((void **) &self->name, new_size, sizeof(char *));
         if (ret != 0) {
             goto out;
         }
-        self->max_total_name_length = new_size;
+        self->max_name_length = new_size;
     }
 out:
     return ret;
@@ -106,7 +126,7 @@ out:
 
 int
 node_table_alloc(node_table_t *self, size_t max_rows_increment,
-        size_t max_total_name_length_increment)
+        size_t max_name_length_increment)
 {
     int ret = 0;
 
@@ -114,15 +134,15 @@ node_table_alloc(node_table_t *self, size_t max_rows_increment,
     if (max_rows_increment == 0) {
        max_rows_increment = DEFAULT_SIZE_INCREMENT;
     }
-    if (max_total_name_length_increment == 0) {
-        max_total_name_length_increment = DEFAULT_SIZE_INCREMENT;
+    if (max_name_length_increment == 0) {
+        max_name_length_increment = DEFAULT_SIZE_INCREMENT;
     }
-    self->max_rows_increment = max_rows_increment;
-    self->max_total_name_length_increment = max_total_name_length_increment;
+    self->max_rows_increment = (list_len_t) max_rows_increment;
+    self->max_name_length_increment = (list_len_t) max_name_length_increment;
     self->max_rows = 0;
     self->num_rows = 0;
-    self->max_total_name_length = 0;
-    self->total_name_length = 0;
+    self->max_name_length = 0;
+    self->name_length = 0;
     ret = node_table_expand_main_columns(self, 1);
     if (ret != 0) {
         goto out;
@@ -131,6 +151,7 @@ node_table_alloc(node_table_t *self, size_t max_rows_increment,
     if (ret != 0) {
         goto out;
     }
+    self->name_offset[0] = 0;
 out:
     return ret;
 }
@@ -153,42 +174,45 @@ out:
 
 int
 node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, char *name, uint32_t *name_length)
+        population_id_t *population, char *name, uint32_t *name_offset)
 {
     int ret;
-    size_t j, total_name_length;
+    list_len_t j, name_length;
 
     if (flags == NULL || time == NULL) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
-    if ((name == NULL) != (name_length == NULL)) {
+    if ((name == NULL) != (name_offset == NULL)) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
-    ret = node_table_expand_main_columns(self, num_rows);
+    ret = node_table_expand_main_columns(self, (list_len_t) num_rows);
     if (ret != 0) {
         goto out;
     }
     memcpy(self->flags + self->num_rows, flags, num_rows * sizeof(uint32_t));
     memcpy(self->time + self->num_rows, time, num_rows * sizeof(double));
     if (name == NULL) {
-        self->total_name_length = 0;
-        memset(self->name_length + self->num_rows, 0, num_rows * sizeof(uint32_t));
-    } else {
-        memcpy(self->name_length + self->num_rows, name_length,
-                num_rows * sizeof(uint32_t));
-        total_name_length = 0;
         for (j = 0; j < num_rows; j++) {
-            total_name_length += name_length[j];
+            self->name_offset[self->num_rows + j + 1] = (list_len_t) self->name_length;
         }
-        ret = node_table_expand_name(self, total_name_length);
+    } else {
+        ret = check_offsets(num_rows, name_offset);
         if (ret != 0) {
             goto out;
         }
-        memcpy(self->name + self->total_name_length, name,
-                total_name_length * sizeof(char));
-        self->total_name_length += total_name_length;
+        for (j = 0; j < num_rows; j++) {
+            self->name_offset[self->num_rows + j] =
+                (list_len_t) self->name_length + name_offset[j];
+        }
+        name_length = name_offset[num_rows];
+        ret = node_table_expand_name(self, name_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->name + self->name_length, name, name_length * sizeof(char));
+        self->name_length += name_length;
     }
     if (population == NULL) {
         /* Set population to NULL_POPULATION (-1) if not specified */
@@ -198,49 +222,44 @@ node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *flags, 
         memcpy(self->population + self->num_rows, population,
                 num_rows * sizeof(population_id_t));
     }
-    self->num_rows += num_rows;
+    self->num_rows += (list_len_t) num_rows;
+    self->name_offset[self->num_rows] = self->name_length;
 out:
     return ret;
 }
 
 static int
 node_table_add_row_internal(node_table_t *self, uint32_t flags, double time,
-        population_id_t population, size_t name_length, const char *name)
+        population_id_t population, const char *name, list_len_t name_length)
 {
     assert(self->num_rows < self->max_rows);
-    assert(self->total_name_length + name_length < self->max_total_name_length);
-    memcpy(self->name + self->total_name_length, name, name_length);
-    self->total_name_length += name_length;
+    assert(self->name_length + name_length < self->max_name_length);
+    memcpy(self->name + self->name_length, name, name_length);
     self->flags[self->num_rows] = flags;
     self->time[self->num_rows] = time;
     self->population[self->num_rows] = population;
-    self->name_length[self->num_rows] = (uint32_t) name_length;
+    self->name_offset[self->num_rows + 1] = self->name_length + name_length;
+    self->name_length += name_length;
     self->num_rows++;
     return 0;
 }
 
-/* TODO this is a bad API: we should include size_t name_length here. */
 int
 node_table_add_row(node_table_t *self, uint32_t flags, double time,
-        population_id_t population, const char *name)
+        population_id_t population, const char *name, size_t name_length)
 {
     int ret = 0;
-    size_t name_length;
 
-    if (name == NULL) {
-        ret = MSP_ERR_BAD_PARAM_VALUE;
-        goto out;
-    }
     ret = node_table_expand_main_columns(self, 1);
     if (ret != 0) {
         goto out;
     }
-    name_length = strlen(name);
-    ret = node_table_expand_name(self, name_length);
+    ret = node_table_expand_name(self, (list_len_t) name_length);
     if (ret != 0) {
         goto out;
     }
-    ret = node_table_add_row_internal(self, flags, time, population, name_length, name);
+    ret = node_table_add_row_internal(self, flags, time, population, name,
+            (list_len_t) name_length);
 out:
     return ret;
 }
@@ -249,7 +268,7 @@ int
 node_table_reset(node_table_t *self)
 {
     self->num_rows = 0;
-    self->total_name_length = 0;
+    self->name_length = 0;
     return 0;
 }
 
@@ -260,36 +279,35 @@ node_table_free(node_table_t *self)
     msp_safe_free(self->time);
     msp_safe_free(self->population);
     msp_safe_free(self->name);
-    msp_safe_free(self->name_length);
+    msp_safe_free(self->name_offset);
     return 0;
 }
 
 void
 node_table_print_state(node_table_t *self, FILE *out)
 {
-    size_t j, k, offset;
+    size_t j, k;
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "node_table: %p:\n", (void *) self);
     fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
             (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "total_name_length = %d\tmax= %d\tincrement = %d)\n",
-            (int) self->total_name_length,
-            (int) self->max_total_name_length,
-            (int) self->max_total_name_length_increment);
+    fprintf(out, "name_length = %d\tmax= %d\tincrement = %d)\n",
+            (int) self->name_length,
+            (int) self->max_name_length,
+            (int) self->max_name_length_increment);
     fprintf(out, TABLE_SEP);
     fprintf(out, "index\tflags\ttime\tpopulation\tname_length\tname\n");
-    offset = 0;
     for (j = 0; j < self->num_rows; j++) {
         fprintf(out, "%d\t%d\t%f\t%d\t%d\t", (int) j, self->flags[j], self->time[j],
-                (int) self->population[j], self->name_length[j]);
-        for (k = 0; k < self->name_length[j]; k++) {
-            assert(offset < self->total_name_length);
-            fprintf(out, "%c", self->name[offset]);
-            offset++;
+                (int) self->population[j], self->name_offset[j]);
+        for (k = self->name_offset[j]; k < self->name_offset[j + 1]; k++) {
+            fprintf(out, "%c", self->name[k]);
         }
         fprintf(out, "\n");
     }
+    assert(self->name_offset[0] == 0);
+    assert(self->name_offset[self->num_rows] == self->name_length);
 }
 
 bool
@@ -297,17 +315,17 @@ node_table_equal(node_table_t *self, node_table_t *other)
 {
     bool ret = false;
     if (self->num_rows == other->num_rows
-            && self->total_name_length == other->total_name_length) {
+            && self->name_length == other->name_length) {
         ret = memcmp(self->time, other->time,
                 self->num_rows * sizeof(double)) == 0
             && memcmp(self->flags, other->flags,
                     self->num_rows * sizeof(uint32_t)) == 0
             && memcmp(self->population, other->population,
                     self->num_rows * sizeof(population_id_t)) == 0
-            && memcmp(self->name_length, other->name_length,
-                    self->num_rows * sizeof(list_len_t)) == 0
+            && memcmp(self->name_offset, other->name_offset,
+                    (self->num_rows + 1) * sizeof(list_len_t)) == 0
             && memcmp(self->name, other->name,
-                    self->total_name_length * sizeof(char)) == 0;
+                    self->name_length * sizeof(char)) == 0;
     }
     return ret;
 }
@@ -484,15 +502,15 @@ static int
 site_table_expand_main_columns(site_table_t *self, size_t additional_rows)
 {
     int ret = 0;
-    size_t increment = GSL_MAX(additional_rows, self->max_rows_increment);
-    size_t new_size = self->max_rows + increment;
+    list_len_t increment = (list_len_t) GSL_MAX(additional_rows, self->max_rows_increment);
+    list_len_t new_size = self->max_rows + increment;
 
     if ((self->num_rows + additional_rows) > self->max_rows) {
         ret = expand_column((void **) &self->position, new_size, sizeof(double));
         if (ret != 0) {
             goto out;
         }
-        ret = expand_column((void **) &self->ancestral_state_length, new_size,
+        ret = expand_column((void **) &self->ancestral_state_offset, new_size + 1,
                 sizeof(uint32_t));
         if (ret != 0) {
             goto out;
@@ -507,17 +525,17 @@ static int
 site_table_expand_ancestral_state(site_table_t *self, size_t additional_length)
 {
     int ret = 0;
-    size_t increment = GSL_MAX(additional_length,
-            self->max_total_ancestral_state_length_increment);
-    size_t new_size = self->max_total_ancestral_state_length + increment;
+    list_len_t increment = (list_len_t) GSL_MAX(additional_length,
+            self->max_ancestral_state_length_increment);
+    list_len_t new_size = self->max_ancestral_state_length + increment;
 
-    if ((self->total_ancestral_state_length + additional_length)
-            > self->max_total_ancestral_state_length) {
+    if ((self->ancestral_state_length + additional_length)
+            > self->max_ancestral_state_length) {
         ret = expand_column((void **) &self->ancestral_state, new_size, sizeof(char));
         if (ret != 0) {
             goto out;
         }
-        self->max_total_ancestral_state_length = new_size;
+        self->max_ancestral_state_length = new_size;
     }
 out:
     return ret;
@@ -525,7 +543,7 @@ out:
 
 int
 site_table_alloc(site_table_t *self, size_t max_rows_increment,
-        size_t max_total_ancestral_state_length_increment)
+        size_t max_ancestral_state_length_increment)
 {
     int ret = 0;
 
@@ -533,16 +551,16 @@ site_table_alloc(site_table_t *self, size_t max_rows_increment,
     if (max_rows_increment == 0) {
         max_rows_increment = DEFAULT_SIZE_INCREMENT;
     }
-    if (max_total_ancestral_state_length_increment == 0) {
-        max_total_ancestral_state_length_increment = DEFAULT_SIZE_INCREMENT;
+    if (max_ancestral_state_length_increment == 0) {
+        max_ancestral_state_length_increment = DEFAULT_SIZE_INCREMENT;
     }
-    self->max_rows_increment = max_rows_increment;
+    self->max_rows_increment = (list_len_t) max_rows_increment;
     self->max_rows = 0;
     self->num_rows = 0;
-    self->max_total_ancestral_state_length_increment =
-        max_total_ancestral_state_length_increment;
-    self->max_total_ancestral_state_length = 0;
-    self->total_ancestral_state_length = 0;
+    self->max_ancestral_state_length_increment =
+        (list_len_t) max_ancestral_state_length_increment;
+    self->max_ancestral_state_length = 0;
+    self->ancestral_state_length = 0;
     ret = site_table_expand_main_columns(self, 1);
     if (ret != 0) {
         goto out;
@@ -551,6 +569,7 @@ site_table_alloc(site_table_t *self, size_t max_rows_increment,
     if (ret != 0) {
         goto out;
     }
+    self->ancestral_state_offset[0] = 0;
 out:
     return ret;
 }
@@ -560,7 +579,9 @@ site_table_add_row(site_table_t *self, double position, const char *ancestral_st
         list_len_t ancestral_state_length)
 {
     int ret = 0;
+    list_len_t offset = (list_len_t) self->ancestral_state_length;
 
+    assert(self->ancestral_state_offset[self->num_rows] == offset);
     ret = site_table_expand_main_columns(self, 1);
     if (ret != 0) {
         goto out;
@@ -569,47 +590,50 @@ site_table_add_row(site_table_t *self, double position, const char *ancestral_st
     if (ret != 0) {
         goto out;
     }
+    self->ancestral_state_length += ancestral_state_length;
     self->position[self->num_rows] = position;
-    self->ancestral_state_length[self->num_rows] = (uint32_t) ancestral_state_length;
-    memcpy(self->ancestral_state + self->total_ancestral_state_length,
-            ancestral_state, ancestral_state_length);
-    self->total_ancestral_state_length += ancestral_state_length;
+    memcpy(self->ancestral_state + offset, ancestral_state, ancestral_state_length);
     self->num_rows++;
+    self->ancestral_state_offset[self->num_rows] = self->ancestral_state_length;
 out:
     return ret;
 }
 
 int
 site_table_append_columns(site_table_t *self, size_t num_rows, double *position,
-        const char *ancestral_state, list_len_t *ancestral_state_length)
+        const char *ancestral_state, list_len_t *ancestral_state_offset)
 {
     int ret = 0;
-    size_t total_ancestral_state_length = 0;
-    size_t j;
+    list_len_t j, ancestral_state_length;
 
-    if (position == NULL || ancestral_state == NULL || ancestral_state_length == NULL) {
+    if (position == NULL || ancestral_state == NULL || ancestral_state_offset == NULL) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
 
-    for (j = 0; j < num_rows; j++) {
-        total_ancestral_state_length += ancestral_state_length[j];
-    }
+    ancestral_state_length = ancestral_state_offset[num_rows];
     ret = site_table_expand_main_columns(self, num_rows);
     if (ret != 0) {
         goto out;
     }
-    ret = site_table_expand_ancestral_state(self, total_ancestral_state_length);
+    ret = site_table_expand_ancestral_state(self, ancestral_state_length);
     if (ret != 0) {
         goto out;
     }
     memcpy(self->position + self->num_rows, position, num_rows * sizeof(double));
-    memcpy(self->ancestral_state + self->total_ancestral_state_length, ancestral_state,
-            total_ancestral_state_length * sizeof(char));
-    memcpy(self->ancestral_state_length + self->num_rows, ancestral_state_length,
-            num_rows * sizeof(uint32_t));
-    self->num_rows += num_rows;
-    self->total_ancestral_state_length += total_ancestral_state_length;
+    memcpy(self->ancestral_state + self->ancestral_state_length, ancestral_state,
+            ancestral_state_length * sizeof(char));
+    ret = check_offsets(num_rows, ancestral_state_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    for (j = 0; j < num_rows; j++) {
+        self->ancestral_state_offset[self->num_rows + j] =
+            (list_len_t) self->ancestral_state_length + ancestral_state_offset[j];
+    }
+    self->num_rows += (list_len_t) num_rows;
+    self->ancestral_state_length += ancestral_state_length;
+    self->ancestral_state_offset[self->num_rows] = self->ancestral_state_length;
 out:
     return ret;
 }
@@ -635,13 +659,13 @@ site_table_equal(site_table_t *self, site_table_t *other)
 {
     bool ret = false;
     if (self->num_rows == other->num_rows
-            && self->total_ancestral_state_length == other->total_ancestral_state_length) {
+            && self->ancestral_state_length == other->ancestral_state_length) {
         ret = memcmp(self->position, other->position,
                 self->num_rows * sizeof(double)) == 0
-            && memcmp(self->ancestral_state_length, other->ancestral_state_length,
-                    self->num_rows * sizeof(list_len_t)) == 0
+            && memcmp(self->ancestral_state_offset, other->ancestral_state_offset,
+                    (self->num_rows + 1) * sizeof(list_len_t)) == 0
             && memcmp(self->ancestral_state, other->ancestral_state,
-                    self->total_ancestral_state_length * sizeof(char)) == 0;
+                    self->ancestral_state_length * sizeof(char)) == 0;
     }
     return ret;
 }
@@ -650,7 +674,8 @@ int
 site_table_reset(site_table_t *self)
 {
     self->num_rows = 0;
-    self->total_ancestral_state_length = 0;
+    self->ancestral_state_length = 0;
+    self->ancestral_state_offset[0] = 0;
     return 0;
 }
 
@@ -659,35 +684,38 @@ site_table_free(site_table_t *self)
 {
     msp_safe_free(self->position);
     msp_safe_free(self->ancestral_state);
-    msp_safe_free(self->ancestral_state_length);
+    msp_safe_free(self->ancestral_state_offset);
     return 0;
 }
 
 void
 site_table_print_state(site_table_t *self, FILE *out)
 {
-    size_t j, k, ancestral_state_offset;
+    list_len_t j, k, offset, length;
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "site_table: %p:\n", (void *) self);
     fprintf(out, "num_rows = %d\tmax= %d\tincrement = %d)\n",
             (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "total_ancestral_state_length = %d\tmax= %d\tincrement = %d)\n",
-            (int) self->total_ancestral_state_length,
-            (int) self->max_total_ancestral_state_length,
-            (int) self->max_total_ancestral_state_length_increment);
+    fprintf(out, "ancestral_state_length = %d\tmax= %d\tincrement = %d)\n",
+            (int) self->ancestral_state_length,
+            (int) self->max_ancestral_state_length,
+            (int) self->max_ancestral_state_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tposition\tancestral_state_length\tancestral_state\n");
-    ancestral_state_offset = 0;
+    fprintf(out, "index\tposition\tancestral_state_offset\tancestral_state\n");
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%f\t%d\t", (int) j, self->position[j],
-                self->ancestral_state_length[j]);
-        for (k = 0; k < self->ancestral_state_length[j]; k++) {
-            fprintf(out, "%c", self->ancestral_state[ancestral_state_offset]);
-            ancestral_state_offset++;
+        offset = self->ancestral_state_offset[j];
+        length = self->ancestral_state_offset[j + 1] - offset;
+        fprintf(out, "%d\t%f\t%d\t", (int) j, self->position[j], offset);
+        for (k = 0; k < length; k++) {
+            fprintf(out, "%c", self->ancestral_state[offset + k]);
         }
         fprintf(out, "\n");
     }
+
+    assert(self->ancestral_state_offset[0] == 0);
+    assert(self->ancestral_state_length
+            == self->ancestral_state_offset[self->num_rows]);
 }
 
 /*************************
@@ -698,8 +726,8 @@ static int
 mutation_table_expand_main_columns(mutation_table_t *self, size_t additional_rows)
 {
     int ret = 0;
-    size_t increment = GSL_MAX(additional_rows, self->max_rows_increment);
-    size_t new_size = self->max_rows + increment;
+    list_len_t increment = (list_len_t) GSL_MAX(additional_rows, self->max_rows_increment);
+    list_len_t new_size = self->max_rows + increment;
 
     if ((self->num_rows + additional_rows) > self->max_rows) {
         ret = expand_column((void **) &self->site, new_size, sizeof(site_id_t));
@@ -714,8 +742,8 @@ mutation_table_expand_main_columns(mutation_table_t *self, size_t additional_row
         if (ret != 0) {
             goto out;
         }
-        ret = expand_column((void **) &self->derived_state_length, new_size,
-                sizeof(uint32_t));
+        ret = expand_column((void **) &self->derived_state_offset, new_size + 1,
+                sizeof(list_len_t));
         if (ret != 0) {
             goto out;
         }
@@ -729,17 +757,17 @@ static int
 mutation_table_expand_derived_state(mutation_table_t *self, size_t additional_length)
 {
     int ret = 0;
-    size_t increment = GSL_MAX(additional_length,
-            self->max_total_derived_state_length_increment);
-    size_t new_size = self->max_total_derived_state_length + increment;
+    list_len_t increment = (list_len_t) GSL_MAX(additional_length,
+            self->max_derived_state_length_increment);
+    list_len_t new_size = self->max_derived_state_length + increment;
 
-    if ((self->total_derived_state_length + additional_length)
-            > self->max_total_derived_state_length) {
+    if ((self->derived_state_length + additional_length)
+            > self->max_derived_state_length) {
         ret = expand_column((void **) &self->derived_state, new_size, sizeof(char));
         if (ret != 0) {
             goto out;
         }
-        self->max_total_derived_state_length = new_size;
+        self->max_derived_state_length = (list_len_t) new_size;
     }
 out:
     return ret;
@@ -747,7 +775,7 @@ out:
 
 int
 mutation_table_alloc(mutation_table_t *self, size_t max_rows_increment,
-        size_t max_total_derived_state_length_increment)
+        size_t max_derived_state_length_increment)
 {
     int ret = 0;
 
@@ -755,16 +783,16 @@ mutation_table_alloc(mutation_table_t *self, size_t max_rows_increment,
     if (max_rows_increment == 0) {
         max_rows_increment = DEFAULT_SIZE_INCREMENT;
     }
-    if (max_total_derived_state_length_increment == 0) {
-        max_total_derived_state_length_increment = DEFAULT_SIZE_INCREMENT;
+    if (max_derived_state_length_increment == 0) {
+        max_derived_state_length_increment = DEFAULT_SIZE_INCREMENT;
     }
-    self->max_rows_increment = max_rows_increment;
+    self->max_rows_increment = (list_len_t) max_rows_increment;
     self->max_rows = 0;
     self->num_rows = 0;
-    self->max_total_derived_state_length_increment =
-        max_total_derived_state_length_increment;
-    self->max_total_derived_state_length = 0;
-    self->total_derived_state_length = 0;
+    self->max_derived_state_length_increment =
+        (list_len_t) max_derived_state_length_increment;
+    self->max_derived_state_length = 0;
+    self->derived_state_length = 0;
     ret = mutation_table_expand_main_columns(self, 1);
     if (ret != 0) {
         goto out;
@@ -773,6 +801,7 @@ mutation_table_alloc(mutation_table_t *self, size_t max_rows_increment,
     if (ret != 0) {
         goto out;
     }
+    self->derived_state_offset[0] = 0;
 out:
     return ret;
 }
@@ -782,7 +811,9 @@ mutation_table_add_row(mutation_table_t *self, site_id_t site, node_id_t node,
         mutation_id_t parent, const char *derived_state, list_len_t derived_state_length)
 {
     int ret = 0;
+    list_len_t offset = (list_len_t) self->derived_state_length;
 
+    assert(self->derived_state_offset[self->num_rows] == offset);
     ret = mutation_table_expand_main_columns(self, 1);
     if (ret != 0) {
         goto out;
@@ -794,11 +825,10 @@ mutation_table_add_row(mutation_table_t *self, site_id_t site, node_id_t node,
     self->site[self->num_rows] = site;
     self->node[self->num_rows] = node;
     self->parent[self->num_rows] = parent;
-    self->derived_state_length[self->num_rows] = (list_len_t) derived_state_length;
-    memcpy(self->derived_state + self->total_derived_state_length, derived_state,
-            derived_state_length * sizeof(char));
-    self->total_derived_state_length += derived_state_length;
+    self->derived_state_length += derived_state_length;
+    memcpy(self->derived_state + offset, derived_state, derived_state_length);
     self->num_rows++;
+    self->derived_state_offset[self->num_rows] = self->derived_state_length;
 out:
     return ret;
 }
@@ -806,14 +836,14 @@ out:
 int
 mutation_table_append_columns(mutation_table_t *self, size_t num_rows, site_id_t *site,
         node_id_t *node, mutation_id_t *parent,
-        const char *derived_state, uint32_t *derived_state_length)
+        const char *derived_state, list_len_t *derived_state_offset)
 {
     int ret = 0;
-    size_t total_derived_state_length = 0;
+    size_t derived_state_length = 0;
     size_t j;
 
     if (site == NULL || node == NULL || derived_state == NULL
-            || derived_state_length == NULL) {
+            || derived_state_offset == NULL) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
@@ -821,27 +851,32 @@ mutation_table_append_columns(mutation_table_t *self, size_t num_rows, site_id_t
     if (ret != 0) {
         goto out;
     }
-    for (j = 0; j < num_rows; j++) {
-        total_derived_state_length += (size_t) derived_state_length[j];
-    }
-    ret = mutation_table_expand_derived_state(self, total_derived_state_length);
+    derived_state_length = derived_state_offset[num_rows];
+    ret = mutation_table_expand_derived_state(self, derived_state_length);
     if (ret != 0) {
         goto out;
     }
     memcpy(self->site + self->num_rows, site, num_rows * sizeof(site_id_t));
     memcpy(self->node + self->num_rows, node, num_rows * sizeof(node_id_t));
-    memcpy(self->derived_state_length + self->num_rows, derived_state_length,
-            num_rows * sizeof(node_id_t));
-    memcpy(self->derived_state + self->total_derived_state_length, derived_state,
-            total_derived_state_length * sizeof(char));
+    memcpy(self->derived_state + self->derived_state_length, derived_state,
+            derived_state_length * sizeof(char));
+    ret = check_offsets(num_rows, derived_state_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    for (j = 0; j < num_rows; j++) {
+        self->derived_state_offset[self->num_rows + j] =
+            (list_len_t) self->derived_state_length + derived_state_offset[j];
+    }
     if (parent == NULL) {
         /* If parent is NULL, set all parents to the null mutation */
         memset(self->parent + self->num_rows, 0xff, num_rows * sizeof(mutation_id_t));
     } else {
         memcpy(self->parent + self->num_rows, parent, num_rows * sizeof(mutation_id_t));
     }
-    self->num_rows += num_rows;
-    self->total_derived_state_length += total_derived_state_length;
+    self->num_rows += (list_len_t) num_rows;
+    self->derived_state_length += (list_len_t) derived_state_length;
+    self->derived_state_offset[self->num_rows] = self->derived_state_length;
 out:
     return ret;
 }
@@ -849,7 +884,7 @@ out:
 int
 mutation_table_set_columns(mutation_table_t *self, size_t num_rows, site_id_t *site,
         node_id_t *node, mutation_id_t *parent,
-        const char *derived_state, uint32_t *derived_state_length)
+        const char *derived_state, list_len_t *derived_state_offset)
 {
     int ret = 0;
 
@@ -857,8 +892,8 @@ mutation_table_set_columns(mutation_table_t *self, size_t num_rows, site_id_t *s
     if (ret != 0) {
         goto out;
     }
-    ret = mutation_table_append_columns(self, num_rows ,site, node, parent,
-            derived_state, derived_state_length);
+    ret = mutation_table_append_columns(self, num_rows, site, node, parent,
+            derived_state, derived_state_offset);
 out:
     return ret;
 }
@@ -868,15 +903,15 @@ mutation_table_equal(mutation_table_t *self, mutation_table_t *other)
 {
     bool ret = false;
     if (self->num_rows == other->num_rows
-            && self->total_derived_state_length == other->total_derived_state_length) {
+            && self->derived_state_length == other->derived_state_length) {
         ret = memcmp(self->site, other->site, self->num_rows * sizeof(site_id_t)) == 0
             && memcmp(self->node, other->node, self->num_rows * sizeof(node_id_t)) == 0
             && memcmp(self->parent, other->parent,
                     self->num_rows * sizeof(mutation_id_t)) == 0
-            && memcmp(self->derived_state_length, other->derived_state_length,
-                    self->num_rows * sizeof(list_len_t)) == 0
+            && memcmp(self->derived_state_offset, other->derived_state_offset,
+                    (self->num_rows + 1) * sizeof(list_len_t)) == 0
             && memcmp(self->derived_state, other->derived_state,
-                    self->total_derived_state_length * sizeof(char)) == 0;
+                    self->derived_state_length * sizeof(char)) == 0;
     }
     return ret;
 }
@@ -885,7 +920,8 @@ int
 mutation_table_reset(mutation_table_t *self)
 {
     self->num_rows = 0;
-    self->total_derived_state_length = 0;
+    self->derived_state_length = 0;
+    self->derived_state_offset[0] = 0;
     return 0;
 }
 
@@ -896,7 +932,7 @@ mutation_table_free(mutation_table_t *self)
     msp_safe_free(self->site);
     msp_safe_free(self->parent);
     msp_safe_free(self->derived_state);
-    msp_safe_free(self->derived_state_length);
+    msp_safe_free(self->derived_state_offset);
     return 0;
 }
 
@@ -910,21 +946,26 @@ mutation_table_print_state(mutation_table_t *self, FILE *out)
     fprintf(out, "num_rows = %d\tmax= %d\tincrement = %d)\n",
             (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
     fprintf(out, "derived_state_length = %d\tmax= %d\tincrement = %d)\n",
-            (int) self->total_derived_state_length,
-            (int) self->max_total_derived_state_length,
-            (int) self->max_total_derived_state_length_increment);
+            (int) self->derived_state_length,
+            (int) self->max_derived_state_length,
+            (int) self->max_derived_state_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tsite\tnode\tparent\tderived_state_length\tderived_state\n");
+    fprintf(out, "index\tsite\tnode\tparent\tderived_state_offset\tderived_state\n");
     offset = 0;
     for (j = 0; j < self->num_rows; j++) {
         fprintf(out, "%d\t%d\t%d\t%d\t%d\t", (int) j, self->site[j], self->node[j],
-                self->parent[j], self->derived_state_length[j]);
-        for (k = 0; k < self->derived_state_length[j]; k++) {
+                self->parent[j], self->derived_state_offset[j]);
+        for (k = self->derived_state_offset[j];
+                k < self->derived_state_offset[j + 1]; k++) {
             fprintf(out, "%c", self->derived_state[offset]);
             offset++;
         }
         fprintf(out, "\n");
     }
+
+    assert(self->derived_state_offset[0] == 0);
+    assert(self->derived_state_length
+            == self->derived_state_offset[self->num_rows]);
 }
 
 /*************************
@@ -1192,7 +1233,7 @@ table_sorter_alloc(table_sorter_t *self, node_table_t *nodes, edge_table_t *edge
             goto out;
         }
         self->sorted_sites = malloc(sites->num_rows * sizeof(site_t));
-        self->ancestral_state_mem = malloc(sites->total_ancestral_state_length * sizeof(char));
+        self->ancestral_state_mem = malloc(sites->ancestral_state_length * sizeof(char));
         self->site_id_map = malloc(sites->num_rows * sizeof(site_id_t));
         if (self->sorted_sites == NULL || self->ancestral_state_mem == NULL
                 || self->site_id_map == NULL) {
@@ -1200,7 +1241,7 @@ table_sorter_alloc(table_sorter_t *self, node_table_t *nodes, edge_table_t *edge
             goto out;
         }
         self->sorted_mutations = malloc(mutations->num_rows * sizeof(mutation_t));
-        self->derived_state_mem = malloc(mutations->total_derived_state_length * sizeof(char));
+        self->derived_state_mem = malloc(mutations->derived_state_length * sizeof(char));
         if (self->sorted_mutations == NULL || self->derived_state_mem == NULL) {
             ret = MSP_ERR_NO_MEMORY;
             goto out;
@@ -1249,31 +1290,32 @@ static int
 table_sorter_sort_sites(table_sorter_t *self)
 {
     int ret = 0;
-    size_t j, ancestral_state_offset;
+    list_len_t j, offset, length;
 
     memcpy(self->ancestral_state_mem, self->sites->ancestral_state,
-            self->sites->total_ancestral_state_length * sizeof(char));
-    ancestral_state_offset = 0;
+            self->sites->ancestral_state_length * sizeof(char));
     for (j = 0; j < self->sites->num_rows; j++) {
         self->sorted_sites[j].id = (site_id_t) j;
         self->sorted_sites[j].position = self->sites->position[j];
-        self->sorted_sites[j].ancestral_state_length = self->sites->ancestral_state_length[j];
-        self->sorted_sites[j].ancestral_state = self->ancestral_state_mem
-            + ancestral_state_offset;
-        ancestral_state_offset += self->sites->ancestral_state_length[j];
+        offset = self->sites->ancestral_state_offset[j];
+        length = self->sites->ancestral_state_offset[j + 1] - offset;
+        self->sorted_sites[j].ancestral_state_length = length;
+        self->sorted_sites[j].ancestral_state = self->ancestral_state_mem + offset;
     }
     /* Sort the sites by position */
     qsort(self->sorted_sites, self->sites->num_rows, sizeof(site_t), cmp_site);
     /* Build the mapping from old site IDs to new site IDs and copy back into the table */
-    ancestral_state_offset = 0;
+    offset = 0;
     for (j = 0; j < self->sites->num_rows; j++) {
         self->site_id_map[self->sorted_sites[j].id] = (site_id_t) j;
         self->sites->position[j] = self->sorted_sites[j].position;
-        self->sites->ancestral_state_length[j] = self->sorted_sites[j].ancestral_state_length;
-        memcpy(self->sites->ancestral_state + ancestral_state_offset,
-            self->sorted_sites[j].ancestral_state, self->sorted_sites[j].ancestral_state_length);
-        ancestral_state_offset += self->sorted_sites[j].ancestral_state_length;
+        self->sites->ancestral_state_offset[j] = offset;
+        memcpy(self->sites->ancestral_state + offset,
+            self->sorted_sites[j].ancestral_state,
+            self->sorted_sites[j].ancestral_state_length);
+        offset += self->sorted_sites[j].ancestral_state_length;
     }
+    self->sites->ancestral_state_offset[self->sites->num_rows] = offset;
     return ret;
 }
 
@@ -1281,16 +1323,15 @@ static int
 table_sorter_sort_mutations(table_sorter_t *self)
 {
     int ret = 0;
-    size_t j, derived_state_offset;
     site_id_t site;
     node_id_t node;
+    list_len_t j, offset, length;
     mutation_id_t parent, mapped_parent;
     mutation_id_t *mutation_id_map = malloc(self->mutations->num_rows
             * sizeof(mutation_id_t));
 
     memcpy(self->derived_state_mem, self->mutations->derived_state,
-            self->mutations->total_derived_state_length * sizeof(char));
-    derived_state_offset = 0;
+            self->mutations->derived_state_length * sizeof(char));
     for (j = 0; j < self->mutations->num_rows; j++) {
         site = self->mutations->site[j];
         if (site >= (site_id_t) self->sites->num_rows) {
@@ -1309,26 +1350,25 @@ table_sorter_sort_mutations(table_sorter_t *self)
                 goto out;
             }
         }
+        offset = self->mutations->derived_state_offset[j];
+        length = self->mutations->derived_state_offset[j + 1] - offset;
         self->sorted_mutations[j].id = (mutation_id_t) j;
         self->sorted_mutations[j].site = self->site_id_map[site];
         self->sorted_mutations[j].node = node;
         self->sorted_mutations[j].parent = self->mutations->parent[j];
-        self->sorted_mutations[j].derived_state_length =
-            self->mutations->derived_state_length[j];
-        self->sorted_mutations[j].derived_state = self->derived_state_mem
-            + derived_state_offset;
-        derived_state_offset += self->mutations->derived_state_length[j];
+        self->sorted_mutations[j].derived_state_length = length;
+        self->sorted_mutations[j].derived_state = self->derived_state_mem + offset;
     }
 
     qsort(self->sorted_mutations, self->mutations->num_rows, sizeof(mutation_t),
         cmp_mutation);
+
     /* Make a first pass through the sorted mutations to build the ID map. */
     for (j = 0; j < self->mutations->num_rows; j++) {
         mutation_id_map[self->sorted_mutations[j].id] = (mutation_id_t) j;
     }
-
+    offset = 0;
     /* Copy the sorted mutations back into the table */
-    derived_state_offset = 0;
     for (j = 0; j < self->mutations->num_rows; j++) {
         self->mutations->site[j] = self->sorted_mutations[j].site;
         self->mutations->node[j] = self->sorted_mutations[j].node;
@@ -1338,13 +1378,12 @@ table_sorter_sort_mutations(table_sorter_t *self)
             mapped_parent = mutation_id_map[parent];
         }
         self->mutations->parent[j] = mapped_parent;
-        self->mutations->derived_state_length[j] =
-            self->sorted_mutations[j].derived_state_length;
-        memcpy(self->mutations->derived_state + derived_state_offset,
+        memcpy(self->mutations->derived_state + offset,
             self->sorted_mutations[j].derived_state,
             self->sorted_mutations[j].derived_state_length * sizeof(char));
-        derived_state_offset += self->sorted_mutations[j].derived_state_length;
+        offset += self->sorted_mutations[j].derived_state_length;
     }
+    self->mutations->derived_state_offset[self->mutations->num_rows] = offset;
 out:
     msp_safe_free(mutation_id_map);
     return ret;
@@ -1625,7 +1664,8 @@ static int WARN_UNUSED
 simplifier_record_node(simplifier_t *self, node_id_t input_id, bool is_sample)
 {
     int ret = 0;
-    const char *name = self->input_nodes.name + self->node_name_offset[input_id];
+    list_len_t offset = self->input_nodes.name_offset[input_id];
+    list_len_t length = self->input_nodes.name_offset[input_id + 1] - offset;
     uint32_t flags = self->input_nodes.flags[input_id];
 
     /* Zero out the sample bit */
@@ -1636,7 +1676,7 @@ simplifier_record_node(simplifier_t *self, node_id_t input_id, bool is_sample)
     self->node_id_map[input_id] = (node_id_t) self->nodes->num_rows;
     ret = node_table_add_row_internal(self->nodes, flags,
             self->input_nodes.time[input_id], self->input_nodes.population[input_id],
-            self->input_nodes.name_length[input_id], name);
+            self->input_nodes.name + offset, length);
     if (ret != 0) {
         goto out;
     }
@@ -1917,7 +1957,7 @@ simplifier_alloc(simplifier_t *self, double sequence_length,
         size_t max_buffered_edges, int flags)
 {
     int ret = 0;
-    size_t j, offset, max_alloc_block, num_nodes_alloc, num_edges_alloc;
+    size_t j, max_alloc_block, num_nodes_alloc, num_edges_alloc;
 
     memset(self, 0, sizeof(simplifier_t));
     self->num_samples = num_samples;
@@ -1966,12 +2006,12 @@ simplifier_alloc(simplifier_t *self, double sequence_length,
     }
 
     /* Make a copy of the input nodes and clear the table ready for output */
-    ret = node_table_alloc(&self->input_nodes, nodes->num_rows, nodes->total_name_length);
+    ret = node_table_alloc(&self->input_nodes, nodes->num_rows, nodes->name_length);
     if (ret != 0) {
         goto out;
     }
     ret = node_table_set_columns(&self->input_nodes, nodes->num_rows,
-            nodes->flags, nodes->time, nodes->population, nodes->name, nodes->name_length);
+            nodes->flags, nodes->time, nodes->population, nodes->name, nodes->name_offset);
     if (ret != 0) {
         goto out;
     }
@@ -1979,18 +2019,6 @@ simplifier_alloc(simplifier_t *self, double sequence_length,
     if (ret != 0) {
         goto out;
     }
-    /* Build the offset table so we can map node names */
-    self->node_name_offset = malloc(num_nodes_alloc * sizeof(size_t));
-    if (self->node_name_offset == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-    offset = 0;
-    for (j = 0; j < self->input_nodes.num_rows; j++) {
-        self->node_name_offset[j] = offset;
-        offset += self->input_nodes.name_length[j];
-    }
-
     /* Make a copy of the input edges and clear the input table, ready for output. */
     ret = edge_table_alloc(&self->input_edges, edges->num_rows);
     if (ret != 0) {
@@ -2018,12 +2046,12 @@ simplifier_alloc(simplifier_t *self, double sequence_length,
 
     /* Make a copy of the input sites and clear the input table, ready for output. */
     ret = site_table_alloc(&self->input_sites, sites->num_rows,
-            sites->total_ancestral_state_length);
+            sites->ancestral_state_length);
     if (ret != 0) {
         goto out;
     }
     ret = site_table_set_columns(&self->input_sites, sites->num_rows,
-            sites->position, sites->ancestral_state, sites->ancestral_state_length);
+            sites->position, sites->ancestral_state, sites->ancestral_state_offset);
     if (ret != 0) {
         goto out;
     }
@@ -2034,13 +2062,13 @@ simplifier_alloc(simplifier_t *self, double sequence_length,
 
     /* Make a copy of the input mutations and clear the input table, ready for output. */
     ret = mutation_table_alloc(&self->input_mutations, mutations->num_rows,
-            mutations->total_derived_state_length);
+            mutations->derived_state_length);
     if (ret != 0) {
         goto out;
     }
     ret = mutation_table_set_columns(&self->input_mutations, mutations->num_rows,
             mutations->site, mutations->node, mutations->parent,
-            mutations->derived_state, mutations->derived_state_length);
+            mutations->derived_state, mutations->derived_state_offset);
     if (ret != 0) {
         goto out;
     }
@@ -2470,6 +2498,7 @@ simplifier_output_sites(simplifier_t *self)
 {
     int ret = 0;
     site_id_t input_site;
+    list_len_t offset, length;
     mutation_id_t input_mutation, mapped_parent ,site_start, site_end;
     site_id_t num_input_sites = (site_id_t) self->input_sites.num_rows;
     mutation_id_t num_input_mutations = (mutation_id_t) self->input_mutations.num_rows;
@@ -2480,9 +2509,8 @@ simplifier_output_sites(simplifier_t *self)
 
     /* TODO Implement the checks below for ancestral state and derived state properly when
      * we've added the _offset columns to the tables. */
-    assert(self->input_sites.total_ancestral_state_length
-            == self->input_sites.num_rows);
-    assert(self->input_mutations.total_derived_state_length
+    assert(self->input_sites.ancestral_state_length == self->input_sites.num_rows);
+    assert(self->input_mutations.derived_state_length
             == self->input_mutations.num_rows);
 
     input_mutation = 0;
@@ -2534,23 +2562,23 @@ simplifier_output_sites(simplifier_t *self)
                     if (mapped_parent != MSP_NULL_MUTATION) {
                         mapped_parent = self->mutation_id_map[mapped_parent];
                     }
+                    offset = self->input_mutations.derived_state_offset[input_mutation];
+                    length = self->input_mutations.derived_state_offset[input_mutation + 1]
+                        - offset;
                     ret = mutation_table_add_row(self->mutations,
                             (site_id_t) self->sites->num_rows,
                             mapped_node, mapped_parent,
-                            /* FIXME do this properly when derived_state_offset is
-                             * implemented */
-                            self->input_mutations.derived_state + input_mutation,
-                            self->input_mutations.derived_state_length[input_mutation]);
+                            self->input_mutations.derived_state + offset, length);
                     if (ret != 0) {
                         goto out;
                     }
                 }
             }
+            offset = self->input_sites.ancestral_state_offset[input_site];
+            length = self->input_sites.ancestral_state_offset[input_site + 1] - offset;
             ret = site_table_add_row(self->sites,
                     self->input_sites.position[input_site],
-                    /* FIXME do this properly when ancestral_state_offset is implemented */
-                    self->input_sites.ancestral_state + input_site,
-                    self->input_sites.ancestral_state_length[input_site]);
+                    self->input_sites.ancestral_state + offset, length);
             if (ret != 0) {
                 goto out;
             }

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6560,40 +6560,40 @@ test_provenance_table(void)
     const char *test_timestamp = "2017-12-06T20:40:25+00:00";
     size_t test_timestamp_length = strlen(test_timestamp);
     char timestamp_copy[test_timestamp_length + 1];
-    char *provenance;
-    uint32_t *provenance_offset;
-    const char *test_provenance = "{\"json\"=1234}";
-    size_t test_provenance_length = strlen(test_provenance);
-    char provenance_copy[test_provenance_length + 1];
+    char *record;
+    uint32_t *record_offset;
+    const char *test_record = "{\"json\"=1234}";
+    size_t test_record_length = strlen(test_record);
+    char record_copy[test_record_length + 1];
 
     timestamp_copy[test_timestamp_length] = '\0';
-    provenance_copy[test_provenance_length] = '\0';
+    record_copy[test_record_length] = '\0';
     ret = provenance_table_alloc(&table, 1, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     provenance_table_print_state(&table, _devnull);
 
     for (j = 0; j < num_rows; j++) {
         ret = provenance_table_add_row(&table, test_timestamp, test_timestamp_length,
-                test_provenance, test_provenance_length);
+                test_record, test_record_length);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_EQUAL(table.timestamp_length, (j + 1) * test_timestamp_length);
         CU_ASSERT_EQUAL(table.timestamp_offset[j + 1], table.timestamp_length);
-        CU_ASSERT_EQUAL(table.provenance_length, (j + 1) * test_provenance_length);
-        CU_ASSERT_EQUAL(table.provenance_offset[j + 1], table.provenance_length);
+        CU_ASSERT_EQUAL(table.record_length, (j + 1) * test_record_length);
+        CU_ASSERT_EQUAL(table.record_offset[j + 1], table.record_length);
         /* check the timestamp */
         memcpy(timestamp_copy, table.timestamp + table.timestamp_offset[j],
                 test_timestamp_length);
         CU_ASSERT_NSTRING_EQUAL(timestamp_copy, test_timestamp, test_timestamp_length);
-        /* check the provenance */
-        memcpy(provenance_copy, table.provenance + table.provenance_offset[j],
-                test_provenance_length);
-        CU_ASSERT_NSTRING_EQUAL(provenance_copy, test_provenance, test_provenance_length);
+        /* check the record */
+        memcpy(record_copy, table.record + table.record_offset[j],
+                test_record_length);
+        CU_ASSERT_NSTRING_EQUAL(record_copy, test_record, test_record_length);
     }
     provenance_table_print_state(&table, _devnull);
     provenance_table_reset(&table);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.timestamp_length, 0);
-    CU_ASSERT_EQUAL(table.provenance_length, 0);
+    CU_ASSERT_EQUAL(table.record_length, 0);
 
     num_rows *= 2;
     timestamp = malloc(num_rows * sizeof(char));
@@ -6601,61 +6601,61 @@ test_provenance_table(void)
     CU_ASSERT_FATAL(timestamp != NULL);
     timestamp_offset = malloc((num_rows + 1) * sizeof(list_len_t));
     CU_ASSERT_FATAL(timestamp_offset != NULL);
-    provenance = malloc(num_rows * sizeof(char));
-    memset(provenance, 'a', num_rows * sizeof(char));
-    CU_ASSERT_FATAL(provenance != NULL);
-    provenance_offset = malloc((num_rows + 1) * sizeof(list_len_t));
-    CU_ASSERT_FATAL(provenance_offset != NULL);
+    record = malloc(num_rows * sizeof(char));
+    memset(record, 'a', num_rows * sizeof(char));
+    CU_ASSERT_FATAL(record != NULL);
+    record_offset = malloc((num_rows + 1) * sizeof(list_len_t));
+    CU_ASSERT_FATAL(record_offset != NULL);
     for (j = 0; j < num_rows + 1; j++) {
         timestamp_offset[j] = j;
-        provenance_offset[j] = j;
+        record_offset[j] = j;
     }
     ret = provenance_table_set_columns(&table, num_rows,
-            timestamp, timestamp_offset, provenance, provenance_offset);
+            timestamp, timestamp_offset, record, record_offset);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.timestamp, timestamp, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.timestamp_offset, timestamp_offset,
                 (num_rows + 1) * sizeof(list_len_t)), 0);
-    CU_ASSERT_EQUAL(memcmp(table.provenance, provenance, num_rows * sizeof(char)), 0);
-    CU_ASSERT_EQUAL(memcmp(table.provenance_offset, provenance_offset,
+    CU_ASSERT_EQUAL(memcmp(table.record, record, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.record_offset, record_offset,
                 (num_rows + 1) * sizeof(list_len_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.timestamp_length, num_rows);
-    CU_ASSERT_EQUAL(table.provenance_length, num_rows);
+    CU_ASSERT_EQUAL(table.record_length, num_rows);
     provenance_table_print_state(&table, _devnull);
 
     /* Append another num_rows onto the end */
     ret = provenance_table_append_columns(&table, num_rows,
-            timestamp, timestamp_offset, provenance, provenance_offset);
+            timestamp, timestamp_offset, record, record_offset);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.timestamp, timestamp, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.timestamp + num_rows, timestamp, num_rows * sizeof(char)), 0);
-    CU_ASSERT_EQUAL(memcmp(table.provenance, provenance, num_rows * sizeof(char)), 0);
-    CU_ASSERT_EQUAL(memcmp(table.provenance + num_rows, provenance, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.record, record, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.record + num_rows, record, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.timestamp_length, 2 * num_rows);
-    CU_ASSERT_EQUAL(table.provenance_length, 2 * num_rows);
+    CU_ASSERT_EQUAL(table.record_length, 2 * num_rows);
     provenance_table_print_state(&table, _devnull);
 
     /* No arguments can be null */
     ret = provenance_table_set_columns(&table, num_rows, NULL, timestamp_offset,
-            provenance, provenance_offset);
+            record, record_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     ret = provenance_table_set_columns(&table, num_rows, timestamp, NULL,
-            provenance, provenance_offset);
+            record, record_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     ret = provenance_table_set_columns(&table, num_rows, timestamp, timestamp_offset,
-            NULL, provenance_offset);
+            NULL, record_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     ret = provenance_table_set_columns(&table, num_rows, timestamp, timestamp_offset,
-            provenance, NULL);
+            record, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
 
     provenance_table_free(&table);
     free(timestamp);
     free(timestamp_offset);
-    free(provenance);
-    free(provenance_offset);
+    free(record);
+    free(record_offset);
 }
 
 

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -481,8 +481,8 @@ tree_sequence_from_text(tree_sequence_t *ts, double sequence_length,
     }
     ret = tree_sequence_initialise(ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(ts, sequence_length, &node_table, &edge_table,
-            &migration_table, &site_table, &mutation_table, 0, NULL);
+    ret = tree_sequence_load_tables(ts, sequence_length, &node_table, &edge_table,
+            &migration_table, &site_table, &mutation_table, NULL, 0);
     /* tree_sequence_print_state(ts, stdout); */
     /* printf("ret = %s\n", msp_strerror(ret)); */
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1245,7 +1245,7 @@ get_example_tree_sequence(uint32_t num_samples,
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutgen_populate_tables(mutgen, sites, mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(tree_seq, 0, nodes, edges, migrations,
+    ret = tree_sequence_load_tables(tree_seq, 0, nodes, edges, migrations,
             sites, mutations, 1, provenance);
     /* edge_table_print_state(edges, stdout); */
     /* printf("ret = %s\n", msp_strerror(ret)); */
@@ -1383,7 +1383,7 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, 0, &nodes, &edges, &migrations,
+    ret = tree_sequence_load_tables(new_ts, 0, &nodes, &edges, &migrations,
             &sites, &mutations, num_provenance_strings, provenance_strings);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -1463,7 +1463,7 @@ make_permuted_nodes_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, 0, &nodes, &edges, &migrations,
+    ret = tree_sequence_load_tables(new_ts, 0, &nodes, &edges, &migrations,
             &sites, &mutations, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -1534,7 +1534,7 @@ make_gappy_copy(tree_sequence_t *ts)
 
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, ts->sequence_length + 1,
+    ret = tree_sequence_load_tables(new_ts, ts->sequence_length + 1,
             &nodes, &edges, &migrations, &sites, &mutations, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -1591,7 +1591,7 @@ make_decapitated_copy(tree_sequence_t *ts)
 
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(new_ts, 0, &nodes, &edges, &migrations,
+    ret = tree_sequence_load_tables(new_ts, 0, &nodes, &edges, &migrations,
             &sites, &mutations, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -1940,10 +1940,10 @@ test_empty_tree_sequence(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Zero length TS is invalid. */
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SEQUENCE_LENGTH);
-    ret = tree_sequence_load_tables_tmp(&ts, 1, &node_table, &edge_table,
+    ret = tree_sequence_load_tables(&ts, 1, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -2692,7 +2692,7 @@ test_simplest_bad_records(void)
     /* Make sure we have a good set of records */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
@@ -2700,21 +2700,21 @@ test_simplest_bad_records(void)
     /* NULL for nodes or edges should be an error */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, NULL, NULL, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, NULL, NULL, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, NULL, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, NULL, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, NULL, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, NULL, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
@@ -2723,7 +2723,7 @@ test_simplest_bad_records(void)
     edge_table.right[0] = 0.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
@@ -2733,7 +2733,7 @@ test_simplest_bad_records(void)
     edge_table.right[0] = 2.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 1, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 1, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_RIGHT_GREATER_SEQ_LENGTH);
     tree_sequence_free(&ts);
@@ -2743,7 +2743,7 @@ test_simplest_bad_records(void)
     edge_table.child[0] = 1;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_DUPLICATE_EDGES);
     tree_sequence_free(&ts);
@@ -2754,7 +2754,7 @@ test_simplest_bad_records(void)
     edge_table.left[0] = 0.5;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_LEFT);
     tree_sequence_free(&ts);
@@ -2765,7 +2765,7 @@ test_simplest_bad_records(void)
     edge_table.child[1] = 2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_NODE_TIME_ORDERING);
     tree_sequence_free(&ts);
@@ -2776,7 +2776,7 @@ test_simplest_bad_records(void)
     edge_table.child[1] = 0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_CHILD);
     tree_sequence_free(&ts);
@@ -2791,7 +2791,7 @@ test_simplest_bad_records(void)
     edge_table.child[2] = 1;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NONCONTIGUOUS_PARENTS);
     tree_sequence_free(&ts);
@@ -2804,7 +2804,7 @@ test_simplest_bad_records(void)
     edge_table.parent[0] = MSP_NULL_NODE;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NULL_PARENT);
     tree_sequence_free(&ts);
@@ -2814,7 +2814,7 @@ test_simplest_bad_records(void)
     node_table.num_rows = 2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -2824,7 +2824,7 @@ test_simplest_bad_records(void)
     edge_table.parent[0] = -2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -2834,7 +2834,7 @@ test_simplest_bad_records(void)
     edge_table.child[0] = MSP_NULL_NODE;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NULL_CHILD);
     tree_sequence_free(&ts);
@@ -2844,7 +2844,7 @@ test_simplest_bad_records(void)
     edge_table.child[0] = 100;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -2854,7 +2854,7 @@ test_simplest_bad_records(void)
     edge_table.child[0] = -2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -2863,7 +2863,7 @@ test_simplest_bad_records(void)
     /* Make sure we've preserved a good tree sequence */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
@@ -2902,7 +2902,7 @@ test_simplest_overlapping_parents(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     edge_table.left[0] = 0;
     edge_table.parent[0] = 2;
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_alloc(&tree, &ts, 0);
@@ -2954,7 +2954,7 @@ test_simplest_contradictory_children(void)
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_alloc(&tree, &ts, 0);
@@ -3303,7 +3303,7 @@ test_single_tree_bad_records(void)
     node_table.time[5] = 0.5;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_PARENT_TIME);
     tree_sequence_free(&ts);
@@ -3313,7 +3313,7 @@ test_single_tree_bad_records(void)
     edge_table.left[2] = 2.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
@@ -3321,7 +3321,7 @@ test_single_tree_bad_records(void)
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
@@ -3431,7 +3431,7 @@ test_single_tree_bad_mutations(void)
     /* Check to make sure we have legal mutations */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
@@ -3442,7 +3442,7 @@ test_single_tree_bad_mutations(void)
     site_table.position[0] = -1.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
@@ -3452,7 +3452,7 @@ test_single_tree_bad_mutations(void)
     site_table.position[2] = 1.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
@@ -3462,7 +3462,7 @@ test_single_tree_bad_mutations(void)
     site_table.position[2] = 1.1;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
@@ -3472,7 +3472,7 @@ test_single_tree_bad_mutations(void)
     site_table.position[0] = 0.3;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_UNSORTED_SITES);
     tree_sequence_free(&ts);
@@ -3482,7 +3482,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.site[0] = -2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3492,7 +3492,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.site[0] = 3;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3502,7 +3502,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.node[0] = MSP_NULL_NODE;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3512,7 +3512,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.node[0] = 7;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3522,7 +3522,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.parent[0] = -2;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3532,7 +3532,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.parent[0] = 7;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
@@ -3542,7 +3542,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.parent[1] = 0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_DIFFERENT_SITE);
     tree_sequence_free(&ts);
@@ -3552,7 +3552,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.parent[0] = 0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_EQUAL);
     tree_sequence_free(&ts);
@@ -3562,7 +3562,7 @@ test_single_tree_bad_mutations(void)
     mutation_table.parent[2] = 3;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_AFTER_CHILD);
     tree_sequence_free(&ts);
@@ -3571,7 +3571,7 @@ test_single_tree_bad_mutations(void)
     /* Check to make sure we've maintained legal mutations */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             &site_table, &mutation_table, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
@@ -5010,7 +5010,7 @@ test_tree_sequence_bad_records(void)
     /* Make sure we have a good set of records */
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(ts.num_trees, 3);
@@ -5021,7 +5021,7 @@ test_tree_sequence_bad_records(void)
     edge_table.left[0] = 10.0;
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
@@ -5029,7 +5029,7 @@ test_tree_sequence_bad_records(void)
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts, 0, &node_table, &edge_table, NULL,
+    ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
             NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     verify_trees(&ts, num_trees, parents);
@@ -5573,7 +5573,7 @@ test_save_empty_hdf5(void)
 
     ret = tree_sequence_initialise(&ts1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables_tmp(&ts1, sequence_length, &node_table, &edge_table,
+    ret = tree_sequence_load_tables(&ts1, sequence_length, &node_table, &edge_table,
             NULL, NULL, NULL, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -5691,7 +5691,7 @@ test_sort_tables(void)
             unsort_edges(&edges, start);
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, &edges,
+            ret = tree_sequence_load_tables(&ts2, 0, &nodes, &edges,
                     &migrations, &sites, &mutations, num_provenance_strings,
                     provenance_strings);
             CU_ASSERT_NOT_EQUAL_FATAL(ret, 0);
@@ -5702,7 +5702,7 @@ test_sort_tables(void)
 
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+            ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                     &nodes, &edges, &migrations, &sites, &mutations,
                     num_provenance_strings, provenance_strings);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5716,7 +5716,7 @@ test_sort_tables(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+        ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                 &nodes, &edges, &migrations, &sites, &mutations,
                 num_provenance_strings, provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5728,7 +5728,7 @@ test_sort_tables(void)
             unsort_sites(&sites, &mutations);
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+            ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                     &nodes, &edges, &migrations, &sites, &mutations,
                     num_provenance_strings, provenance_strings);
             CU_ASSERT_NOT_EQUAL(ret, 0);
@@ -5739,7 +5739,7 @@ test_sort_tables(void)
 
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
-            ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+            ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                     &nodes, &edges, &migrations, &sites, &mutations,
                     num_provenance_strings, provenance_strings);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5823,11 +5823,11 @@ test_dump_tables(void)
                 &migrations, &sites, &mutations, &num_provenance_strings,
                 &provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-        ret = tree_sequence_load_tables_tmp(&ts2, 0, NULL, &edges,
+        ret = tree_sequence_load_tables(&ts2, 0, NULL, &edges,
                 &migrations, &sites, &mutations, num_provenance_strings,
                 provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-        ret = tree_sequence_load_tables_tmp(&ts2, 0, &nodes, NULL,
+        ret = tree_sequence_load_tables(&ts2, 0, &nodes, NULL,
                 &migrations, &sites, &mutations, num_provenance_strings,
                 provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
@@ -5837,7 +5837,7 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+        ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                 &nodes, &edges, &migrations, &sites, &mutations,
                 num_provenance_strings, provenance_strings);
         verify_tree_sequences_equal(ts1, &ts2, true, true, true);
@@ -5849,7 +5849,7 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+        ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                 &nodes, &edges, NULL, &sites, &mutations,
                 num_provenance_strings, provenance_strings);
         verify_tree_sequences_equal(ts1, &ts2, false, true, true);
@@ -5862,7 +5862,7 @@ test_dump_tables(void)
                 &provenance_strings);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+        ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                 &nodes, &edges, &migrations, NULL, NULL, num_provenance_strings,
                 provenance_strings);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5917,7 +5917,7 @@ test_dump_tables_hdf5(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables_tmp(&ts2, ts1->sequence_length,
+        ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                 &nodes, &edges, &migrations, &sites, &mutations,
                 num_provenance_strings, provenance_strings);
         ret = tree_sequence_dump(&ts2, _tmp_file_name, 0);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -390,7 +390,7 @@ parse_sites(const char *text, site_table_t *site_table)
         CU_ASSERT_FATAL(p != NULL);
         strncpy(ancestral_state, p, MAX_LINE);
         ret = site_table_add_row(site_table, position, ancestral_state,
-                strlen(ancestral_state));
+                strlen(ancestral_state), NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
     }
 }
@@ -466,7 +466,7 @@ tree_sequence_from_text(tree_sequence_t *ts, double sequence_length,
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = edge_table_alloc(&edge_table, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&site_table, 0, 0);
+    ret = site_table_alloc(&site_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutation_table, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1199,7 +1199,7 @@ get_example_tree_sequence(uint32_t num_samples,
     CU_ASSERT_EQUAL(ret, 0);
     ret = migration_table_alloc(migrations, 10);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = site_table_alloc(sites, 10, 10);
+    ret = site_table_alloc(sites, 10, 10, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = mutation_table_alloc(mutations, 10, 10);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1353,7 +1353,7 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_alloc(&provenance, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1367,7 +1367,9 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     stack = tree.stack1;
     site_id = 0;
     for (ret = sparse_tree_first(&tree); ret == 1; ret = sparse_tree_next(&tree)) {
-        ret = site_table_add_row(&sites, tree.left, "0", 1);
+        /* add some fake metadata here to make sure we have cases with site metadata
+         * in our examples */
+        ret = site_table_add_row(&sites, tree.left, "0", 1, "recurrent", 9);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         for (root = tree.left_root; root != MSP_NULL_NODE; root = tree.right_sib[root]) {
             /* Traverse down the tree and put a mutation on every branch. */
@@ -1452,7 +1454,7 @@ make_permuted_nodes_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migrations, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1537,7 +1539,7 @@ make_gappy_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migrations, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1561,7 +1563,7 @@ make_gappy_copy(tree_sequence_t *ts)
         sites.position[j] += gap_size;
     }
     /* Add a site into the gap at the end. */
-    ret = site_table_add_row(&sites, ts->sequence_length + 0.5, "0", 1);
+    ret = site_table_add_row(&sites, ts->sequence_length + 0.5, "0", 1, "end-gap", 7);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_add_row(&mutations, sites.num_rows - 1, 0, MSP_NULL_MUTATION,
             "1", 1);
@@ -1609,7 +1611,7 @@ make_decapitated_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migrations, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3041,7 +3043,7 @@ test_simplest_overlapping_edges_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migration_table, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&site_table, 0, 0);
+    ret = site_table_alloc(&site_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutation_table, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3115,7 +3117,7 @@ test_simplest_overlapping_unary_edges_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migration_table, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&site_table, 0, 0);
+    ret = site_table_alloc(&site_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutation_table, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3184,7 +3186,7 @@ test_simplest_overlapping_unary_edges_internal_samples_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migration_table, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&site_table, 1, 1);
+    ret = site_table_alloc(&site_table, 1, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutation_table, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3459,7 +3461,7 @@ test_single_tree_bad_mutations(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = edge_table_alloc(&edge_table, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&site_table, 0, 0);
+    ret = site_table_alloc(&site_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutation_table, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4107,7 +4109,7 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migrations, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4367,11 +4369,11 @@ test_single_tree_mutgen(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     parse_nodes(nodes, &node_table);
     parse_edges(edges, &edge_table);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites_after, 0, 0);
+    ret = site_table_alloc(&sites_after, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations_after, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5526,6 +5528,9 @@ verify_tree_sequences_equal(tree_sequence_t *ts1, tree_sequence_t *ts2,
             CU_ASSERT_EQUAL(site_1.ancestral_state_length, site_2.ancestral_state_length);
             CU_ASSERT_NSTRING_EQUAL(site_1.ancestral_state, site_2.ancestral_state,
                     site_1.ancestral_state_length);
+            CU_ASSERT_EQUAL(site_1.metadata_length, site_2.metadata_length);
+            CU_ASSERT_NSTRING_EQUAL(site_1.metadata, site_2.metadata,
+                    site_1.metadata_length);
         }
         CU_ASSERT_EQUAL_FATAL(
             tree_sequence_get_num_mutations(ts1),
@@ -5682,7 +5687,7 @@ test_sort_tables(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migrations, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5837,7 +5842,7 @@ test_dump_tables(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migrations, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5936,7 +5941,7 @@ test_dump_tables_hdf5(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migrations, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = site_table_alloc(&sites, 0, 0);
+    ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6249,37 +6254,51 @@ test_site_table(void)
     site_table_t table;
     size_t num_rows, j;
     char *ancestral_state;
+    char *metadata;
     double *position;
     table_size_t *ancestral_state_offset;
+    table_size_t *metadata_offset;
 
-    ret = site_table_alloc(&table, 1, 1);
+    ret = site_table_alloc(&table, 1, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     site_table_print_state(&table, _devnull);
 
-    ret = site_table_add_row(&table, 0, "A", 1);
+    ret = site_table_add_row(&table, 0, "A", 1, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(table.position[0], 0);
     CU_ASSERT_EQUAL(table.ancestral_state_offset[0], 0);
     CU_ASSERT_EQUAL(table.ancestral_state_offset[1], 1);
+    CU_ASSERT_EQUAL(table.ancestral_state_length, 1);
+    CU_ASSERT_EQUAL(table.metadata_offset[0], 0);
+    CU_ASSERT_EQUAL(table.metadata_offset[1], 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
     CU_ASSERT_EQUAL(table.num_rows, 1);
 
-    ret = site_table_add_row(&table, 1, "AA", 2);
+    ret = site_table_add_row(&table, 1, "AA", 2, "{}", 2);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(table.position[1], 1);
     CU_ASSERT_EQUAL(table.ancestral_state_offset[2], 3);
+    CU_ASSERT_EQUAL(table.metadata_offset[1], 0);
+    CU_ASSERT_EQUAL(table.metadata_offset[2], 2);
+    CU_ASSERT_EQUAL(table.metadata_length, 2);
     CU_ASSERT_EQUAL(table.num_rows, 2);
 
-    ret = site_table_add_row(&table, 2, "A", 1);
+    ret = site_table_add_row(&table, 2, "A", 1, "metadata", 8);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(table.position[1], 1);
     CU_ASSERT_EQUAL(table.ancestral_state_offset[3], 4);
-    CU_ASSERT_EQUAL(table.num_rows, 3);
     CU_ASSERT_EQUAL(table.ancestral_state_length, 4);
+    CU_ASSERT_EQUAL(table.metadata_offset[3], 10);
+    CU_ASSERT_EQUAL(table.metadata_length, 10);
+    CU_ASSERT_EQUAL(table.num_rows, 3);
 
     site_table_print_state(&table, _devnull);
     site_table_reset(&table);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.ancestral_state_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
+    CU_ASSERT_EQUAL(table.ancestral_state_offset[0], 0);
+    CU_ASSERT_EQUAL(table.metadata_offset[0], 0);
 
     num_rows = 100;
     position = malloc(num_rows * sizeof(double));
@@ -6288,26 +6307,37 @@ test_site_table(void)
     CU_ASSERT_FATAL(ancestral_state != NULL);
     ancestral_state_offset = malloc((num_rows + 1) * sizeof(uint32_t));
     CU_ASSERT_FATAL(ancestral_state_offset != NULL);
+    metadata = malloc(num_rows * sizeof(char));
+    CU_ASSERT_FATAL(metadata != NULL);
+    metadata_offset = malloc((num_rows + 1) * sizeof(uint32_t));
+    CU_ASSERT_FATAL(metadata_offset != NULL);
 
     for (j = 0; j < num_rows; j++) {
         position[j] = j;
         ancestral_state[j] = j;
         ancestral_state_offset[j] = j;
+        metadata[j] = 'A' + j;
+        metadata_offset[j] = j;
     }
     ancestral_state_offset[num_rows] = num_rows;
-    ret = site_table_set_columns(&table, num_rows, position, ancestral_state,
-            ancestral_state_offset);
-    CU_ASSERT_EQUAL(ret, 0);
+    metadata_offset[num_rows] = num_rows;
+
+    ret = site_table_set_columns(&table, num_rows, position,
+            ancestral_state, ancestral_state_offset,
+            metadata, metadata_offset);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.position, position,
                 num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.ancestral_state, ancestral_state,
                 num_rows * sizeof(char)), 0);
-    CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.ancestral_state_length, num_rows);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(table.metadata_length, num_rows);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
 
     /* Append another num rows */
     ret = site_table_append_columns(&table, num_rows, position, ancestral_state,
-            ancestral_state_offset);
+            ancestral_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.position, position,
                 num_rows * sizeof(double)), 0);
@@ -6317,38 +6347,84 @@ test_site_table(void)
                 num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.ancestral_state + num_rows, ancestral_state,
                 num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata,
+                num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata + num_rows, metadata,
+                num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.ancestral_state_length, 2 * num_rows);
 
     /* Inputs cannot be NULL */
     ret = site_table_set_columns(&table, num_rows, NULL, ancestral_state,
-            ancestral_state_offset);
+            ancestral_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = site_table_set_columns(&table, num_rows, position, NULL, ancestral_state_offset);
+    ret = site_table_set_columns(&table, num_rows, position, NULL, ancestral_state_offset,
+            metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = site_table_set_columns(&table, num_rows, position, ancestral_state, NULL);
+    ret = site_table_set_columns(&table, num_rows, position, ancestral_state, NULL,
+            metadata, metadata_offset);
+    /* Metadata and metadata_offset must both be null */
+    ret = site_table_set_columns(&table, num_rows, position, ancestral_state,
+            ancestral_state_offset, NULL, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = site_table_set_columns(&table, num_rows, position, ancestral_state,
+            ancestral_state_offset, metadata, NULL);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+
+    /* Set metadata to NULL */
+    ret = site_table_set_columns(&table, num_rows, position,
+            ancestral_state, ancestral_state_offset, NULL, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    memset(metadata_offset, 0, (num_rows + 1) * sizeof(uint32_t));
+    CU_ASSERT_EQUAL(memcmp(table.position, position,
+                num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.ancestral_state, ancestral_state,
+                num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(table.ancestral_state_length, num_rows);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
+                (num_rows + 1) * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
 
     /* Test for bad offsets */
     ancestral_state_offset[0] = 1;
     ret = site_table_set_columns(&table, num_rows, position,
-            ancestral_state, ancestral_state_offset);
+            ancestral_state, ancestral_state_offset,
+            metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_OFFSET);
     ancestral_state_offset[0] = 0;
     ancestral_state_offset[num_rows] = 0;
     ret = site_table_set_columns(&table, num_rows, position,
-            ancestral_state, ancestral_state_offset);
+            ancestral_state, ancestral_state_offset,
+            metadata, metadata_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_OFFSET);
+    ancestral_state_offset[0] = 0;
+
+    metadata_offset[0] = 0;
+    ret = site_table_set_columns(&table, num_rows, position,
+            ancestral_state, ancestral_state_offset,
+            metadata, metadata_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_OFFSET);
+    metadata_offset[0] = 0;
+    metadata_offset[num_rows] = 0;
+    ret = site_table_set_columns(&table, num_rows, position,
+            ancestral_state, ancestral_state_offset,
+            metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_OFFSET);
 
     ret = site_table_reset(&table);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.ancestral_state_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     site_table_free(&table);
     free(position);
     free(ancestral_state);
     free(ancestral_state_offset);
+    free(metadata);
+    free(metadata_offset);
 }
 
 static void

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -1157,7 +1157,6 @@ get_example_tree_sequence(uint32_t num_samples,
     migration_table_t *migrations= malloc(sizeof(migration_table_t));
     site_table_t *sites = malloc(sizeof(site_table_t));
     mutation_table_t *mutations = malloc(sizeof(mutation_table_t));
-    char *provenance[] = {"get_example_tree_sequence"};
     uint32_t j;
     size_t num_populations = 3;
     double migration_matrix[] = {
@@ -1246,7 +1245,7 @@ get_example_tree_sequence(uint32_t num_samples,
     ret = mutgen_populate_tables(mutgen, sites, mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(tree_seq, 0, nodes, edges, migrations,
-            sites, mutations, 1, provenance);
+            sites, mutations, NULL, 0);
     /* edge_table_print_state(edges, stdout); */
     /* printf("ret = %s\n", msp_strerror(ret)); */
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1304,8 +1303,6 @@ tree_sequence_t *
 make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
 {
     int ret;
-    size_t num_provenance_strings;
-    char **provenance_strings;
     tree_sequence_t *new_ts = malloc(sizeof(tree_sequence_t));
     sparse_tree_t tree;
     node_table_t nodes;
@@ -1377,14 +1374,13 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     }
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tree_sequence_dump_tables_tmp(ts, &nodes, &edges,
-            &migrations, NULL, NULL, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(ts, &nodes, &edges,
+            &migrations, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(new_ts, 0, &nodes, &edges, &migrations,
-            &sites, &mutations, num_provenance_strings, provenance_strings);
+            &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     node_table_free(&nodes);
@@ -1414,8 +1410,6 @@ make_permuted_nodes_copy(tree_sequence_t *ts)
     edge_t edge;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
     size_t num_nodes = tree_sequence_get_num_nodes(ts);
-    char **provenance_strings;
-    size_t num_provenance_strings;
 
     CU_ASSERT_FATAL(new_ts != NULL);
     ret = node_table_alloc(&nodes, 0, 0);
@@ -1431,9 +1425,8 @@ make_permuted_nodes_copy(tree_sequence_t *ts)
     node_map = malloc(num_nodes * sizeof(node_id_t));
     CU_ASSERT_FATAL(node_map != NULL);
 
-    ret = tree_sequence_dump_tables_tmp(ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     for (j = 0; j < num_nodes; j++) {
         node_map[j] = j;
@@ -1464,7 +1457,7 @@ make_permuted_nodes_copy(tree_sequence_t *ts)
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(new_ts, 0, &nodes, &edges, &migrations,
-            &sites, &mutations, 0, NULL);
+            &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     node_table_free(&nodes);
@@ -1493,8 +1486,6 @@ make_gappy_copy(tree_sequence_t *ts)
     site_table_t sites;
     double left, right;
     double gap_size = 1e-4;
-    char **provenance_strings;
-    size_t num_provenance_strings;
 
     CU_ASSERT_FATAL(new_ts != NULL);
     ret = node_table_alloc(&nodes, 0, 0);
@@ -1508,9 +1499,8 @@ make_gappy_copy(tree_sequence_t *ts)
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tree_sequence_dump_tables_tmp(ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     edge_table_reset(&edges);
     for (j = 0; j < tree_sequence_get_num_edges(ts); j++) {
@@ -1535,7 +1525,7 @@ make_gappy_copy(tree_sequence_t *ts)
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(new_ts, ts->sequence_length + 1,
-            &nodes, &edges, &migrations, &sites, &mutations, 0, NULL);
+            &nodes, &edges, &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     node_table_free(&nodes);
@@ -1558,8 +1548,7 @@ make_decapitated_copy(tree_sequence_t *ts)
     migration_table_t migrations;
     mutation_table_t mutations;
     site_table_t sites;
-    char **provenance_strings;
-    size_t j, num_provenance_strings;
+    size_t j;
     node_id_t oldest_node;
 
     CU_ASSERT_FATAL(new_ts != NULL);
@@ -1574,9 +1563,8 @@ make_decapitated_copy(tree_sequence_t *ts)
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tree_sequence_dump_tables_tmp(ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     edges.num_rows -= edges.num_rows / 4;
     oldest_node = edges.parent[edges.num_rows - 1];
@@ -1592,7 +1580,7 @@ make_decapitated_copy(tree_sequence_t *ts)
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(new_ts, 0, &nodes, &edges, &migrations,
-            &sites, &mutations, 0, NULL);
+            &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     node_table_free(&nodes);
@@ -1941,10 +1929,10 @@ test_empty_tree_sequence(void)
 
     /* Zero length TS is invalid. */
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table,
-            NULL, NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SEQUENCE_LENGTH);
     ret = tree_sequence_load_tables(&ts, 1, &node_table, &edge_table,
-            NULL, NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     verify_empty_tree_sequence(&ts, 1.0);
@@ -2693,7 +2681,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table,
-            NULL, NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
 
@@ -2701,21 +2689,21 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, NULL, NULL, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, NULL, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
 
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, NULL, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
 
@@ -2724,7 +2712,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
     edge_table.right[0]= 1.0;
@@ -2734,7 +2722,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 1, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_RIGHT_GREATER_SEQ_LENGTH);
     tree_sequence_free(&ts);
     edge_table.right[0]= 1.0;
@@ -2744,7 +2732,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_DUPLICATE_EDGES);
     tree_sequence_free(&ts);
     edge_table.child[0] = 0;
@@ -2755,7 +2743,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_LEFT);
     tree_sequence_free(&ts);
     edge_table.child[0] = 0;
@@ -2766,7 +2754,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_NODE_TIME_ORDERING);
     tree_sequence_free(&ts);
     edge_table.child[1] = 1;
@@ -2777,7 +2765,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_CHILD);
     tree_sequence_free(&ts);
     edge_table.child[0] = 0;
@@ -2792,7 +2780,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NONCONTIGUOUS_PARENTS);
     tree_sequence_free(&ts);
     edge_table.parent[2] = 4;
@@ -2805,7 +2793,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NULL_PARENT);
     tree_sequence_free(&ts);
     edge_table.parent[0] = 2;
@@ -2815,7 +2803,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     node_table.num_rows = 5;
@@ -2825,7 +2813,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     edge_table.parent[0] = 2;
@@ -2835,7 +2823,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NULL_CHILD);
     tree_sequence_free(&ts);
     edge_table.child[0] = 0;
@@ -2845,7 +2833,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     edge_table.child[0] = 0;
@@ -2855,7 +2843,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     edge_table.child[0] = 0;
@@ -2864,7 +2852,7 @@ test_simplest_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
 
@@ -2903,7 +2891,7 @@ test_simplest_overlapping_parents(void)
     edge_table.left[0] = 0;
     edge_table.parent[0] = 2;
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table,
-            NULL, NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_alloc(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
@@ -2955,7 +2943,7 @@ test_simplest_contradictory_children(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table,
-            NULL, NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_alloc(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
@@ -3304,7 +3292,7 @@ test_single_tree_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_PARENT_TIME);
     tree_sequence_free(&ts);
     node_table.time[5] = 2.0;
@@ -3314,7 +3302,7 @@ test_single_tree_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
     edge_table.left[2] = 0.0;
@@ -3322,7 +3310,7 @@ test_single_tree_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
 
@@ -3432,7 +3420,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(&ts), 4);
@@ -3443,7 +3431,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
     site_table.position[0] = 0.0;
@@ -3453,7 +3441,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
     site_table.position[2] = 0.2;
@@ -3463,7 +3451,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
     site_table.position[2] = 0.2;
@@ -3473,7 +3461,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_UNSORTED_SITES);
     tree_sequence_free(&ts);
     site_table.position[0] = 0.0;
@@ -3483,7 +3471,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     mutation_table.site[0] = 0;
@@ -3493,7 +3481,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     mutation_table.site[0] = 0;
@@ -3503,7 +3491,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     mutation_table.node[0] = 0;
@@ -3513,7 +3501,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     mutation_table.node[0] = 0;
@@ -3523,7 +3511,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     mutation_table.parent[0] = MSP_NULL_MUTATION;
@@ -3533,7 +3521,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     mutation_table.parent[0] = MSP_NULL_MUTATION;
@@ -3543,7 +3531,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_DIFFERENT_SITE);
     tree_sequence_free(&ts);
     mutation_table.parent[1] = MSP_NULL_MUTATION;
@@ -3553,7 +3541,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_EQUAL);
     tree_sequence_free(&ts);
     mutation_table.parent[0] = MSP_NULL_MUTATION;
@@ -3563,7 +3551,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_AFTER_CHILD);
     tree_sequence_free(&ts);
     mutation_table.parent[2] = MSP_NULL_MUTATION;
@@ -3572,7 +3560,7 @@ test_single_tree_bad_mutations(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            &site_table, &mutation_table, 0, NULL);
+            &site_table, &mutation_table, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(&ts), 4);
@@ -4047,8 +4035,6 @@ test_single_tree_simplify(void)
     migration_table_t migrations;
     site_table_t sites;
     mutation_table_t mutations;
-    size_t num_provenance_strings;
-    char **provenance_strings;
     int ret;
     simplifier_t simplifier;
     node_id_t samples[] = {0, 1};
@@ -4069,9 +4055,8 @@ test_single_tree_simplify(void)
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tree_sequence_dump_tables_tmp(&ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Set the max_buffered_edges to 1 to ensure we excercise the realloc */
@@ -4088,9 +4073,8 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL(edges.num_rows, 2);
 
     /* Make sure we detect unsorted edges */
-    ret = tree_sequence_dump_tables_tmp(&ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     unsort_edges(&edges, 0);
     ret = simplifier_alloc(&simplifier, 0.0, samples, 2,
@@ -4100,9 +4084,8 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* detect bad parents */
-    ret = tree_sequence_dump_tables_tmp(&ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     edges.parent[0] = -1;
     ret = simplifier_alloc(&simplifier, 0.0, samples, 2,
@@ -4112,9 +4095,8 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* detect bad children */
-    ret = tree_sequence_dump_tables_tmp(&ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     edges.child[0] = -1;
     ret = simplifier_alloc(&simplifier, 0.0, samples, 2,
@@ -4124,9 +4106,8 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* detect loops */
-    ret = tree_sequence_dump_tables_tmp(&ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     edges.child[0] = edges.parent[0];
     ret = simplifier_alloc(&simplifier, 0.0, samples, 2,
@@ -4136,9 +4117,8 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* detect bad sites */
-    ret = tree_sequence_dump_tables_tmp(&ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FATAL(mutations.num_rows > 0 && sites.num_rows > 0);
     mutations.site[0] = -1;
@@ -4149,9 +4129,8 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* detect bad mutation nodes */
-    ret = tree_sequence_dump_tables_tmp(&ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FATAL(mutations.num_rows > 0 && sites.num_rows > 0);
     mutations.node[0] = -1;
@@ -4162,9 +4141,8 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Test the interface for NULL inputs */
-    ret = tree_sequence_dump_tables_tmp(&ts, &nodes, &edges,
-            &migrations, &sites, &mutations, &num_provenance_strings,
-            &provenance_strings);
+    ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
+            &migrations, &sites, &mutations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = simplifier_alloc(&simplifier, 0.0, NULL, 2,
             &nodes, &edges, &migrations, &sites, &mutations, 0, 0);
@@ -5011,7 +4989,7 @@ test_tree_sequence_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(ts.num_trees, 3);
     verify_trees(&ts, num_trees, parents);
@@ -5022,7 +5000,7 @@ test_tree_sequence_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
     edge_table.left[0] = 2.0;
@@ -5030,7 +5008,7 @@ test_tree_sequence_bad_records(void)
     ret = tree_sequence_initialise(&ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts, 0, &node_table, &edge_table, NULL,
-            NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);
     verify_trees(&ts, num_trees, parents);
     tree_sequence_free(&ts);
@@ -5432,14 +5410,13 @@ test_newick_from_examples(void)
 static void
 verify_tree_sequences_equal(tree_sequence_t *ts1, tree_sequence_t *ts2,
         bool check_migrations, bool check_mutations,
-        bool check_provenance_strings)
+        bool check_provenance)
 {
     int ret, err1, err2;
-    size_t j, nps1, nps2;
+    size_t j;
     edge_t r1, r2;
     node_t n1, n2;
     migration_t m1, m2;
-    char **ps1, **ps2;
     size_t num_mutations = tree_sequence_get_num_mutations(ts1);
     site_t site_1, site_2;
     mutation_t mutation_1, mutation_2;
@@ -5525,17 +5502,8 @@ verify_tree_sequences_equal(tree_sequence_t *ts1, tree_sequence_t *ts2,
             verify_migrations_equal(&m1, &m2, 1.0);
         }
     }
-    if (check_provenance_strings) {
-        ret = tree_sequence_get_provenance_strings(ts1, &nps1, &ps1);
-        CU_ASSERT_EQUAL(ret, 0);
-        ret = tree_sequence_get_provenance_strings(ts2, &nps2, &ps2);
-        CU_ASSERT_EQUAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(nps1, nps2);
-        for (j = 0; j < nps1; j++) {
-            CU_ASSERT_FATAL(ps1[j] != NULL);
-            CU_ASSERT_FATAL(ps2[j] != NULL);
-            CU_ASSERT_STRING_EQUAL(ps1[j], ps2[j]);
-        }
+    if (check_provenance) {
+        /* FIXME add checks for provenance */
     }
     ret = sparse_tree_alloc(&t1, ts1, 0);
     CU_ASSERT_EQUAL(ret, 0);
@@ -5574,7 +5542,7 @@ test_save_empty_hdf5(void)
     ret = tree_sequence_initialise(&ts1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_load_tables(&ts1, sequence_length, &node_table, &edge_table,
-            NULL, NULL, NULL, 0, NULL);
+            NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tree_sequence_initialise(&ts2);
@@ -5632,9 +5600,8 @@ test_sort_tables(void)
     tree_sequence_t **examples = get_example_tree_sequences(1);
     tree_sequence_t ts2;
     tree_sequence_t *ts1;
-    size_t j, k, start, starts[3], num_provenance_strings;
+    size_t j, k, start, starts[3];
 
-    char **provenance_strings;
     node_table_t nodes;
     edge_table_t edges;
     migration_table_t migrations;
@@ -5657,9 +5624,8 @@ test_sort_tables(void)
     for (j = 0; examples[j] != NULL; j++) {
         ts1 = examples[j];
 
-        ret = tree_sequence_dump_tables_tmp(ts1, &nodes, &edges,
-                &migrations, &sites, &mutations, &num_provenance_strings,
-                &provenance_strings);
+        ret = tree_sequence_dump_tables(ts1, &nodes, &edges,
+                &migrations, &sites, &mutations, NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
 
         /* Check the input validation */
@@ -5692,8 +5658,7 @@ test_sort_tables(void)
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             ret = tree_sequence_load_tables(&ts2, 0, &nodes, &edges,
-                    &migrations, &sites, &mutations, num_provenance_strings,
-                    provenance_strings);
+                    &migrations, &sites, &mutations, NULL, 0);
             CU_ASSERT_NOT_EQUAL_FATAL(ret, 0);
             tree_sequence_free(&ts2);
 
@@ -5703,8 +5668,7 @@ test_sort_tables(void)
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
-                    &nodes, &edges, &migrations, &sites, &mutations,
-                    num_provenance_strings, provenance_strings);
+                    &nodes, &edges, &migrations, &sites, &mutations, NULL, 0);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             verify_tree_sequences_equal(ts1, &ts2, true, true, true);
             tree_sequence_free(&ts2);
@@ -5717,8 +5681,7 @@ test_sort_tables(void)
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
-                &nodes, &edges, &migrations, &sites, &mutations,
-                num_provenance_strings, provenance_strings);
+                &nodes, &edges, &migrations, &sites, &mutations, NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_tree_sequences_equal(ts1, &ts2, true, true, true);
         tree_sequence_free(&ts2);
@@ -5729,8 +5692,7 @@ test_sort_tables(void)
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
-                    &nodes, &edges, &migrations, &sites, &mutations,
-                    num_provenance_strings, provenance_strings);
+                    &nodes, &edges, &migrations, &sites, &mutations, NULL, 0);
             CU_ASSERT_NOT_EQUAL(ret, 0);
             tree_sequence_free(&ts2);
 
@@ -5740,8 +5702,7 @@ test_sort_tables(void)
             ret = tree_sequence_initialise(&ts2);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
-                    &nodes, &edges, &migrations, &sites, &mutations,
-                    num_provenance_strings, provenance_strings);
+                    &nodes, &edges, &migrations, &sites, &mutations, NULL, 0);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             verify_tree_sequences_equal(ts1, &ts2, true, true, true);
             tree_sequence_free(&ts2);
@@ -5791,8 +5752,7 @@ test_dump_tables(void)
     tree_sequence_t **examples = get_example_tree_sequences(1);
     tree_sequence_t ts2;
     tree_sequence_t *ts1;
-    size_t j, num_provenance_strings;
-    char **provenance_strings;
+    size_t j;
     node_table_t nodes;
     edge_table_t edges;
     migration_table_t migrations;
@@ -5815,56 +5775,46 @@ test_dump_tables(void)
     for (j = 0; examples[j] != NULL; j++) {
         ts1 = examples[j];
 
-        ret = tree_sequence_dump_tables_tmp(ts1, NULL, &edges,
-                &migrations, &sites, &mutations, &num_provenance_strings,
-                &provenance_strings);
+        ret = tree_sequence_dump_tables(ts1, NULL, &edges,
+                &migrations, &sites, &mutations, NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-        ret = tree_sequence_dump_tables_tmp(ts1, &nodes, NULL,
-                &migrations, &sites, &mutations, &num_provenance_strings,
-                &provenance_strings);
+        ret = tree_sequence_dump_tables(ts1, &nodes, NULL,
+                &migrations, &sites, &mutations, NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
         ret = tree_sequence_load_tables(&ts2, 0, NULL, &edges,
-                &migrations, &sites, &mutations, num_provenance_strings,
-                provenance_strings);
+                &migrations, &sites, &mutations, NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
         ret = tree_sequence_load_tables(&ts2, 0, &nodes, NULL,
-                &migrations, &sites, &mutations, num_provenance_strings,
-                provenance_strings);
+                &migrations, &sites, &mutations, NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
 
-        ret = tree_sequence_dump_tables_tmp(ts1, &nodes, &edges,
-                &migrations, &sites, &mutations, &num_provenance_strings,
-                &provenance_strings);
+        ret = tree_sequence_dump_tables(ts1, &nodes, &edges,
+                &migrations, &sites, &mutations, NULL, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
-                &nodes, &edges, &migrations, &sites, &mutations,
-                num_provenance_strings, provenance_strings);
+                &nodes, &edges, &migrations, &sites, &mutations, NULL, 0);
         verify_tree_sequences_equal(ts1, &ts2, true, true, true);
         tree_sequence_print_state(&ts2, _devnull);
         tree_sequence_free(&ts2);
 
-        ret = tree_sequence_dump_tables_tmp(ts1, &nodes, &edges,
-                NULL, &sites, &mutations, &num_provenance_strings,
-                &provenance_strings);
+        ret = tree_sequence_dump_tables(ts1, &nodes, &edges,
+                NULL, &sites, &mutations, NULL, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
-                &nodes, &edges, NULL, &sites, &mutations,
-                num_provenance_strings, provenance_strings);
+                &nodes, &edges, NULL, &sites, &mutations, NULL, 0);
         verify_tree_sequences_equal(ts1, &ts2, false, true, true);
         CU_ASSERT_EQUAL_FATAL(
             tree_sequence_get_num_migrations(&ts2), 0);
         tree_sequence_free(&ts2);
 
-        ret = tree_sequence_dump_tables_tmp(ts1, &nodes, &edges,
-                &migrations, NULL, NULL, &num_provenance_strings,
-                &provenance_strings);
+        ret = tree_sequence_dump_tables(ts1, &nodes, &edges,
+                &migrations, NULL, NULL, NULL, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
-                &nodes, &edges, &migrations, NULL, NULL, num_provenance_strings,
-                provenance_strings);
+                &nodes, &edges, &migrations, NULL, NULL, NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_tree_sequences_equal(ts1, &ts2, true, false, true);
         CU_ASSERT_EQUAL_FATAL(
@@ -5886,14 +5836,14 @@ static void
 test_dump_tables_hdf5(void)
 {
     int ret;
-    size_t k, num_provenance_strings;
+    size_t k;
     tree_sequence_t *ts1, ts2, ts3, **examples;
-    char **provenance_strings;
     node_table_t nodes;
     edge_table_t edges;
     migration_table_t migrations;
     site_table_t sites;
     mutation_table_t mutations;
+    provenance_table_t provenance;
 
     ret = node_table_alloc(&nodes, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5906,20 +5856,21 @@ test_dump_tables_hdf5(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_alloc(&mutations, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = provenance_table_alloc(&provenance, 0, 0, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     examples = get_example_tree_sequences(1);
     for (k = 0; examples[k] != NULL; k++) {
         ts1 = examples[k];
         CU_ASSERT_FATAL(ts1 != NULL);
-        ret = tree_sequence_dump_tables_tmp(ts1, &nodes, &edges,
-                &migrations, &sites, &mutations, &num_provenance_strings,
-                &provenance_strings);
+        ret = tree_sequence_dump_tables(ts1, &nodes, &edges,
+                &migrations, &sites, &mutations, &provenance, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts2);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_load_tables(&ts2, ts1->sequence_length,
                 &nodes, &edges, &migrations, &sites, &mutations,
-                num_provenance_strings, provenance_strings);
+                &provenance, 0);
         ret = tree_sequence_dump(&ts2, _tmp_file_name, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_initialise(&ts3);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6597,6 +6597,116 @@ test_migration_table(void)
     free(dest);
 }
 
+static void
+test_provenance_table(void)
+{
+    int ret;
+    provenance_table_t table;
+    size_t num_rows = 100;
+    size_t j;
+    char *timestamp;
+    uint32_t *timestamp_offset;
+    const char *test_timestamp = "2017-12-06T20:40:25+00:00";
+    size_t test_timestamp_length = strlen(test_timestamp);
+    char timestamp_copy[test_timestamp_length + 1];
+    char *provenance;
+    uint32_t *provenance_offset;
+    const char *test_provenance = "{\"json\"=1234}";
+    size_t test_provenance_length = strlen(test_provenance);
+    char provenance_copy[test_provenance_length + 1];
+
+    timestamp_copy[test_timestamp_length] = '\0';
+    provenance_copy[test_provenance_length] = '\0';
+    ret = provenance_table_alloc(&table, 1, 1, 1);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    provenance_table_print_state(&table, _devnull);
+
+    for (j = 0; j < num_rows; j++) {
+        ret = provenance_table_add_row(&table, test_timestamp, test_timestamp_length,
+                test_provenance, test_provenance_length);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL(table.timestamp_length, (j + 1) * test_timestamp_length);
+        CU_ASSERT_EQUAL(table.timestamp_offset[j + 1], table.timestamp_length);
+        CU_ASSERT_EQUAL(table.provenance_length, (j + 1) * test_provenance_length);
+        CU_ASSERT_EQUAL(table.provenance_offset[j + 1], table.provenance_length);
+        /* check the timestamp */
+        memcpy(timestamp_copy, table.timestamp + table.timestamp_offset[j],
+                test_timestamp_length);
+        CU_ASSERT_NSTRING_EQUAL(timestamp_copy, test_timestamp, test_timestamp_length);
+        /* check the provenance */
+        memcpy(provenance_copy, table.provenance + table.provenance_offset[j],
+                test_provenance_length);
+        CU_ASSERT_NSTRING_EQUAL(provenance_copy, test_provenance, test_provenance_length);
+    }
+    provenance_table_print_state(&table, _devnull);
+    provenance_table_reset(&table);
+    CU_ASSERT_EQUAL(table.num_rows, 0);
+    CU_ASSERT_EQUAL(table.timestamp_length, 0);
+    CU_ASSERT_EQUAL(table.provenance_length, 0);
+
+    num_rows *= 2;
+    timestamp = malloc(num_rows * sizeof(char));
+    memset(timestamp, 'a', num_rows * sizeof(char));
+    CU_ASSERT_FATAL(timestamp != NULL);
+    timestamp_offset = malloc((num_rows + 1) * sizeof(list_len_t));
+    CU_ASSERT_FATAL(timestamp_offset != NULL);
+    provenance = malloc(num_rows * sizeof(char));
+    memset(provenance, 'a', num_rows * sizeof(char));
+    CU_ASSERT_FATAL(provenance != NULL);
+    provenance_offset = malloc((num_rows + 1) * sizeof(list_len_t));
+    CU_ASSERT_FATAL(provenance_offset != NULL);
+    for (j = 0; j < num_rows + 1; j++) {
+        timestamp_offset[j] = j;
+        provenance_offset[j] = j;
+    }
+    ret = provenance_table_set_columns(&table, num_rows,
+            timestamp, timestamp_offset, provenance, provenance_offset);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.timestamp, timestamp, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.timestamp_offset, timestamp_offset,
+                (num_rows + 1) * sizeof(list_len_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.provenance, provenance, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.provenance_offset, provenance_offset,
+                (num_rows + 1) * sizeof(list_len_t)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+    CU_ASSERT_EQUAL(table.timestamp_length, num_rows);
+    CU_ASSERT_EQUAL(table.provenance_length, num_rows);
+    provenance_table_print_state(&table, _devnull);
+
+    /* Append another num_rows onto the end */
+    ret = provenance_table_append_columns(&table, num_rows,
+            timestamp, timestamp_offset, provenance, provenance_offset);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.timestamp, timestamp, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.timestamp + num_rows, timestamp, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.provenance, provenance, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.provenance + num_rows, provenance, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
+    CU_ASSERT_EQUAL(table.timestamp_length, 2 * num_rows);
+    CU_ASSERT_EQUAL(table.provenance_length, 2 * num_rows);
+    provenance_table_print_state(&table, _devnull);
+
+    /* No arguments can be null */
+    ret = provenance_table_set_columns(&table, num_rows, NULL, timestamp_offset,
+            provenance, provenance_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = provenance_table_set_columns(&table, num_rows, timestamp, NULL,
+            provenance, provenance_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = provenance_table_set_columns(&table, num_rows, timestamp, timestamp_offset,
+            NULL, provenance_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = provenance_table_set_columns(&table, num_rows, timestamp, timestamp_offset,
+            provenance, NULL);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+
+    provenance_table_free(&table);
+    free(timestamp);
+    free(timestamp_offset);
+    free(provenance);
+    free(provenance_offset);
+}
+
 
 static int
 msprime_suite_init(void)
@@ -6744,6 +6854,7 @@ main(int argc, char **argv)
         {"test_site_table", test_site_table},
         {"test_mutation_table", test_mutation_table},
         {"test_migration_table", test_migration_table},
+        {"test_provenance_table", test_provenance_table},
         CU_TEST_INFO_NULL,
     };
 

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -5974,6 +5974,7 @@ test_dump_tables_hdf5(void)
     edge_table_free(&edges);
     migration_table_free(&migrations);
     site_table_free(&sites);
+    provenance_table_free(&provenance);
     mutation_table_free(&mutations);
 }
 

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -438,7 +438,7 @@ parse_mutations(const char *text, mutation_table_t *mutation_table)
             parent = atoi(p);
         }
         ret = mutation_table_add_row(mutation_table, site, node, parent,
-                derived_state, strlen(derived_state));
+                derived_state, strlen(derived_state), NULL, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
     }
 }
@@ -468,7 +468,7 @@ tree_sequence_from_text(tree_sequence_t *ts, double sequence_length,
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&site_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutation_table, 0, 0);
+    ret = mutation_table_alloc(&mutation_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = migration_table_alloc(&migration_table, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1201,7 +1201,7 @@ get_example_tree_sequence(uint32_t num_samples,
     CU_ASSERT_EQUAL(ret, 0);
     ret = site_table_alloc(sites, 10, 10, 0);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = mutation_table_alloc(mutations, 10, 10);
+    ret = mutation_table_alloc(mutations, 10, 10, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = provenance_table_alloc(provenance, 0, 0, 0);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1343,6 +1343,7 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     size_t num_mutations_per_branch = 2;
     char *timestamp = "timestamp";
     char *record = "make_recurrent_and_back_mutations_copy";
+    char *metadata;
 
     CU_ASSERT_FATAL(new_ts != NULL);
     ret = node_table_alloc(&nodes, 0, 0);
@@ -1355,7 +1356,7 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = sparse_tree_alloc(&tree, ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1391,8 +1392,10 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
                     for (j = 0; j < num_mutations_per_branch; j++) {
                         state[u] = (state[u] + 1) % 2;
                         mutation[u] = mutations.num_rows;
+                        metadata = state[u] == 0? "back": "forward";
                         ret = mutation_table_add_row(&mutations, site_id, u,
-                                parent, state[u] == 0? "0": "1", 1);
+                                parent, state[u] == 0? "0": "1", 1,
+                                metadata, strlen(metadata));
                         parent = mutation[u];
                         CU_ASSERT_EQUAL_FATAL(ret, 0);
                     }
@@ -1403,8 +1406,8 @@ make_recurrent_and_back_mutations_copy(tree_sequence_t *ts)
     }
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tree_sequence_dump_tables(ts, &nodes, &edges,
-            &migrations, NULL, NULL, &provenance, 0);
+    ret = tree_sequence_dump_tables(ts, &nodes, &edges, &migrations, NULL, NULL,
+            &provenance, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_initialise(new_ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1456,7 +1459,7 @@ make_permuted_nodes_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_alloc(&provenance, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1541,7 +1544,7 @@ make_gappy_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_alloc(&provenance, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1566,7 +1569,7 @@ make_gappy_copy(tree_sequence_t *ts)
     ret = site_table_add_row(&sites, ts->sequence_length + 0.5, "0", 1, "end-gap", 7);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutation_table_add_row(&mutations, sites.num_rows - 1, 0, MSP_NULL_MUTATION,
-            "1", 1);
+            "1", 1, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_add_row(&provenance,
             timestamp, strlen(timestamp), record, strlen(record));
@@ -1613,7 +1616,7 @@ make_decapitated_copy(tree_sequence_t *ts)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_alloc(&provenance, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3045,7 +3048,7 @@ test_simplest_overlapping_edges_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&site_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutation_table, 0, 0);
+    ret = mutation_table_alloc(&mutation_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     parse_nodes(nodes, &node_table);
@@ -3119,7 +3122,7 @@ test_simplest_overlapping_unary_edges_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&site_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutation_table, 0, 0);
+    ret = mutation_table_alloc(&mutation_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     parse_nodes(nodes, &node_table);
@@ -3188,7 +3191,7 @@ test_simplest_overlapping_unary_edges_internal_samples_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&site_table, 1, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutation_table, 1, 1);
+    ret = mutation_table_alloc(&mutation_table, 1, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     parse_nodes(nodes, &node_table);
@@ -3463,7 +3466,7 @@ test_single_tree_bad_mutations(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&site_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutation_table, 0, 0);
+    ret = mutation_table_alloc(&mutation_table, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     parse_nodes(single_tree_ex_nodes, &node_table);
@@ -4111,7 +4114,7 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tree_sequence_dump_tables(&ts, &nodes, &edges,
@@ -4371,11 +4374,11 @@ test_single_tree_mutgen(void)
     parse_edges(edges, &edge_table);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites_after, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations_after, 0, 0);
+    ret = mutation_table_alloc(&mutations_after, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = mutgen_alloc(&mutgen, 0.0, rng, MSP_ALPHABET_BINARY, 100);
@@ -5551,6 +5554,10 @@ verify_tree_sequences_equal(tree_sequence_t *ts1, tree_sequence_t *ts2,
                     mutation_2.derived_state_length);
             CU_ASSERT_NSTRING_EQUAL(mutation_1.derived_state,
                     mutation_2.derived_state, mutation_1.derived_state_length);
+            CU_ASSERT_EQUAL_FATAL(mutation_1.metadata_length,
+                    mutation_2.metadata_length);
+            CU_ASSERT_NSTRING_EQUAL(mutation_1.metadata,
+                    mutation_2.metadata, mutation_1.metadata_length);
         }
     }
     if (check_migrations) {
@@ -5689,7 +5696,7 @@ test_sort_tables(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_alloc(&provenances, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5844,7 +5851,7 @@ test_dump_tables(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_alloc(&provenances, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5943,7 +5950,7 @@ test_dump_tables_hdf5(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_alloc(&sites, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_table_alloc(&mutations, 0, 0);
+    ret = mutation_table_alloc(&mutations, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_alloc(&provenance, 0, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6438,31 +6445,34 @@ test_mutation_table(void)
     node_id_t *node;
     mutation_id_t *parent;
     site_id_t *site;
-    char *derived_state;
+    char *derived_state, *metadata;
     char c[max_len + 1];
-    table_size_t *derived_state_offset;
+    table_size_t *derived_state_offset, *metadata_offset;
 
     for (j = 0; j < max_len; j++) {
         c[j] = 'A' + j;
     }
 
-    ret = mutation_table_alloc(&table, 1, 1);
+    ret = mutation_table_alloc(&table, 1, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     mutation_table_print_state(&table, _devnull);
 
     len = 0;
     for (j = 0; j < num_rows; j++) {
         k = GSL_MIN(j + 1, max_len);
-        ret = mutation_table_add_row(&table, j, j, j, c, k);
+        ret = mutation_table_add_row(&table, j, j, j, c, k, c, k);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_EQUAL(table.site[j], j);
         CU_ASSERT_EQUAL(table.node[j], j);
         CU_ASSERT_EQUAL(table.parent[j], j);
         CU_ASSERT_EQUAL(table.derived_state_offset[j], len);
+        CU_ASSERT_EQUAL(table.metadata_offset[j], len);
         CU_ASSERT_EQUAL(table.num_rows, j + 1);
         len += k;
         CU_ASSERT_EQUAL(table.derived_state_offset[j + 1], len);
         CU_ASSERT_EQUAL(table.derived_state_length, len);
+        CU_ASSERT_EQUAL(table.metadata_offset[j + 1], len);
+        CU_ASSERT_EQUAL(table.metadata_length, len);
     }
     mutation_table_print_state(&table, _devnull);
 
@@ -6477,6 +6487,10 @@ test_mutation_table(void)
     CU_ASSERT_FATAL(derived_state != NULL);
     derived_state_offset = malloc((num_rows + 1) * sizeof(table_size_t));
     CU_ASSERT_FATAL(derived_state_offset != NULL);
+    metadata = malloc(num_rows * sizeof(char));
+    CU_ASSERT_FATAL(metadata != NULL);
+    metadata_offset = malloc((num_rows + 1) * sizeof(table_size_t));
+    CU_ASSERT_FATAL(metadata_offset != NULL);
 
     for (j = 0; j < num_rows; j++) {
         node[j] = j;
@@ -6484,22 +6498,27 @@ test_mutation_table(void)
         parent[j] = j + 2;
         derived_state[j] = 'Y';
         derived_state_offset[j] = j;
+        metadata[j] = 'M';
+        metadata_offset[j] = j;
     }
     derived_state_offset[num_rows] = num_rows;
+    metadata_offset[num_rows] = num_rows;
     ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
-            derived_state, derived_state_offset);
+            derived_state, derived_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.site, site, num_rows * sizeof(site_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.node, node, num_rows * sizeof(node_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.parent, parent, num_rows * sizeof(mutation_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.derived_state, derived_state,
                 num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.derived_state_length, num_rows);
+    CU_ASSERT_EQUAL(table.metadata_length, num_rows);
 
     /* Append another num_rows */
     ret = mutation_table_append_columns(&table, num_rows, site, node, parent, derived_state,
-            derived_state_offset);
+            derived_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.site, site, num_rows * sizeof(site_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.site + num_rows, site, num_rows * sizeof(site_id_t)), 0);
@@ -6512,13 +6531,19 @@ test_mutation_table(void)
                 num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.derived_state, derived_state,
                 num_rows * sizeof(char)), 0);
-    CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.derived_state_length, 2 * num_rows);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata,
+                num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata,
+                num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 2 * num_rows);
+    CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
 
-    /* Check all this again, except with parent == NULL. */
+    /* Check all this again, except with parent == NULL and metadata == NULL. */
     memset(parent, 0xff, num_rows * sizeof(mutation_id_t));
+    memset(metadata_offset, 0, (num_rows + 1) * sizeof(table_size_t));
     ret = mutation_table_set_columns(&table, num_rows, site, node, NULL,
-            derived_state, derived_state_offset);
+            derived_state, derived_state_offset, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.site, site, num_rows * sizeof(site_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.node, node, num_rows * sizeof(node_id_t)), 0);
@@ -6527,12 +6552,15 @@ test_mutation_table(void)
                 num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.derived_state_offset, derived_state_offset,
                 num_rows * sizeof(table_size_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
+                (num_rows + 1) * sizeof(table_size_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.derived_state_length, num_rows);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     /* Append another num_rows */
     ret = mutation_table_append_columns(&table, num_rows, site, node, NULL, derived_state,
-            derived_state_offset);
+            derived_state_offset, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.site, site, num_rows * sizeof(site_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.site + num_rows, site, num_rows * sizeof(site_id_t)), 0);
@@ -6543,53 +6571,67 @@ test_mutation_table(void)
                 num_rows * sizeof(mutation_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.derived_state, derived_state,
                 num_rows * sizeof(char)), 0);
-    CU_ASSERT_EQUAL(memcmp(table.derived_state, derived_state,
+    CU_ASSERT_EQUAL(memcmp(table.derived_state + num_rows, derived_state,
                 num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.derived_state_length, 2 * num_rows);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
 
-    /* Inputs except parent cannot be NULL */
+    /* Inputs except parent, metadata and metadata_offset cannot be NULL*/
     ret = mutation_table_set_columns(&table, num_rows, NULL, node, parent,
-            derived_state, derived_state_offset);
+            derived_state, derived_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     ret = mutation_table_set_columns(&table, num_rows, site, NULL, parent,
-            derived_state, derived_state_offset);
+            derived_state, derived_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
-            NULL, derived_state_offset);
+            NULL, derived_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
-            derived_state, NULL);
+            derived_state, NULL, metadata, metadata_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
+            derived_state, derived_state_offset, NULL, metadata_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
+            derived_state, derived_state_offset, metadata, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
 
-    /* Inputs except parent cannot be NULL */
-    ret = mutation_table_set_columns(&table, num_rows, NULL, node, parent,
-            derived_state, derived_state_offset);
+    /* Inputs except parent, metadata and metadata_offset cannot be NULL*/
+    ret = mutation_table_append_columns(&table, num_rows, NULL, node, parent,
+            derived_state, derived_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = mutation_table_set_columns(&table, num_rows, site, NULL, parent,
-            derived_state, derived_state_offset);
+    ret = mutation_table_append_columns(&table, num_rows, site, NULL, parent,
+            derived_state, derived_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
-            NULL, derived_state_offset);
+    ret = mutation_table_append_columns(&table, num_rows, site, node, parent,
+            NULL, derived_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
-            derived_state, NULL);
+    ret = mutation_table_append_columns(&table, num_rows, site, node, parent,
+            derived_state, NULL, metadata, metadata_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = mutation_table_append_columns(&table, num_rows, site, node, parent,
+            derived_state, derived_state_offset, NULL, metadata_offset);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
+    ret = mutation_table_append_columns(&table, num_rows, site, node, parent,
+            derived_state, derived_state_offset, metadata, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
 
     /* Test for bad offsets */
     derived_state_offset[0] = 1;
     ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
-            derived_state, derived_state_offset);
+            derived_state, derived_state_offset, NULL, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_OFFSET);
     derived_state_offset[0] = 0;
     derived_state_offset[num_rows] = 0;
     ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
-            derived_state, derived_state_offset);
+            derived_state, derived_state_offset, NULL, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_OFFSET);
 
     mutation_table_reset(&table);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.derived_state_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     mutation_table_free(&table);
     free(site);
@@ -6597,6 +6639,8 @@ test_mutation_table(void)
     free(parent);
     free(derived_state);
     free(derived_state_offset);
+    free(metadata);
+    free(metadata_offset);
 }
 
 static void

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -879,7 +879,7 @@ verify_trees(tree_sequence_t *ts, uint32_t num_trees, node_id_t* parents)
     int ret;
     node_id_t u, v;
     uint32_t j, mutation_index, site_index;
-    list_len_t k, l, tree_sites_length;
+    table_size_t k, l, tree_sites_length;
     site_t *sites = NULL;
     sparse_tree_t tree;
     size_t num_nodes = tree_sequence_get_num_nodes(ts);
@@ -993,7 +993,7 @@ verify_simplify_properties(tree_sequence_t *ts, tree_sequence_t *subset,
     node_t n1, n2;
     sparse_tree_t full_tree, subset_tree;
     site_t *tree_sites;
-    list_len_t tree_sites_length;
+    table_size_t tree_sites_length;
     uint32_t j, k;
     node_id_t u, mrca1, mrca2;
     size_t total_sites;
@@ -6067,7 +6067,7 @@ test_node_table(void)
     metadata = malloc(num_rows * sizeof(char));
     memset(metadata, 'a', num_rows * sizeof(char));
     CU_ASSERT_FATAL(metadata != NULL);
-    metadata_offset = malloc((num_rows + 1) * sizeof(list_len_t));
+    metadata_offset = malloc((num_rows + 1) * sizeof(table_size_t));
     CU_ASSERT_FATAL(metadata_offset != NULL);
     for (j = 0; j < num_rows + 1; j++) {
         metadata_offset[j] = j;
@@ -6080,7 +6080,7 @@ test_node_table(void)
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
-                (num_rows + 1) * sizeof(list_len_t)), 0);
+                (num_rows + 1) * sizeof(table_size_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, num_rows);
     node_table_print_state(&table, _devnull);
@@ -6132,13 +6132,13 @@ test_node_table(void)
 
     /* if metadata and metadata_offset are both null, all metadatas are zero length */
     num_rows = 10;
-    memset(metadata_offset, 0, (num_rows + 1) * sizeof(list_len_t));
+    memset(metadata_offset, 0, (num_rows + 1) * sizeof(table_size_t));
     ret = node_table_set_columns(&table, num_rows, flags, time, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
-                (num_rows + 1) * sizeof(list_len_t)), 0);
+                (num_rows + 1) * sizeof(table_size_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
     ret = node_table_append_columns(&table, num_rows, flags, time, NULL, NULL, NULL);
@@ -6148,7 +6148,7 @@ test_node_table(void)
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time + num_rows, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
-                (num_rows + 1) * sizeof(list_len_t)), 0);
+                (num_rows + 1) * sizeof(table_size_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset + num_rows, metadata_offset,
                 num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
@@ -6250,7 +6250,7 @@ test_site_table(void)
     size_t num_rows, j;
     char *ancestral_state;
     double *position;
-    list_len_t *ancestral_state_offset;
+    table_size_t *ancestral_state_offset;
 
     ret = site_table_alloc(&table, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6364,7 +6364,7 @@ test_mutation_table(void)
     site_id_t *site;
     char *derived_state;
     char c[max_len + 1];
-    list_len_t *derived_state_offset;
+    table_size_t *derived_state_offset;
 
     for (j = 0; j < max_len; j++) {
         c[j] = 'A' + j;
@@ -6399,7 +6399,7 @@ test_mutation_table(void)
     CU_ASSERT_FATAL(parent != NULL);
     derived_state = malloc(num_rows * sizeof(char));
     CU_ASSERT_FATAL(derived_state != NULL);
-    derived_state_offset = malloc((num_rows + 1) * sizeof(list_len_t));
+    derived_state_offset = malloc((num_rows + 1) * sizeof(table_size_t));
     CU_ASSERT_FATAL(derived_state_offset != NULL);
 
     for (j = 0; j < num_rows; j++) {
@@ -6450,7 +6450,7 @@ test_mutation_table(void)
     CU_ASSERT_EQUAL(memcmp(table.derived_state, derived_state,
                 num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.derived_state_offset, derived_state_offset,
-                num_rows * sizeof(list_len_t)), 0);
+                num_rows * sizeof(table_size_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.derived_state_length, num_rows);
 
@@ -6684,12 +6684,12 @@ test_provenance_table(void)
     timestamp = malloc(num_rows * sizeof(char));
     memset(timestamp, 'a', num_rows * sizeof(char));
     CU_ASSERT_FATAL(timestamp != NULL);
-    timestamp_offset = malloc((num_rows + 1) * sizeof(list_len_t));
+    timestamp_offset = malloc((num_rows + 1) * sizeof(table_size_t));
     CU_ASSERT_FATAL(timestamp_offset != NULL);
     record = malloc(num_rows * sizeof(char));
     memset(record, 'a', num_rows * sizeof(char));
     CU_ASSERT_FATAL(record != NULL);
-    record_offset = malloc((num_rows + 1) * sizeof(list_len_t));
+    record_offset = malloc((num_rows + 1) * sizeof(table_size_t));
     CU_ASSERT_FATAL(record_offset != NULL);
     for (j = 0; j < num_rows + 1; j++) {
         timestamp_offset[j] = j;
@@ -6700,10 +6700,10 @@ test_provenance_table(void)
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.timestamp, timestamp, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.timestamp_offset, timestamp_offset,
-                (num_rows + 1) * sizeof(list_len_t)), 0);
+                (num_rows + 1) * sizeof(table_size_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.record, record, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.record_offset, record_offset,
-                (num_rows + 1) * sizeof(list_len_t)), 0);
+                (num_rows + 1) * sizeof(table_size_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.timestamp_length, num_rows);
     CU_ASSERT_EQUAL(table.record_length, num_rows);

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -67,7 +67,7 @@ static void
 tree_sequence_check_state(tree_sequence_t *self)
 {
     size_t j;
-    list_len_t k, l;
+    table_size_t k, l;
     site_t site;
     site_id_t site_id = 0;
 
@@ -90,7 +90,7 @@ void
 tree_sequence_print_state(tree_sequence_t *self, FILE *out)
 {
     size_t j;
-    list_len_t k, l, m;
+    table_size_t k, l, m;
     site_t site;
 
     fprintf(out, "tree_sequence state\n");
@@ -223,9 +223,9 @@ tree_sequence_alloc_mutations(tree_sequence_t *self)
         msp_safe_free(self->sites.site_mutations);
         msp_safe_free(self->sites.site_mutations_length);
         msp_safe_free(self->sites.tree_sites_mem);
-        self->sites.ancestral_state_offset = malloc((size + 1) * sizeof(list_len_t));
+        self->sites.ancestral_state_offset = malloc((size + 1) * sizeof(table_size_t));
         self->sites.position = malloc(size * sizeof(double));
-        self->sites.site_mutations_length = malloc(size * sizeof(list_len_t));
+        self->sites.site_mutations_length = malloc(size * sizeof(table_size_t));
         self->sites.site_mutations = malloc(size * sizeof(mutation_t *));
         self->sites.tree_sites_mem = malloc(size * sizeof(site_t));
         if (self->sites.ancestral_state_offset == NULL
@@ -267,7 +267,7 @@ tree_sequence_alloc_mutations(tree_sequence_t *self)
         msp_safe_free(self->sites.site_mutations_mem);
         self->mutations.node = malloc(size * sizeof(node_id_t));
         self->mutations.parent = malloc(size * sizeof(mutation_id_t));
-        self->mutations.derived_state_offset = malloc((size + 1) * sizeof(list_len_t));
+        self->mutations.derived_state_offset = malloc((size + 1) * sizeof(table_size_t));
         self->mutations.site = malloc(size * sizeof(site_id_t));
         self->sites.site_mutations_mem = malloc(size * sizeof(mutation_t));
         if (self->mutations.site == NULL
@@ -311,7 +311,7 @@ tree_sequence_alloc_trees(tree_sequence_t *self)
         self->nodes.flags = malloc(size * sizeof(uint32_t));
         self->nodes.time = malloc(size * sizeof(double));
         self->nodes.population = malloc(size * sizeof(population_id_t));
-        self->nodes.metadata_offset = malloc((size + 1) * sizeof(list_len_t));
+        self->nodes.metadata_offset = malloc((size + 1) * sizeof(table_size_t));
         self->nodes.sample_index_map = malloc(size * sizeof(node_id_t));
         if (self->nodes.flags == NULL
                 || self->nodes.time == NULL
@@ -418,8 +418,8 @@ tree_sequence_alloc_provenance(tree_sequence_t *self)
         self->provenances.max_num_records = size;
         msp_safe_free(self->provenances.timestamp_offset);
         msp_safe_free(self->provenances.record_offset);
-        self->provenances.timestamp_offset = malloc((size + 1) * sizeof(list_len_t));
-        self->provenances.record_offset = malloc((size + 1) * sizeof(list_len_t));
+        self->provenances.timestamp_offset = malloc((size + 1) * sizeof(table_size_t));
+        self->provenances.record_offset = malloc((size + 1) * sizeof(table_size_t));
         if (self->provenances.timestamp_offset == NULL
                 || self->provenances.record_offset == NULL) {
             ret = MSP_ERR_NO_MEMORY;
@@ -542,7 +542,7 @@ tree_sequence_free(tree_sequence_t *self)
 }
 
 static int
-check_offset_array(size_t num_rows, size_t total_length, list_len_t *offset)
+check_offset_array(size_t num_rows, size_t total_length, table_size_t *offset)
 {
     int ret = MSP_ERR_BAD_OFFSET;
     int j;
@@ -604,7 +604,7 @@ tree_sequence_check(tree_sequence_t *self)
     int ret = MSP_ERR_GENERIC;
     node_id_t child, parent, last_parent, last_child;
     mutation_id_t parent_mut;
-    list_len_t length;
+    table_size_t length;
     size_t j;
     double left, last_left;
     double *time = self->nodes.time;
@@ -796,13 +796,13 @@ static int
 tree_sequence_init_sites(tree_sequence_t *self)
 {
     site_id_t j;
-    list_len_t k;
+    table_size_t k;
     int ret = 0;
     bool binary = true;
     size_t offset = 0;
 
     self->alphabet = MSP_ALPHABET_ASCII;
-    for (k = 0; k < (list_len_t) self->mutations.num_records; k++) {
+    for (k = 0; k < (table_size_t) self->mutations.num_records; k++) {
         ret = tree_sequence_get_mutation(self, (mutation_id_t) k,
                 self->sites.site_mutations_mem + k);
         if (ret != 0) {
@@ -839,7 +839,7 @@ tree_sequence_init_sites(tree_sequence_t *self)
         self->sites.site_mutations[j] = self->sites.site_mutations_mem + offset;
         self->sites.site_mutations_length[j] = 0;
         /* Go through all mutations for this site */
-        while (k < (list_len_t) self->mutations.num_records
+        while (k < (table_size_t) self->mutations.num_records
                 && self->mutations.site[k] == j) {
             self->sites.site_mutations_length[j]++;
             offset++;
@@ -899,13 +899,13 @@ tree_sequence_init_trees(tree_sequence_t *self)
      */
     msp_safe_free(self->sites.tree_sites);
     msp_safe_free(self->sites.tree_sites_length);
-    self->sites.tree_sites_length = malloc(self->num_trees * sizeof(list_len_t));
+    self->sites.tree_sites_length = malloc(self->num_trees * sizeof(table_size_t));
     self->sites.tree_sites = malloc(self->num_trees * sizeof(site_t *));
     if (self->sites.tree_sites == NULL || self->sites.tree_sites_length == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
-    memset(self->sites.tree_sites_length, 0, self->num_trees * sizeof(list_len_t));
+    memset(self->sites.tree_sites_length, 0, self->num_trees * sizeof(table_size_t));
     memset(self->sites.tree_sites, 0, self->num_trees * sizeof(site_t *));
 
     tree_left = 0;
@@ -1063,7 +1063,7 @@ tree_sequence_load_tables(tree_sequence_t *self, double sequence_length,
             nodes->num_rows * sizeof(population_id_t));
     memcpy(self->nodes.metadata, nodes->metadata, nodes->metadata_length * sizeof(char));
     memcpy(self->nodes.metadata_offset, nodes->metadata_offset,
-            (nodes->num_rows + 1) * sizeof(list_len_t));
+            (nodes->num_rows + 1) * sizeof(table_size_t));
     ret = tree_sequence_init_nodes(self);
     if (ret != 0) {
         goto out;
@@ -1078,7 +1078,7 @@ tree_sequence_load_tables(tree_sequence_t *self, double sequence_length,
         memcpy(self->sites.position, sites->position, sites->num_rows * sizeof(double));
         memcpy(self->sites.ancestral_state_offset,
                 sites->ancestral_state_offset,
-                (sites->num_rows + 1) * sizeof(list_len_t));
+                (sites->num_rows + 1) * sizeof(table_size_t));
         memcpy(self->sites.ancestral_state,
                 sites->ancestral_state, sites->ancestral_state_length * sizeof(char));
     }
@@ -1089,7 +1089,7 @@ tree_sequence_load_tables(tree_sequence_t *self, double sequence_length,
                 mutations->num_rows * sizeof(mutation_id_t));
         memcpy(self->mutations.derived_state_offset,
                 mutations->derived_state_offset,
-                (mutations->num_rows + 1) * sizeof(list_len_t));
+                (mutations->num_rows + 1) * sizeof(table_size_t));
         memcpy(self->mutations.derived_state,
                 mutations->derived_state,
                 mutations->derived_state_length * sizeof(char));
@@ -1109,11 +1109,11 @@ tree_sequence_load_tables(tree_sequence_t *self, double sequence_length,
     }
     if (provenance != NULL) {
         memcpy(self->provenances.timestamp_offset, provenance->timestamp_offset,
-                (provenance->num_rows + 1) * sizeof(list_len_t));
+                (provenance->num_rows + 1) * sizeof(table_size_t));
         memcpy(self->provenances.timestamp, provenance->timestamp,
                 provenance->timestamp_length * sizeof(char));
         memcpy(self->provenances.record_offset, provenance->record_offset,
-                (provenance->num_rows + 1) * sizeof(list_len_t));
+                (provenance->num_rows + 1) * sizeof(table_size_t));
         memcpy(self->provenances.record, provenance->record,
                 provenance->record_length * sizeof(char));
     }
@@ -1151,7 +1151,7 @@ tree_sequence_dump_tables(tree_sequence_t *self,
     int ret = -1;
     size_t j;
     double left, right;
-    list_len_t offset, length, timestamp_offset, timestamp_length,
+    table_size_t offset, length, timestamp_offset, timestamp_length,
                record_offset, record_length;
 
     if (nodes == NULL || edges == NULL) {
@@ -2120,7 +2120,7 @@ tree_sequence_get_pairwise_diversity(tree_sequence_t *self,
     sparse_tree_t *tree = NULL;
     double result, denom, n, count;
     site_t *sites;
-    list_len_t j, k, num_sites;
+    table_size_t j, k, num_sites;
 
     if (num_samples < 2 || num_samples > self->num_samples) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
@@ -2175,7 +2175,7 @@ int WARN_UNUSED
 tree_sequence_get_node(tree_sequence_t *self, node_id_t index, node_t *node)
 {
     int ret = 0;
-    list_len_t offset, length;
+    table_size_t offset, length;
 
     if (index < 0 || index >= (node_id_t) self->nodes.num_records) {
         ret = MSP_ERR_OUT_OF_BOUNDS;
@@ -2232,7 +2232,7 @@ int WARN_UNUSED
 tree_sequence_get_mutation(tree_sequence_t *self, mutation_id_t id, mutation_t *record)
 {
     int ret = 0;
-    list_len_t offset, length;
+    table_size_t offset, length;
 
     if (id < 0 || id >= (mutation_id_t) self->mutations.num_records) {
         ret = MSP_ERR_OUT_OF_BOUNDS;
@@ -2255,7 +2255,7 @@ int WARN_UNUSED
 tree_sequence_get_site(tree_sequence_t *self, site_id_t id, site_t *record)
 {
     int ret = 0;
-    list_len_t offset, length;
+    table_size_t offset, length;
 
     if (id < 0 || id >= (site_id_t) self->sites.num_records) {
         ret = MSP_ERR_OUT_OF_BOUNDS;
@@ -2277,13 +2277,13 @@ int WARN_UNUSED
 tree_sequence_get_provenance(tree_sequence_t *self, size_t index, provenance_t *provenance)
 {
     int ret = 0;
-    list_len_t offset, length;
+    table_size_t offset, length;
 
     if (index >= self->provenances.num_records) {
         ret = MSP_ERR_OUT_OF_BOUNDS;
         goto out;
     }
-    provenance->id = (list_len_t) index;
+    provenance->id = (table_size_t) index;
     offset = self->provenances.timestamp_offset[index];
     length = self->provenances.timestamp_offset[index + 1] - offset;
     provenance->timestamp = self->provenances.timestamp + offset;
@@ -3065,7 +3065,7 @@ out:
 }
 
 int WARN_UNUSED
-sparse_tree_get_sites(sparse_tree_t *self, site_t **sites, list_len_t *sites_length)
+sparse_tree_get_sites(sparse_tree_t *self, site_t **sites, table_size_t *sites_length)
 {
     *sites = self->sites;
     *sites_length = self->sites_length;

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -542,7 +542,7 @@ tree_sequence_free(tree_sequence_t *self)
 }
 
 static int
-check_offset_array(size_t num_rows, size_t total_length, list_len_t *restrict offset)
+check_offset_array(size_t num_rows, size_t total_length, list_len_t *offset)
 {
     int ret = MSP_ERR_BAD_OFFSET;
     int j;

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -1413,10 +1413,10 @@ tree_sequence_check_hdf5_dimensions(tree_sequence_t *self, hid_t file_id)
         {"/migrations/dest", self->migrations.num_records},
         {"/migrations/time", self->migrations.num_records},
 
-        {"/provenance/timestamp", self->provenances.timestamp_length},
-        {"/provenance/timestamp_offset", self->provenances.num_records + 1},
-        {"/provenance/record", self->provenances.record_length},
-        {"/provenance/record_offset", self->provenances.num_records + 1},
+        {"/provenances/timestamp", self->provenances.timestamp_length},
+        {"/provenances/timestamp_offset", self->provenances.num_records + 1},
+        {"/provenances/record", self->provenances.record_length},
+        {"/provenances/record_offset", self->provenances.num_records + 1},
     };
     size_t num_fields = sizeof(fields) / sizeof(struct _dimension_check);
     size_t j;
@@ -1488,7 +1488,7 @@ tree_sequence_read_hdf5_groups(tree_sequence_t *self, hid_t file_id)
         "/sites",
         "/mutations",
         "/migrations",
-        "/provenance",
+        "/provenances",
     };
     size_t num_groups = sizeof(groups) / sizeof(const char *);
     size_t j;
@@ -1533,9 +1533,9 @@ tree_sequence_read_hdf5_dimensions(tree_sequence_t *self, hid_t file_id)
         {"/nodes/metadata", &self->nodes.metadata_length},
         {"/edges/left", &self->edges.num_records},
         {"/migrations/left", &self->migrations.num_records},
-        {"/provenance/timestamp_offset", &self->provenances.num_records},
-        {"/provenance/timestamp", &self->provenances.timestamp_length},
-        {"/provenance/record", &self->provenances.record_length},
+        {"/provenances/timestamp_offset", &self->provenances.num_records},
+        {"/provenances/timestamp", &self->provenances.timestamp_length},
+        {"/provenances/record", &self->provenances.record_length},
     };
     size_t num_fields = sizeof(fields) / sizeof(struct _dimension_read);
     size_t j;
@@ -1629,11 +1629,11 @@ tree_sequence_read_hdf5_data(tree_sequence_t *self, hid_t file_id)
         {"/migrations/source", H5T_NATIVE_INT32, self->migrations.source},
         {"/migrations/dest", H5T_NATIVE_INT32, self->migrations.dest},
         {"/migrations/time", H5T_NATIVE_DOUBLE, self->migrations.time},
-        {"/provenance/timestamp", H5T_NATIVE_CHAR, self->provenances.timestamp},
-        {"/provenance/timestamp_offset", H5T_NATIVE_UINT32,
+        {"/provenances/timestamp", H5T_NATIVE_CHAR, self->provenances.timestamp},
+        {"/provenances/timestamp_offset", H5T_NATIVE_UINT32,
             self->provenances.timestamp_offset},
-        {"/provenance/record", H5T_NATIVE_CHAR, self->provenances.record},
-        {"/provenance/record_offset", H5T_NATIVE_UINT32,
+        {"/provenances/record", H5T_NATIVE_CHAR, self->provenances.record},
+        {"/provenances/record_offset", H5T_NATIVE_UINT32,
             self->provenances.record_offset},
     };
     size_t num_fields = sizeof(fields) / sizeof(struct _hdf5_field_read);
@@ -1824,16 +1824,16 @@ tree_sequence_write_hdf5_data(tree_sequence_t *self, hid_t file_id, int flags)
         {"/migrations/dest",
             H5T_STD_I32LE, H5T_NATIVE_INT32,
             self->migrations.num_records, self->migrations.dest},
-        {"/provenance/timestamp",
+        {"/provenances/timestamp",
             H5T_STD_I8LE, H5T_NATIVE_CHAR,
             self->provenances.timestamp_length, self->provenances.timestamp},
-        {"/provenance/timestamp_offset",
+        {"/provenances/timestamp_offset",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
             self->provenances.num_records + 1, self->provenances.timestamp_offset},
-        {"/provenance/record",
+        {"/provenances/record",
             H5T_STD_I8LE, H5T_NATIVE_CHAR,
             self->provenances.record_length, self->provenances.record},
-        {"/provenance/record_offset",
+        {"/provenances/record_offset",
             H5T_STD_U32LE, H5T_NATIVE_UINT32,
             self->provenances.num_records + 1, self->provenances.record_offset},
     };
@@ -1848,7 +1848,7 @@ tree_sequence_write_hdf5_data(tree_sequence_t *self, hid_t file_id, int flags)
         {"/edges"},
         {"/edges/indexes"},
         {"/migrations"},
-        {"/provenance"},
+        {"/provenances"},
     };
     size_t num_groups = sizeof(groups) / sizeof(struct _hdf5_group_write);
     size_t j;
@@ -2283,6 +2283,7 @@ tree_sequence_get_provenance(tree_sequence_t *self, size_t index, provenance_t *
         ret = MSP_ERR_OUT_OF_BOUNDS;
         goto out;
     }
+    provenance->id = (list_len_t) index;
     offset = self->provenances.timestamp_offset[index];
     length = self->provenances.timestamp_offset[index + 1] - offset;
     provenance->timestamp = self->provenances.timestamp + offset;

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -1691,7 +1691,7 @@ tree_sequence_write_hdf5_data(tree_sequence_t *self, hid_t file_id, int flags)
         {"/provenance",
             0, 0, /* We must set this afterwards */
             self->num_provenance_strings, self->provenance_strings},
-        {"/nodes/metadata_",
+        {"/nodes/metadata",
             H5T_STD_I8LE, H5T_NATIVE_CHAR,
             self->nodes.metadata_length, self->nodes.metadata},
         {"/nodes/metadata_offset",

--- a/lib/vargen.c
+++ b/lib/vargen.c
@@ -104,7 +104,7 @@ vargen_apply_tree_site(vargen_t *self, site_t *site, char *genotypes, char state
     node_list_t *w, *tail;
     node_id_t sample_index;
     bool not_done;
-    list_len_t j;
+    table_size_t j;
     char derived;
     char ancestral = (char) (site->ancestral_state[0] - state_offset);
 

--- a/lib/vargen.c
+++ b/lib/vargen.c
@@ -55,6 +55,7 @@ vargen_alloc(vargen_t *self, tree_sequence_t *tree_sequence, int flags)
 
     assert(tree_sequence != NULL);
     memset(self, 0, sizeof(vargen_t));
+
     /* For now, the logic only supports infinite sites binary mutations. We need to
      * think about how to structure this API to support the general case (lots of
      * mutations happening along the tree) without making it too inefficient and

--- a/msprime/__init__.py
+++ b/msprime/__init__.py
@@ -26,7 +26,7 @@ from __future__ import division
 from _msprime import FORWARD  # NOQA
 from _msprime import REVERSE  # NOQA
 
-from msprime.environment import __version__  # NOQA
+from msprime.provenance import __version__  # NOQA
 from msprime.formats import *  # NOQA
 from msprime.trees import *  # NOQA
 from msprime.simulations import *  # NOQA

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 
 import argparse
 import hashlib
+import json
 import os
 import random
 import signal
@@ -824,7 +825,13 @@ def run_dump_mutations(args):
 
 def run_dump_provenances(args):
     tree_sequence = msprime.load(args.history_file)
-    tree_sequence.dump_text(provenances=sys.stdout)
+    if args.human:
+        for provenance in tree_sequence.provenances():
+            d = json.loads(provenance.record)
+            print("id={}, timestamp={}, record={}".format(
+                provenance.id, provenance.timestamp, json.dumps(d, indent=4)))
+    else:
+        tree_sequence.dump_text(provenances=sys.stdout)
 
 
 def run_dump_vcf(args):
@@ -935,6 +942,9 @@ def get_msp_parser():
         "provenances",
         help="Dump provenance information in tabular format.")
     add_history_file_argument(parser)
+    parser.add_argument(
+        "-H", "--human", action="store_true",
+        help="Print out the provenances in a human readable format")
     parser.set_defaults(runner=run_dump_provenances)
 
     parser = subparsers.add_parser(

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -822,9 +822,9 @@ def run_dump_mutations(args):
     tree_sequence.dump_text(mutations=sys.stdout, precision=args.precision)
 
 
-def run_dump_provenance(args):
+def run_dump_provenances(args):
     tree_sequence = msprime.load(args.history_file)
-    tree_sequence.dump_text(provenance=sys.stdout)
+    tree_sequence.dump_text(provenances=sys.stdout)
 
 
 def run_dump_vcf(args):
@@ -932,10 +932,10 @@ def get_msp_parser():
     parser.set_defaults(runner=run_dump_mutations)
 
     parser = subparsers.add_parser(
-        "provenance",
+        "provenances",
         help="Dump provenance information in tabular format.")
     add_history_file_argument(parser)
-    parser.set_defaults(runner=run_dump_provenance)
+    parser.set_defaults(runner=run_dump_provenances)
 
     parser = subparsers.add_parser(
         "haplotypes",

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -822,6 +822,11 @@ def run_dump_mutations(args):
     tree_sequence.dump_text(mutations=sys.stdout, precision=args.precision)
 
 
+def run_dump_provenance(args):
+    tree_sequence = msprime.load(args.history_file)
+    tree_sequence.dump_text(provenance=sys.stdout)
+
+
 def run_dump_vcf(args):
     tree_sequence = msprime.load(args.history_file)
     tree_sequence.write_vcf(sys.stdout, args.ploidy)
@@ -925,6 +930,12 @@ def get_msp_parser():
     add_history_file_argument(parser)
     add_precision_argument(parser)
     parser.set_defaults(runner=run_dump_mutations)
+
+    parser = subparsers.add_parser(
+        "provenance",
+        help="Dump provenance information in tabular format.")
+    add_history_file_argument(parser)
+    parser.set_defaults(runner=run_dump_provenance)
 
     parser = subparsers.add_parser(
         "haplotypes",

--- a/msprime/formats.py
+++ b/msprime/formats.py
@@ -99,12 +99,12 @@ def _convert_hdf5_mutations(
     sites.set_columns(
         position=position,
         ancestral_state=ord("0") * np.ones(num_mutations, dtype=np.int8),
-        ancestral_state_length=np.ones(num_mutations, dtype=np.uint32))
+        ancestral_state_offset=np.arange(num_mutations + 1, dtype=np.uint32))
     mutations.set_columns(
         node=node,
         site=np.arange(num_mutations, dtype=np.int32),
         derived_state=ord("1") * np.ones(num_mutations, dtype=np.int8),
-        derived_state_length=np.ones(num_mutations, dtype=np.uint32))
+        derived_state_offset=np.arange(num_mutations + 1, dtype=np.uint32))
 
 
 def _load_legacy_hdf5_v2(root, remove_duplicate_positions):

--- a/msprime/formats.py
+++ b/msprime/formats.py
@@ -368,11 +368,6 @@ def _dump_legacy_hdf5_v3(tree_sequence, root):
         mutations.create_dataset("position", (l, ), data=position, dtype=float)
         mutations.create_dataset("node", (l, ), data=node, dtype="u4")
 
-    provenance = tree_sequence.get_provenance()
-    if len(provenance) > 0:
-        dt = h5py.special_dtype(vlen=bytes)
-        root.create_dataset("provenance", (len(provenance), ), data=provenance, dtype=dt)
-
 
 def dump_legacy(tree_sequence, filename, version=3):
     """

--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -35,6 +35,13 @@ except ImportError:
     pass
 
 
+# Getting the hdf5 version here on import because we seem to leak memory
+# if we call this function over and over again. Looks like a bug in the
+# underlying HDF5 lib.
+_hdf5_version = _msprime.get_hdf5_version()
+_gsl_version = _msprime.get_gsl_version()
+
+
 def get_environment():
     """
     Returns a dictionary describing the environment in which msprime
@@ -42,10 +49,10 @@ def get_environment():
     """
     env = {
         "hdf5": {
-            "version": _msprime.get_hdf5_version()
+            "version": _hdf5_version
         },
         "gsl": {
-            "version": _msprime.get_gsl_version()
+            "version": _gsl_version
         },
         "os": {
             "system": platform.system(),

--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 University of Oxford
+# Copyright (C) 2016-2017 University of Oxford
 #
 # This file is part of msprime.
 #
@@ -17,7 +17,7 @@
 # along with msprime.  If not, see <http://www.gnu.org/licenses/>.
 #
 """
-Common environment methods used to determine the state and versions
+Common provenance methods used to determine the state and versions
 of various dependencies and the OS.
 """
 from __future__ import print_function
@@ -60,3 +60,19 @@ def get_environment():
         }
     }
     return env
+
+
+def get_provenance_dict(command, parameters):
+    """
+    Returns a dictionary encoding an execution of msprime.
+
+    Note: this format is incomplete and provisional.
+    """
+    document = {
+        "software": "msprime",
+        "version": __version__,
+        "command": command,
+        "parameters": parameters,
+        "environment": get_environment()
+    }
+    return document

--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -62,7 +62,7 @@ def get_environment():
     return env
 
 
-def get_provenance_dict(command, parameters):
+def get_provenance_dict(command, parameters=None):
     """
     Returns a dictionary encoding an execution of msprime.
 

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -356,7 +356,7 @@ class Simulator(object):
         self.node_table = tables.NodeTable(block_size)
         self.edge_table = tables.EdgeTable(block_size)
         self.migration_table = tables.MigrationTable(block_size)
-        self.mutation_type_table = tables.SiteTable()
+        self.site_table = tables.SiteTable()
         self.mutation_table = tables.MutationTable(block_size)
         self.provenance_table = tables.ProvenanceTable()
 
@@ -576,16 +576,14 @@ class Simulator(object):
             recombination_map=ll_recomb_map)
         if mutation_generator is not None:
             mutation_generator.generate(
-                self.node_table, self.edge_table, self.mutation_type_table,
-                self.mutation_table)
+                self.node_table, self.edge_table, self.site_table, self.mutation_table)
         self.provenance_table.reset()
-        # if provenance is not None:
-        #     self.provenance_table.add_row(provenance)
-        # print(self.provenance_table)
+        if provenance is not None:
+            self.provenance_table.add_row(provenance)
         ll_tree_sequence = _msprime.TreeSequence()
         ll_tree_sequence.load_tables(
             self.node_table, self.edge_table, self.migration_table,
-            self.mutation_type_table, self.mutation_table)
+            self.site_table, self.mutation_table, self.provenance_table)
         return trees.TreeSequence(ll_tree_sequence)
 
     def reset(self):

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -103,13 +103,13 @@ def _replicate_generator(
     # simulation parameters so that particular simulations can be
     # replicated. This will also involve encoding the state of the
     # random generator.
-    provenance = [json.dumps(provenance_dict).encode()]
+    # provenance = [json.dumps(provenance_dict).encode()]
     # Should use range here, but Python 2 makes this awkward...
     j = 0
     while j < num_replicates:
         j += 1
         sim.run()
-        tree_sequence = sim.get_tree_sequence(mutation_generator, provenance)
+        tree_sequence = sim.get_tree_sequence(mutation_generator)
         yield tree_sequence
         sim.reset()
 
@@ -565,7 +565,7 @@ class Simulator(object):
             self.ll_sim = self.create_ll_instance()
         self.ll_sim.run()
 
-    def get_tree_sequence(self, mutation_generator=None, provenance_strings=[]):
+    def get_tree_sequence(self, mutation_generator=None):
         """
         Returns a TreeSequence representing the state of the simulation.
         """
@@ -580,8 +580,7 @@ class Simulator(object):
         ll_tree_sequence = _msprime.TreeSequence()
         ll_tree_sequence.load_tables(
             self.node_table, self.edge_table, self.migration_table,
-            self.mutation_type_table, self.mutation_table,
-            provenance_strings=provenance_strings)
+            self.mutation_type_table, self.mutation_table)
         return trees.TreeSequence(ll_tree_sequence)
 
     def reset(self):

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -22,7 +22,7 @@ Tree sequence IO via the tables API.
 from __future__ import division
 from __future__ import print_function
 
-# import datetime
+import datetime
 
 from six.moves import copyreg
 
@@ -416,12 +416,23 @@ class ProvenanceTable(_msprime.ProvenanceTable):
     """
     TODO Document
     """
-    # def add_row(self, record, timestamp=None):
-    #     if timestamp is None:
-    #         timestamp = datetime.datetime.now().isoformat()
-    #     print(timestamp)
+    def add_row(self, record, timestamp=None):
+        """
+        Adds a new row to this ProvenanceTable consisting of the specified record and
+        timestamp. If timestamp is not specified, it is automatically generated from
+        the current time.
 
-    #     super(ProvenanceTable, self).add_row(record=record, timestamp=timestamp)
+        :param str record: A provenance record, describing the parameters and
+            environment used to generate the current set of tables.
+        :param str timestamp: A string timestamp. This should be in ISO8601 form.
+        """
+        if timestamp is None:
+            timestamp = datetime.datetime.now().isoformat()
+        # Note that the order of the positional arguments has been reversed
+        # from the low-level module, which is a bit confusing. However, we
+        # want the default behaviour here to be to add a row to the table at
+        # the current time as simply as possible.
+        super(ProvenanceTable, self).add_row(record=record, timestamp=timestamp)
 
     def __str__(self):
         timestamp = unpack_strings(self.timestamp, self.timestamp_offset)

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -88,7 +88,6 @@ class NodeTable(_msprime.NodeTable):
 
     # Unpickle support
     def __setstate__(self, state):
-        self.__init__()
         self.set_columns(
             time=state["time"], flags=state["flags"], population=state["population"],
             metadata=state["metadata"], metadata_offset=state["metadata_offset"])
@@ -183,7 +182,6 @@ class EdgeTable(_msprime.EdgeTable):
 
     # Unpickle support
     def __setstate__(self, state):
-        self.__init__()
         self.set_columns(
             left=state["left"], right=state["right"], parent=state["parent"],
             child=state["child"])
@@ -243,7 +241,6 @@ class MigrationTable(_msprime.MigrationTable):
 
     # Unpickle support
     def __setstate__(self, state):
-        self.__init__()
         self.set_columns(
             left=state["left"], right=state["right"], node=state["node"],
             source=state["source"], dest=state["dest"], time=state["time"])
@@ -311,7 +308,6 @@ class SiteTable(_msprime.SiteTable):
 
     # Unpickle support
     def __setstate__(self, state):
-        self.__init__()
         self.set_columns(
             position=state["position"], ancestral_state=state["ancestral_state"],
             ancestral_state_offset=state["ancestral_state_offset"])
@@ -385,7 +381,6 @@ class MutationTable(_msprime.MutationTable):
 
     # Unpickle support
     def __setstate__(self, state):
-        self.__init__()
         self.set_columns(
             site=state["site"], node=state["node"], parent=state["parent"],
             derived_state=state["derived_state"],
@@ -453,7 +448,6 @@ class ProvenanceTable(_msprime.ProvenanceTable):
 
     # Unpickle support
     def __setstate__(self, state):
-        self.__init__()
         self.set_columns(
             timestamp=state["timestamp"],
             timestamp_offset=state["timestamp_offset"],

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -22,6 +22,8 @@ Tree sequence IO via the tables API.
 from __future__ import division
 from __future__ import print_function
 
+# import datetime
+
 from six.moves import copyreg
 
 import _msprime
@@ -412,22 +414,21 @@ def _mutation_table_pickle(table):
 
 class ProvenanceTable(_msprime.ProvenanceTable):
     """
-    Class for tables describing all sites at which mutations have occurred in a
-    tree sequence, of the form
-        id	position	timestamp
-        0	0.1     	0
-        1	0.5     	0
-    Here ``id`` is not stored directly, but is determined by the row index in
-    the table.  ``position`` is the position along the genome, and
-    ``timestamp`` gives the allele at the root of the tree at that
-    position.
+    TODO Document
     """
+    # def add_row(self, record, timestamp=None):
+    #     if timestamp is None:
+    #         timestamp = datetime.datetime.now().isoformat()
+    #     print(timestamp)
+
+    #     super(ProvenanceTable, self).add_row(record=record, timestamp=timestamp)
+
     def __str__(self):
         timestamp = unpack_strings(self.timestamp, self.timestamp_offset)
-        provenance = unpack_strings(self.provenance, self.provenance_offset)
-        ret = "id\ttimestamp\tprovenance\n"
+        record = unpack_strings(self.record, self.record_offset)
+        ret = "id\ttimestamp\trecord\n"
         for j in range(self.num_rows):
-            ret += "{}\t{}\t{}\n".format(j, timestamp[j], provenance[j])
+            ret += "{}\t{}\t{}\n".format(j, timestamp[j], record[j])
         return ret[:-1]
 
     def __eq__(self, other):
@@ -436,8 +437,8 @@ class ProvenanceTable(_msprime.ProvenanceTable):
             ret = (
                 np.array_equal(self.timestamp, other.timestamp) and
                 np.array_equal(self.timestamp_offset, other.timestamp_offset) and
-                np.array_equal(self.provenance, other.provenance) and
-                np.array_equal(self.provenance_offset, other.provenance_offset))
+                np.array_equal(self.record, other.record) and
+                np.array_equal(self.record_offset, other.record_offset))
         return ret
 
     def __ne__(self, other):
@@ -451,8 +452,8 @@ class ProvenanceTable(_msprime.ProvenanceTable):
         self.set_columns(
             timestamp=state["timestamp"],
             timestamp_offset=state["timestamp_offset"],
-            provenance=state["provenance"],
-            provenance_offset=state["provenance_offset"])
+            record=state["record"],
+            record_offset=state["record_offset"])
 
     def copy(self):
         """
@@ -462,8 +463,8 @@ class ProvenanceTable(_msprime.ProvenanceTable):
         copy.set_columns(
             timestamp=self.timestamp,
             timestamp_offset=self.timestamp_offset,
-            provenance=self.provenance,
-            provenance_offset=self.provenance_offset)
+            record=self.record,
+            record_offset=self.record_offset)
         return copy
 
 
@@ -472,8 +473,8 @@ def _provenance_table_pickle(table):
     state = {
         "timestamp": table.timestamp,
         "timestamp_offset": table.timestamp_offset,
-        "provenance": table.provenance,
-        "provenance_offset": table.provenance_offset,
+        "record": table.record,
+        "record_offset": table.record_offset,
     }
     return ProvenanceTable, tuple(), state
 

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -544,9 +544,11 @@ def pack_bytes(data):
     Packs the specified list of bytes into a flattened numpy array of 8 bit integers
     and corresponding lengths.
     """
-    lengths = np.array([0] + [len(b) for b in data], dtype=np.uint32)
-    offsets = np.cumsum(lengths, dtype=np.uint32)
-    column = np.empty(offsets[-1], dtype=np.int8)
+    n = len(data)
+    offsets = np.zeros(n + 1, dtype=np.uint32)
+    for j in range(n):
+        offsets[j + 1] = offsets[j] + len(data[j])
+    column = np.zeros(offsets[-1], dtype=np.int8)
     for j, value in enumerate(data):
         column[offsets[j]: offsets[j + 1]] = bytearray(value)
     return column, offsets

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -71,8 +71,8 @@ class NodeTable(_msprime.NodeTable):
                 np.array_equal(self.flags, other.flags) and
                 np.array_equal(self.population, other.population) and
                 np.array_equal(self.time, other.time) and
-                np.array_equal(self.name, other.name) and
-                np.array_equal(self.name_offset, other.name_offset))
+                np.array_equal(self.metadata, other.metadata) and
+                np.array_equal(self.metadata_offset, other.metadata_offset))
         return ret
 
     def __ne__(self, other):
@@ -86,7 +86,7 @@ class NodeTable(_msprime.NodeTable):
         self.__init__()
         self.set_columns(
             time=state["time"], flags=state["flags"], population=state["population"],
-            name=state["name"], name_offset=state["name_offset"])
+            metadata=state["metadata"], metadata_offset=state["metadata_offset"])
 
     def copy(self):
         """
@@ -95,7 +95,7 @@ class NodeTable(_msprime.NodeTable):
         copy = NodeTable()
         copy.set_columns(
             flags=self.flags, time=self.time, population=self.population,
-            name=self.name, name_offset=self.name_offset)
+            metadata=self.metadata, metadata_offset=self.metadata_offset)
         return copy
 
 
@@ -105,8 +105,8 @@ def _pickle_node_table(table):
         "time": table.time,
         "flags": table.flags,
         "population": table.population,
-        "name": table.name,
-        "name_offset": table.name_offset,
+        "metadata": table.metadata,
+        "metadata_offset": table.metadata_offset,
     }
     return NodeTable, tuple(), state
 

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -59,9 +59,14 @@ class NodeTable(_msprime.NodeTable):
         time = self.time
         flags = self.flags
         population = self.population
-        ret = "id\tis_sample\tpopulation\ttime\n"
+        metadata = unpack_bytes(self.metadata, self.metadata_offset)
+        ret = "id\tis_sample\tpopulation\ttime\tmetadata\n"
         for j in range(self.num_rows):
-            ret += "{}\t{}\t{}\t\t{:.14f}\n".format(j, flags[j], population[j], time[j])
+            # Not clear how we should deal with printing metadata out here.
+            # Probably try to decode as utf8, but printout as raw bytes if
+            # this fails??
+            ret += "{}\t{}\t{}\t{:.14f}\t{}\n".format(
+                j, flags[j], population[j], time[j], metadata[j])
         return ret[:-1]
 
     def __eq__(self, other):

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -508,12 +508,14 @@ class TableCollection(object):
     printing and comparisons of a collection of related tables.
     """
     def __init__(
-            self, nodes=None, edges=None, migrations=None, sites=None, mutations=None):
+            self, nodes=None, edges=None, migrations=None, sites=None, mutations=None,
+            provenances=None):
         self.nodes = nodes
         self.edges = edges
         self.migrations = migrations
         self.sites = sites
         self.mutations = mutations
+        self.provenances = provenances
 
     def asdict(self):
         """
@@ -525,7 +527,8 @@ class TableCollection(object):
             "edges": self.edges,
             "migrations": self.migrations,
             "sites": self.sites,
-            "mutations": self.mutations
+            "mutations": self.mutations,
+            "provenances": self.provenances
         }
 
     def __banner(self, title):
@@ -547,6 +550,8 @@ class TableCollection(object):
         s += str(self.mutations) + "\n"
         s += self.__banner("Migrations")
         s += str(self.migrations)
+        s += self.__banner("Provenances")
+        s += str(self.provenances)
         return s
 
     # TODO add support for __eq__ and __ne__
@@ -586,7 +591,12 @@ def sort_tables(*args, **kwargs):
     :param MutationTable mutations:
     :param int edge_start: The index in the edge table where sorting starts.
     """
-    return _msprime.sort_tables(*args, **kwargs)
+    kwargs_copy = dict(kwargs)
+    # If provenances is supplied as a keyword argument just ignore it. This is
+    # because we'll often call sort_tables(**t.asdict()), and the provenances
+    # entry breaks this pattern.
+    kwargs_copy.pop("provenances", None)
+    return _msprime.sort_tables(*args, **kwargs_copy)
 
 
 def simplify_tables(*args, **kwargs):

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -626,8 +626,14 @@ def simplify_tables(*args, **kwargs):
     Simplifies the tables, in place, to retain only the information necessary
     to reconstruct the tree sequence describing the given ``samples``.  This
     will change the ID of the nodes, so that the individual ``samples[k]]``
-    will have ID ``k`` in the result.  The resulting NodeTable will have only
-    the first ``len(samples)`` individuals marked as samples.
+    will have ID ``k`` in the result. The resulting NodeTable will have only
+    the first ``len(samples)`` individuals marked as samples. The mapping from
+    node IDs in the current set of tables to their equivalent values in the
+    simplified tables is returned as a numpy array. If an array ``a`` is
+    returned by this function and ``u`` is the ID of a node in the input
+    table, then ``a[u]`` is the ID of this node in the output table. For
+    any node ``u`` that is not mapped into the output tables, this mapping
+    will equal ``-1``.
 
     Tables operated on by this function must: be sorted (see ``sort_tables``),
     have children be born strictly after their parents, and the intervals on
@@ -643,6 +649,9 @@ def simplify_tables(*args, **kwargs):
     :param MutationTable mutations: The MutationTable to be simplified.
     :param bool filter_invariant_sites: Whether to remove sites that have no
         mutations from the output (default: True).
+    :return: A numpy array mapping node IDs in the input tables to their
+        corresponding node IDs in the output tables.
+    :rtype: numpy array (dtype=np.int32).
     """
     return _msprime.simplify_tables(*args, **kwargs)
 

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1121,7 +1121,8 @@ class TreeSequence(object):
             mutations=mutations)
 
     def dump_text(
-            self, nodes=None, edges=None, sites=None, mutations=None, precision=6):
+            self, nodes=None, edges=None, sites=None, mutations=None, provenance=None,
+            precision=6):
         """
         Writes a text representation of the tables underlying the tree sequence
         to the specified connections.
@@ -1131,6 +1132,7 @@ class TreeSequence(object):
         :param stream edges: The file-like object to write the EdgeTable to.
         :param stream sites: The file-like object to write the SiteTable to.
         :param stream mutations: The file-like object to write the MutationTable to.
+        :param stream mutations: The file-like object to write the ProvenanceTable to.
         :param int precision: The number of digits of precision.
         """
 
@@ -1182,6 +1184,20 @@ class TreeSequence(object):
                             derived_state=mutation.derived_state,
                             parent=mutation.parent)
                     print(row, file=mutations)
+
+        # if provenance is not None:
+        #     print("timestamp", "prov", sep="\t", file=mutations)
+        #     for record in self.provenance():
+        #         for mutation in site.mutations:
+        #             row = (
+        #                 "{site}\t"
+        #                 "{node}\t"
+        #                 "{derived_state}\t"
+        #                 "{parent}").format(
+        #                     site=mutation.site, node=mutation.node,
+        #                     derived_state=mutation.derived_state,
+        #                     parent=mutation.parent)
+        #             print(row, file=mutations)
 
     # num_samples was originally called sample_size, and so we must keep sample_size
     # around as a deprecated alias.

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1121,7 +1121,7 @@ class TreeSequence(object):
             mutations=mutations)
 
     def dump_text(
-            self, nodes=None, edges=None, sites=None, mutations=None, provenance=None,
+            self, nodes=None, edges=None, sites=None, mutations=None, provenances=None,
             precision=6):
         """
         Writes a text representation of the tables underlying the tree sequence
@@ -1132,7 +1132,7 @@ class TreeSequence(object):
         :param stream edges: The file-like object to write the EdgeTable to.
         :param stream sites: The file-like object to write the SiteTable to.
         :param stream mutations: The file-like object to write the MutationTable to.
-        :param stream mutations: The file-like object to write the ProvenanceTable to.
+        :param stream provenances: The file-like object to write the ProvenanceTable to.
         :param int precision: The number of digits of precision.
         """
 
@@ -1185,19 +1185,17 @@ class TreeSequence(object):
                             parent=mutation.parent)
                     print(row, file=mutations)
 
-        # if provenance is not None:
-        #     print("timestamp", "prov", sep="\t", file=mutations)
-        #     for record in self.provenance():
-        #         for mutation in site.mutations:
-        #             row = (
-        #                 "{site}\t"
-        #                 "{node}\t"
-        #                 "{derived_state}\t"
-        #                 "{parent}").format(
-        #                     site=mutation.site, node=mutation.node,
-        #                     derived_state=mutation.derived_state,
-        #                     parent=mutation.parent)
-        #             print(row, file=mutations)
+        if provenances is not None:
+            print("id", "timestamp", "record", sep="\t", file=mutations)
+            for provenance in self.provenances():
+                row = (
+                    "{id}\t"
+                    "{timestamp}\t"
+                    "{record}\t").format(
+                        id=provenance.id,
+                        timestamp=provenance.timestamp,
+                        record=provenance.record)
+                print(row, file=provenances)
 
     # num_samples was originally called sample_size, and so we must keep sample_size
     # around as a deprecated alias.

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -71,7 +71,7 @@ Migration = collections.namedtuple(
 
 Site = collections.namedtuple(
     "Site",
-    ["position", "ancestral_state", "index", "mutations"])
+    ["position", "ancestral_state", "index", "mutations", "metadata"])
 
 
 Mutation = collections.namedtuple(
@@ -556,10 +556,11 @@ class SparseTree(object):
 
     def sites(self):
         for ll_site in self._ll_sparse_tree.get_sites():
-            pos, ancestral_state, mutations, index = ll_site
+            pos, ancestral_state, mutations, index, metadata = ll_site
             yield Site(
                 position=pos, ancestral_state=ancestral_state, index=index,
-                mutations=[Mutation(*mutation) for mutation in mutations])
+                mutations=[Mutation(*mutation) for mutation in mutations],
+                metadata=metadata)
 
     def mutations(self):
         """
@@ -1409,10 +1410,12 @@ class TreeSequence(object):
 
     def sites(self):
         for j in range(self.num_sites):
-            pos, ancestral_state, mutations, index = self._ll_tree_sequence.get_site(j)
+            ll_site = self._ll_tree_sequence.get_site(j)
+            pos, ancestral_state, mutations, index, metadata = ll_site
             yield Site(
                 position=pos, ancestral_state=ancestral_state, index=index,
-                mutations=[Mutation(*mutation) for mutation in mutations])
+                mutations=[Mutation(*mutation) for mutation in mutations],
+                metadata=metadata)
 
     def mutations(self):
         """
@@ -1589,19 +1592,21 @@ class TreeSequence(object):
         iterator = _msprime.VariantGenerator(
             self._ll_tree_sequence, genotypes_buffer, as_bytes)
         if as_bytes:
-            for pos, ancestral_state, mutations, index in iterator:
+            for pos, ancestral_state, mutations, index, metadata in iterator:
                 site = Site(
                     position=pos, ancestral_state=ancestral_state, index=index,
-                    mutations=[Mutation(*mutation) for mutation in mutations])
+                    mutations=[Mutation(*mutation) for mutation in mutations],
+                    metadata=metadata)
                 g = bytes(genotypes_buffer)
                 yield Variant(position=pos, site=site, index=index, genotypes=g)
         else:
             check_numpy()
             g = np.frombuffer(genotypes_buffer, "u1", n)
-            for pos, ancestral_state, mutations, index in iterator:
+            for pos, ancestral_state, mutations, index, metadata in iterator:
                 site = Site(
                     position=pos, ancestral_state=ancestral_state, index=index,
-                    mutations=[Mutation(*mutation) for mutation in mutations])
+                    mutations=[Mutation(*mutation) for mutation in mutations],
+                    metadata=metadata)
                 yield Variant(position=pos, site=site, index=index, genotypes=g)
 
     def genotype_matrix(self):

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -111,10 +111,10 @@ class SimpleContainer(object):
 
 class Node(SimpleContainer):
     def __init__(
-            self, time=0, population=NULL_POPULATION, name="", is_sample=False):
+            self, time=0, population=NULL_POPULATION, metadata="", is_sample=False):
         self.time = time
         self.population = population
-        self.name = name
+        self.metadata = metadata
         self.flags = 0
         if is_sample:
             self.flags |= NODE_IS_SAMPLE
@@ -1621,9 +1621,9 @@ class TreeSequence(object):
         return self._ll_tree_sequence.get_pairwise_diversity(samples)
 
     def node(self, u):
-        flags, time, population, name = self._ll_tree_sequence.get_node(u)
+        flags, time, population, metadata = self._ll_tree_sequence.get_node(u)
         return Node(
-            time=time, population=population, name=name,
+            time=time, population=population, metadata=metadata,
             is_sample=flags & NODE_IS_SAMPLE)
 
     def time(self, u):

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -76,7 +76,7 @@ Site = collections.namedtuple(
 
 Mutation = collections.namedtuple(
     "Mutation",
-    ["site", "node", "derived_state", "parent", "id"])
+    ["site", "node", "derived_state", "parent", "id", "metadata"])
 
 
 # This is provided for backwards compatibility with the deprecated mutations()

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1762,19 +1762,11 @@ class TreeSequence(object):
         t = self.dump_tables()
         if samples is None:
             samples = self.get_samples()
-        if map_nodes:
-            node_map = np.empty(self.num_nodes, dtype=np.int32)
-            tables.simplify_tables(
-                samples=samples, sequence_length=self.sequence_length,
-                nodes=t.nodes, edges=t.edges,
-                sites=t.sites, mutations=t.mutations, node_map=node_map,
-                filter_zero_mutation_sites=filter_zero_mutation_sites)
-        else:
-            tables.simplify_tables(
-                samples=samples, sequence_length=self.sequence_length,
-                nodes=t.nodes, edges=t.edges,
-                sites=t.sites, mutations=t.mutations,
-                filter_zero_mutation_sites=filter_zero_mutation_sites)
+        node_map = tables.simplify_tables(
+            samples=samples, sequence_length=self.sequence_length,
+            nodes=t.nodes, edges=t.edges,
+            sites=t.sites, mutations=t.mutations,
+            filter_zero_mutation_sites=filter_zero_mutation_sites)
         # TODO add simplify arguments here??
         t.provenances.add_row(record=json.dumps(
             provenance.get_provenance_dict("simplify", [])))

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -111,7 +111,9 @@ class SimpleContainer(object):
 
 class Node(SimpleContainer):
     def __init__(
-            self, time=0, population=NULL_POPULATION, metadata="", is_sample=False):
+            self, id_=None, time=0, population=NULL_POPULATION, metadata="",
+            is_sample=False):
+        self.id = id_
         self.time = time
         self.population = population
         self.metadata = metadata
@@ -1133,13 +1135,15 @@ class TreeSequence(object):
         """
 
         if nodes is not None:
-            print("is_sample", "time", "population", sep="\t", file=nodes)
+            print("id", "is_sample", "time", "population", sep="\t", file=nodes)
             for node in self.nodes():
                 row = (
+                    "{id:d}\t"
                     "{is_sample:d}\t"
                     "{time:.{precision}f}\t"
                     "{population:d}\t").format(
-                        precision=precision, is_sample=node.is_sample(), time=node.time,
+                        precision=precision, id=node.id,
+                        is_sample=node.is_sample(), time=node.time,
                         population=node.population)
                 print(row, file=nodes)
 
@@ -1178,28 +1182,6 @@ class TreeSequence(object):
                             derived_state=mutation.derived_state,
                             parent=mutation.parent)
                     print(row, file=mutations)
-
-    def dump_samples_text(self, samples, precision=6):
-        """
-        Writes a text representation of the entries in the NodeTable
-        corresponding to samples to the specified connections.
-
-        :param stream samples: The file-like object to write the subset of the NodeTable
-            describing the samples to, with an extra column, `id`.
-        :param int precision: The number of digits of precision.
-        """
-
-        print("id", "is_sample", "time", "population", sep="\t", file=samples)
-        for node_id in self.samples():
-            node = self.node(node_id)
-            row = (
-                "{node_id:d}\t"
-                "{is_sample:d}\t"
-                "{time:.{precision}f}\t"
-                "{population:d}").format(
-                    precision=precision, is_sample=node.is_sample(), time=node.time,
-                    population=node.population, node_id=node_id)
-            print(row, file=samples)
 
     # num_samples was originally called sample_size, and so we must keep sample_size
     # around as a deprecated alias.
@@ -1623,7 +1605,7 @@ class TreeSequence(object):
     def node(self, u):
         flags, time, population, metadata = self._ll_tree_sequence.get_node(u)
         return Node(
-            time=time, population=population, metadata=metadata,
+            id_=u, time=time, population=population, metadata=metadata,
             is_sample=flags & NODE_IS_SAMPLE)
 
     def time(self, u):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -220,15 +220,16 @@ class PythonTreeSequence(object):
         self._sites = []
         _Site = collections.namedtuple(
             "Site",
-            ["position", "ancestral_state", "index", "mutations"])
+            ["position", "ancestral_state", "index", "mutations", "metadata"])
         _Mutation = collections.namedtuple(
             "Mutation",
             ["site", "node", "derived_state", "parent", "id"])
         for j in range(tree_sequence.get_num_sites()):
-            pos, ancestral_state, mutations, index = tree_sequence.get_site(j)
+            pos, ancestral_state, mutations, index, metadata = tree_sequence.get_site(j)
             self._sites.append(_Site(
                 position=pos, ancestral_state=ancestral_state, index=index,
-                mutations=[_Mutation(*mut) for mut in mutations]))
+                mutations=[_Mutation(*mut) for mut in mutations],
+                metadata=metadata))
 
     def edge_diffs(self):
         M = self._tree_sequence.get_num_edges()
@@ -727,7 +728,8 @@ class Simplifier(object):
             flags |= msprime.NODE_IS_SAMPLE
         self.node_id_map[input_id] = len(self.node_table)
         self.node_table.add_row(
-            flags=flags, time=node.time, population=node.population)
+            flags=flags, time=node.time, population=node.population,
+            metadata=node.metadata)
 
     def flush_edges(self):
         """
@@ -861,7 +863,8 @@ class Simplifier(object):
                             parent=mapped_parent,
                             derived_state=mut.derived_state)
                 self.site_table.add_row(
-                    position=site.position, ancestral_state=site.ancestral_state)
+                    position=site.position, ancestral_state=site.ancestral_state,
+                    metadata=site.metadata)
 
     def simplify(self):
         # print("START")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -223,7 +223,7 @@ class PythonTreeSequence(object):
             ["position", "ancestral_state", "index", "mutations", "metadata"])
         _Mutation = collections.namedtuple(
             "Mutation",
-            ["site", "node", "derived_state", "parent", "id"])
+            ["site", "node", "derived_state", "parent", "id", "metadata"])
         for j in range(tree_sequence.get_num_sites()):
             pos, ancestral_state, mutations, index, metadata = tree_sequence.get_site(j)
             self._sites.append(_Site(
@@ -861,7 +861,8 @@ class Simplifier(object):
                             site=len(self.site_table),
                             node=self.mutation_node_map[mut.id],
                             parent=mapped_parent,
-                            derived_state=mut.derived_state)
+                            derived_state=mut.derived_state,
+                            metadata=mut.metadata)
                 self.site_table.add_row(
                     position=site.position, ancestral_state=site.ancestral_state,
                     metadata=site.metadata)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1514,7 +1514,8 @@ class TestMspConversionOutput(unittest.TestCase):
                 self.assertEqual(col[j], haplotypes[j][site])
 
 
-@unittest.skipIf(not _h5py_available, "h5py not installed, skipping upgrade tests")
+# @unittest.skipIf(not _h5py_available, "h5py not installed, skipping upgrade tests")
+@unittest.skip("provenance API")
 class TestUpgrade(TestCli):
     """
     Tests the results of the upgrade operation to ensure they are

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1231,6 +1231,30 @@ class TestMspArgumentParser(unittest.TestCase):
         self.assertEqual(args.history_file, history_file)
         self.assertEqual(args.precision, 9)
 
+    def test_provenances_default_values(self):
+        parser = cli.get_msp_parser()
+        cmd = "provenances"
+        history_file = "test.hdf5"
+        args = parser.parse_args([cmd, history_file])
+        self.assertEqual(args.history_file, history_file)
+        self.assertEqual(args.human, False)
+
+    def test_provenances_short_args(self):
+        parser = cli.get_msp_parser()
+        cmd = "provenances"
+        history_file = "test.hdf5"
+        args = parser.parse_args([cmd, history_file, "-H"])
+        self.assertEqual(args.history_file, history_file)
+        self.assertEqual(args.human, True)
+
+    def test_provenances_long_args(self):
+        parser = cli.get_msp_parser()
+        cmd = "provenances"
+        history_file = "test.hdf5"
+        args = parser.parse_args([cmd, history_file, "--human"])
+        self.assertEqual(args.history_file, history_file)
+        self.assertEqual(args.human, True)
+
     def test_vcf_default_values(self):
         parser = cli.get_msp_parser()
         cmd = "vcf"
@@ -1430,6 +1454,28 @@ class TestMspConversionOutput(unittest.TestCase):
         self.assertEqual(len(stderr), 0)
         output_mutations = stdout.splitlines()
         self.verify_mutations(output_mutations, precision)
+
+    def verify_provenances(self, output_provenances):
+        with tempfile.TemporaryFile("w+") as f:
+            self._tree_sequence.dump_text(provenances=f)
+            f.seek(0)
+            output = f.read().splitlines()
+        self.assertEqual(output, output_provenances)
+
+    def test_provenances(self):
+        cmd = "provenances"
+        stdout, stderr = capture_output(cli.msp_main, [cmd, self._history_file])
+        self.assertEqual(len(stderr), 0)
+        output_provenances = stdout.splitlines()
+        self.verify_provenances(output_provenances)
+
+    def test_provenances_human(self):
+        cmd = "provenances"
+        stdout, stderr = capture_output(cli.msp_main, [cmd, "-H", self._history_file])
+        self.assertEqual(len(stderr), 0)
+        output_provenances = stdout.splitlines()
+        # TODO Check the actual output here.
+        self.assertGreater(len(output_provenances), 0)
 
     def verify_vcf(self, output_vcf):
         with tempfile.TemporaryFile("w+") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1560,8 +1560,7 @@ class TestMspConversionOutput(unittest.TestCase):
                 self.assertEqual(col[j], haplotypes[j][site])
 
 
-# @unittest.skipIf(not _h5py_available, "h5py not installed, skipping upgrade tests")
-@unittest.skip("provenance API")
+@unittest.skipIf(not _h5py_available, "h5py not installed, skipping upgrade tests")
 class TestUpgrade(TestCli):
     """
     Tests the results of the upgrade operation to ensure they are

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 from __future__ import division
 
 import contextlib
-import json
+# import json
 import os
 import sys
 import tempfile
@@ -155,6 +155,7 @@ class TestHdf5(unittest.TestCase):
         os.unlink(self.temp_file)
 
 
+@unittest.skip("provenance API")
 class TestLoadLegacyExamples(TestHdf5):
     """
     Tests using the saved legacy file examples to ensure we can load them.
@@ -183,6 +184,7 @@ class TestLoadLegacyExamples(TestHdf5):
         self.verify_tree_sequence(ts)
 
 
+@unittest.skip("provenance API")
 class TestRoundTrip(TestHdf5):
     """
     Tests if we can round trip convert a tree sequence in memory
@@ -204,10 +206,10 @@ class TestRoundTrip(TestHdf5):
             num_trees += 1
         self.assertEqual(num_trees, ts.num_trees)
 
-        provenance = tsp.get_provenance()
-        self.assertGreater(len(provenance), 1)
-        for p in provenance:
-            self.assertIsInstance(json.loads(p.decode()), dict)
+        # provenance = tsp.get_provenance()
+        # self.assertGreater(len(provenance), 1)
+        # for p in provenance:
+        #     self.assertIsInstance(json.loads(p.decode()), dict)
 
     def verify_round_trip(self, ts, version):
         msprime.dump_legacy(ts, self.temp_file, version=version)
@@ -507,6 +509,7 @@ class TestHdf5Format(TestHdf5):
     def test_node_names_example(self):
         self.verify_tree_dump_format(node_name_example())
 
+    @unittest.skip("fix provenance tests")
     def test_optional_provenance(self):
         ts = single_locus_no_mutation_example()
         ts.dump(self.temp_file)

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -534,9 +534,7 @@ class TestHdf5FormatErrors(TestHdf5):
         names = []
 
         def visit(name):
-            # The only dataset we can delete on its own is provenance
-            if name != "provenance":
-                names.append(name)
+            names.append(name)
         ts.dump(self.temp_file)
         hfile = h5py.File(self.temp_file, "r")
         hfile.visit(visit)

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -340,6 +340,7 @@ class TestErrors(TestHdf5):
         self.assertRaises(ValueError, msprime.load_legacy, self.temp_file)
 
 
+@unittest.skip("Format update in progress.")
 class TestHdf5Format(TestHdf5):
     """
     Tests on the HDF5 file format.

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -393,9 +393,10 @@ class TestHdf5Format(TestHdf5):
             ("site", int32), ("node", int32), ("parent", int32),
             ("derived_state", int8), ("derived_state_offset", uint32)]
         derived_state_offset = g["derived_state_offset"]
+        self.verify_metadata(g, ts.num_sites)
         if ts.num_mutations == 0:
             self.assertEqual(derived_state_offset.shape, (1,))
-            self.assertEqual(1, len(list(g.keys())))
+            self.assertNotIn("derived_state", list(g.keys()))
         else:
             for name, dtype in fields:
                 self.assertEqual(len(g[name].shape), 1)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1084,14 +1084,14 @@ class TestTreeSequence(HighLevelTestCase):
                 new_node = new_ts.node(node_map[u])
                 self.assertEqual(old_node.time, new_node.time)
                 self.assertEqual(old_node.population, new_node.population)
-                self.assertEqual(old_node.name, new_node.name)
+                self.assertEqual(old_node.metadata, new_node.metadata)
         for u in sample:
             old_node = ts.node(u)
             new_node = new_ts.node(node_map[u])
             self.assertEqual(old_node.flags, new_node.flags)
             self.assertEqual(old_node.time, new_node.time)
             self.assertEqual(old_node.population, new_node.population)
-            self.assertEqual(old_node.name, new_node.name)
+            self.assertEqual(old_node.metadata, new_node.metadata)
         old_trees = ts.trees()
         old_tree = next(old_trees)
         self.assertGreaterEqual(ts.get_num_trees(), new_ts.get_num_trees())
@@ -1414,7 +1414,7 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         checked = 0
         for n1, n2 in zip(ts1.nodes(), ts2.nodes()):
             self.assertEqual(n1.population, n2.population)
-            self.assertEqual(n1.name, n2.name)
+            self.assertEqual(n1.metadata, n2.metadata)
             self.assertAlmostEqual(n1.time, n2.time)
             checked += 1
         self.assertEqual(checked, ts1.num_nodes)
@@ -2116,7 +2116,7 @@ class TestNodeOrdering(HighLevelTestCase):
         self.assertEqual(ts1.num_edges, j)
         j = 0
         for n1, n2 in zip(ts1.nodes(), ts2.nodes()):
-            self.assertEqual(n1.name, n2.name)
+            self.assertEqual(n1.metadata, n2.metadata)
             self.assertEqual(n1.population, n2.population)
             if approx:
                 self.assertAlmostEqual(n1.time, n2.time)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -59,7 +59,8 @@ def get_uniform_mutations(num_mutations, sequence_length, nodes):
     mutations = msprime.MutationTable()
     for j in range(num_mutations):
         sites.add_row(
-            position=j * (sequence_length / num_mutations), ancestral_state='0')
+            position=j * (sequence_length / num_mutations), ancestral_state='0',
+            metadata=json.dumps({"index": j}).encode())
         mutations.add_row(site=j, derived_state='1', node=nodes[j % len(nodes)])
     return sites, mutations
 

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1294,12 +1294,13 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         self.assertEqual(len(output_nodes) - 1, ts.num_nodes)
         self.assertEqual(
             list(output_nodes[0].split()),
-            ["is_sample", "time", "population"])
+            ["id", "is_sample", "time", "population"])
         for node, line in zip(ts.nodes(), output_nodes[1:]):
             splits = line.split("\t")
-            self.assertEqual(str(node.is_sample()), splits[0])
-            self.assertEqual(convert(node.time), splits[1])
-            self.assertEqual(str(node.population), splits[2])
+            self.assertEqual(str(node.id), splits[0])
+            self.assertEqual(str(node.is_sample()), splits[1])
+            self.assertEqual(convert(node.time), splits[2])
+            self.assertEqual(str(node.population), splits[3])
 
     def verify_samples_format(self, ts, samples_file, precision):
         """
@@ -1391,14 +1392,6 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
                 self.verify_edges_format(ts, edges_file, precision)
                 self.verify_sites_format(ts, sites_file, precision)
                 self.verify_mutations_format(ts, mutations_file, precision)
-
-    def test_dump_samples_text(self):
-        for ts in get_example_tree_sequences():
-            for precision in [2, 7]:
-                samples_file = six.StringIO()
-                ts.dump_samples_text(samples_file, precision=precision)
-                samples_file.seek(0)
-                self.verify_samples_format(ts, samples_file, precision)
 
     def verify_approximate_equality(self, ts1, ts2):
         """

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1064,6 +1064,16 @@ class TestTreeSequence(HighLevelTestCase):
             for bad_ploidy in [-1, 0, n + 1]:
                 self.assertRaises(ValueError, ts.write_vcf, self.temp_file, bad_ploidy)
 
+    def verify_simplify_provenance(self, ts):
+        new_ts = ts.simplify()
+        self.assertEqual(new_ts.num_provenances, ts.num_provenances + 1)
+        old = list(ts.provenances())
+        new = list(new_ts.provenances())
+        self.assertEqual(old, new[:-1])
+        # TODO call verify_provenance on this.
+        self.assertGreater(len(new[-1].timestamp), 0)
+        self.assertGreater(len(new[-1].record), 0)
+
     def verify_simplify_topology(self, ts, sample):
         new_ts, node_map = ts.simplify(sample, map_nodes=True)
         if len(sample) == 0:
@@ -1169,6 +1179,7 @@ class TestTreeSequence(HighLevelTestCase):
     def test_simplify(self):
         num_mutations = 0
         for ts in get_example_tree_sequences():
+            self.verify_simplify_provenance(ts)
             n = ts.get_sample_size()
             num_mutations += ts.get_num_mutations()
             sample_sizes = {0, 1}

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1202,6 +1202,7 @@ class TestTreeSequence(HighLevelTestCase):
             j += 1
         self.assertGreater(j, 1)
 
+    @unittest.skip("provenance API")
     def test_apis(self):
         ts = msprime.simulate(10, random_seed=1)
         self.assertEqual(ts.get_ll_tree_sequence(), ts.ll_tree_sequence)
@@ -2024,6 +2025,7 @@ class TestSimulateInterface(unittest.TestCase):
     """
     Some simple test cases for the simulate() interface.
     """
+    @unittest.skip("provenance API")
     def test_defaults(self):
         n = 10
         ts = msprime.simulate(n)
@@ -2034,6 +2036,7 @@ class TestSimulateInterface(unittest.TestCase):
         self.assertEqual(ts.get_sequence_length(), 1)
         self.assertEqual(len(ts.provenance), 1)
 
+    @unittest.skip("provenance API")
     def test_provenance(self):
         ts = msprime.simulate(10)
         self.assertEqual(len(ts.provenance), 1)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -61,7 +61,9 @@ def get_uniform_mutations(num_mutations, sequence_length, nodes):
         sites.add_row(
             position=j * (sequence_length / num_mutations), ancestral_state='0',
             metadata=json.dumps({"index": j}).encode())
-        mutations.add_row(site=j, derived_state='1', node=nodes[j % len(nodes)])
+        mutations.add_row(
+            site=j, derived_state='1', node=nodes[j % len(nodes)],
+            metadata=json.dumps({"index": j}).encode())
     return sites, mutations
 
 
@@ -1160,6 +1162,8 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertEqual(t1.edges, t2.edges)
             self.assertEqual(t1.migrations, t2.migrations)
             self.assertEqual(t1.sites, t2.sites)
+            if t1.mutations != t2.mutations:
+                print(t1.mutations)
             self.assertEqual(t1.mutations, t2.mutations)
 
     def verify_simplify_variants(self, ts, sample):
@@ -1433,10 +1437,13 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         self.assertEqual(ts1.num_edges, checked)
 
         checked = 0
+        # TODO add in checks for metadata here when we implement it in the
+        # the text format.
         for s1, s2 in zip(ts1.sites(), ts2.sites()):
             checked += 1
             self.assertAlmostEqual(s1.position, s2.position)
             self.assertAlmostEqual(s1.ancestral_state, s2.ancestral_state)
+            # self.assertAlmostEqual(s1.metadata, s2.metadata)
             self.assertEqual(s1.mutations, s2.mutations)
         self.assertEqual(ts1.num_sites, checked)
 
@@ -1447,6 +1454,7 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             check += 1
         self.assertEqual(check, ts1.get_num_trees())
 
+    @unittest.skip("text metadata")
     def test_text_record_round_trip(self):
         for ts1 in get_example_tree_sequences():
             nodes_file = six.StringIO()

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2862,18 +2862,21 @@ class TestTablesInterface(LowLevelTestCase):
         sites = _msprime.SiteTable()
         mutations = _msprime.MutationTable()
         migrations = _msprime.MigrationTable()
+        provenances = _msprime.ProvenanceTable()
         kwargs = {
             "nodes": nodes,
             "edges": edges,
             "sites": sites,
             "mutations": mutations,
             "migrations": migrations,
+            "provenances": provenances,
         }
         ts.dump_tables(**kwargs)
         self.verify_node_table(nodes, ts)
         self.verify_edge_table(edges, ts)
         self.verify_migration_table(migrations, ts)
         self.verify_mutation_table(mutations, ts)
+        self.verify_provenance_table(provenances, ts)
 
     def test_dump_tables_errors(self):
         ts = self.get_example_migration_tree_sequence()
@@ -2882,7 +2885,8 @@ class TestTablesInterface(LowLevelTestCase):
             "edges": _msprime.EdgeTable(),
             "sites": _msprime.SiteTable(),
             "mutations": _msprime.MutationTable(),
-            "migrations": _msprime.MigrationTable()
+            "migrations": _msprime.MigrationTable(),
+            "provenances": _msprime.ProvenanceTable()
         }
 
         for bad_type in [None, "", []]:
@@ -2909,6 +2913,7 @@ class TestTablesInterface(LowLevelTestCase):
         sites = _msprime.SiteTable()
         mutations = _msprime.MutationTable()
         migrations = _msprime.MigrationTable()
+        provenances = _msprime.ProvenanceTable()
 
         ts.dump_tables(nodes=nodes, edges=edges)
         self.verify_node_table(nodes, ts)
@@ -2926,6 +2931,11 @@ class TestTablesInterface(LowLevelTestCase):
         self.verify_edge_table(edges, ts)
         self.verify_site_table(sites, ts)
         self.verify_mutation_table(mutations, ts)
+
+        ts.dump_tables(nodes=nodes, edges=edges, provenances=provenances)
+        self.verify_node_table(nodes, ts)
+        self.verify_edge_table(edges, ts)
+        self.verify_provenance_table(provenances, ts)
 
     def test_load_tables(self):
         ex_ts = self.get_example_migration_tree_sequence()
@@ -2961,10 +2971,10 @@ class TestTablesInterface(LowLevelTestCase):
             "sites": _msprime.SiteTable(),
             "mutations": _msprime.MutationTable(),
             "migrations": _msprime.MigrationTable(),
+            "provenances": _msprime.ProvenanceTable(),
         }
         ex_ts.dump_tables(**kwargs)
         ts = _msprime.TreeSequence()
-        kwargs["provenance_strings"] = ["sdf", "wer"]
 
         for bad_type in [None, "", tuple()]:
             for parameter in kwargs.keys():
@@ -2990,9 +3000,11 @@ class TestTablesInterface(LowLevelTestCase):
         sites = _msprime.SiteTable()
         mutations = _msprime.MutationTable()
         migrations = _msprime.MigrationTable()
+        provenances = _msprime.ProvenanceTable()
         ex_ts.dump_tables(
             nodes=nodes, edges=edges, sites=sites,
-            mutations=mutations, migrations=migrations)
+            mutations=mutations, migrations=migrations,
+            provenances=provenances)
 
         ts = _msprime.TreeSequence()
         ts.load_tables(nodes=nodes, edges=edges)
@@ -3017,6 +3029,14 @@ class TestTablesInterface(LowLevelTestCase):
         self.verify_site_table(sites, ts)
         self.verify_mutation_table(mutations, ts)
         self.assertEqual(ts.get_num_migrations(), 0)
+
+        ts = _msprime.TreeSequence()
+        ts.load_tables(nodes=nodes, edges=edges, provenances=provenances)
+        self.verify_node_table(nodes, ts)
+        self.verify_edge_table(edges, ts)
+        self.verify_provenance_table(provenances, ts)
+        self.assertEqual(ts.get_num_migrations(), 0)
+        self.assertEqual(ts.get_num_mutations(), 0)
 
     def test_load_tables_sequence_length(self):
         ex_ts = self.get_example_migration_tree_sequence()

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -3047,14 +3047,14 @@ class TestTablesInterface(LowLevelTestCase):
         self.assertEqual(list(table.metadata), [])
         self.assertEqual(list(table.metadata_offset), [0, 0])
 
-        metadata = "abcde"
+        metadata = b"abcde"
         table = _msprime.NodeTable()
         table.add_row(flags=5, population=10, time=1.23, metadata=metadata)
         self.assertEqual(table.num_rows, 1)
         self.assertEqual(table.population, [10])
         self.assertEqual(table.flags, [5])
         self.assertEqual(table.time, [1.23])
-        self.assertEqual(list(table.metadata), [ord(c) for c in metadata])
+        self.assertEqual(table.metadata.tobytes(), metadata)
         self.assertEqual(list(table.metadata_offset), [0, len(metadata)])
 
     def test_node_table_add_row_errors(self):

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2451,10 +2451,11 @@ class TestSparseTree(LowLevelTestCase):
                     self.assertTrue(st.get_left() <= position < st.get_right())
                     self.assertEqual(index, j)
                     self.assertEqual(metadata, b"")
-                    for site, node, derived_state, parent, mut_id in mutations:
+                    for site, node, derived_state, parent, mut_id, metadata in mutations:
                         self.assertEqual(site, index)
                         self.assertEqual(mutation_id, mut_id)
                         self.assertNotEqual(st.get_parent(node), NULL_NODE)
+                        self.assertEqual(metadata, b"")
                         mutation_id += 1
                     j += 1
             self.assertEqual(all_tree_sites, all_sites)
@@ -3178,8 +3179,9 @@ class TestTablesInterface(LowLevelTestCase):
 
         new_mutations = _msprime.MutationTable()
         for j in range(ts.get_num_mutations()):
-            site, node, derived_state, parent, mut_id = ts.get_mutation(j)
+            site, node, derived_state, parent, mut_id, metadata = ts.get_mutation(j)
             self.assertEqual(mut_id, new_mutations.num_rows)
+            self.assertEqual(metadata, b'')
             new_mutations.add_row(site, node, derived_state, parent)
         self.assertEqual(list(new_mutations.site), list(mutations.site))
         self.assertEqual(list(new_mutations.node), list(mutations.node))

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -468,7 +468,7 @@ class LowLevelTestCase(tests.MsprimeTestCase):
         ts = _msprime.TreeSequence()
         mutgen = _msprime.MutationGenerator(rng, mutation_rate)
         for j in range(num_provenance_records):
-            provenance.add_row(timestamp="y" * j, provenance="x" * j)
+            provenance.add_row(timestamp="y" * j, record="x" * j)
         sim.populate_tables(nodes, edges, migrations)
         mutgen.generate(nodes, edges, sites, mutations)
         ts.load_tables(nodes, edges, migrations, sites, mutations, provenance)

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -569,7 +569,7 @@ class TestSimulationState(LowLevelTestCase):
         self.assertEqual(breakpoints, sorted(breakpoints))
         nodes = sim.get_nodes()
         self.assertEqual(len(nodes), sim.get_num_nodes())
-        for j, (flags, t, pop, name) in enumerate(nodes):
+        for j, (flags, t, pop, metadata) in enumerate(nodes):
             if j < sim.get_num_samples():
                 self.assertEqual(t, 0.0)
                 self.assertEqual(flags, 1)
@@ -577,6 +577,7 @@ class TestSimulationState(LowLevelTestCase):
                 self.assertGreater(t, 0.0)
                 self.assertEqual(flags, 0)
             self.assertTrue(0 <= pop < sim.get_num_populations())
+            self.assertEqual(len(metadata), 0)
 
         edges = sim.get_edges()
         self.assertEqual(len(edges), sim.get_num_edges())
@@ -3043,18 +3044,18 @@ class TestTablesInterface(LowLevelTestCase):
         self.assertEqual(table.population, [-1])
         self.assertEqual(table.flags, [0])
         self.assertEqual(table.time, [0])
-        self.assertEqual(list(table.name), [])
-        self.assertEqual(list(table.name_offset), [0, 0])
+        self.assertEqual(list(table.metadata), [])
+        self.assertEqual(list(table.metadata_offset), [0, 0])
 
-        name = "abcde"
+        metadata = "abcde"
         table = _msprime.NodeTable()
-        table.add_row(flags=5, population=10, time=1.23, name=name)
+        table.add_row(flags=5, population=10, time=1.23, metadata=metadata)
         self.assertEqual(table.num_rows, 1)
         self.assertEqual(table.population, [10])
         self.assertEqual(table.flags, [5])
         self.assertEqual(table.time, [1.23])
-        self.assertEqual(list(table.name), [ord(c) for c in name])
-        self.assertEqual(list(table.name_offset), [0, len(name)])
+        self.assertEqual(list(table.metadata), [ord(c) for c in metadata])
+        self.assertEqual(list(table.metadata_offset), [0, len(metadata)])
 
     def test_node_table_add_row_errors(self):
         table = _msprime.NodeTable()
@@ -3063,7 +3064,7 @@ class TestTablesInterface(LowLevelTestCase):
             self.assertRaises(TypeError, table.add_row, population=bad_type)
             self.assertRaises(TypeError, table.add_row, time=bad_type)
         for bad_type in [234, None, []]:
-            self.assertRaises(TypeError, table.add_row, name=bad_type)
+            self.assertRaises(TypeError, table.add_row, metadata=bad_type)
 
     def test_edge_table_add_row(self):
         table = _msprime.EdgeTable()
@@ -3093,7 +3094,7 @@ class TestTablesInterface(LowLevelTestCase):
                 TypeError, table.add_row, left=0, right=1, parent=1,
                 children=(0, bad_type))
         for bad_type in [234, None, []]:
-            self.assertRaises(TypeError, table.add_row, name=bad_type)
+            self.assertRaises(TypeError, table.add_row, metadata=bad_type)
 
     def test_add_row_data(self):
         nodes = _msprime.NodeTable()
@@ -3107,12 +3108,13 @@ class TestTablesInterface(LowLevelTestCase):
 
         new_nodes = _msprime.NodeTable()
         for j in range(ts.get_num_nodes()):
-            flags, time, population, name = ts.get_node(j)
-            new_nodes.add_row(flags=flags, time=time, population=population, name=name)
+            flags, time, population, metadata = ts.get_node(j)
+            new_nodes.add_row(
+                flags=flags, time=time, population=population, metadata=metadata)
         self.assertEqual(list(nodes.time), list(new_nodes.time))
         self.assertEqual(list(nodes.flags), list(new_nodes.flags))
         self.assertEqual(list(nodes.population), list(new_nodes.population))
-        self.assertEqual(list(nodes.name), list(new_nodes.name))
+        self.assertEqual(list(nodes.metadata), list(new_nodes.metadata))
 
         new_edges = _msprime.EdgeTable()
         for j in range(ts.get_num_edges()):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -71,10 +71,10 @@ class TestMetadataHdf5RoundTrip(unittest.TestCase):
         ts = msprime.simulate(10, random_seed=1)
         tables = ts.dump_tables()
         nodes = tables.nodes
-        # For each node, we create some Python metadata that can be JSON encoded.
+        # For each node, we create some Python metadata that can be pickled
         metadata = [
             {"one": j, "two": 2 * j, "three": list(range(j))} for j in range(len(nodes))]
-        encoded, offset = msprime.pack_bytes(map(pickle.dumps, metadata))
+        encoded, offset = msprime.pack_bytes(list(map(pickle.dumps, metadata)))
         nodes.set_columns(
             flags=nodes.flags, time=nodes.time, population=nodes.population,
             metadata_offset=offset, metadata=encoded)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 University of Oxford
+#
+# This file is part of msprime.
+#
+# msprime is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# msprime is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with msprime.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Tests for metadata handling.
+"""
+from __future__ import print_function
+from __future__ import division
+
+import json
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import msprime
+
+
+class TestMetadataHdf5RoundTrip(unittest.TestCase):
+    """
+    Tests that we can encode metadata under various formats and this will
+    successfully round-trip through the HDF5 format.
+    """
+    def setUp(self):
+        fd, self.temp_file = tempfile.mkstemp(prefix="msp_hdf5meta_test_")
+        os.close(fd)
+
+    def tearDown(self):
+        os.unlink(self.temp_file)
+
+    def test_json(self):
+        ts = msprime.simulate(10, random_seed=1)
+        tables = ts.dump_tables()
+        nodes = tables.nodes
+        # For each node, we create some Python metadata that can be JSON encoded.
+        metadata = [
+            {"one": j, "two": 2 * j, "three": list(range(j))} for j in range(len(nodes))]
+        encoded, offset = msprime.pack_strings(map(json.dumps, metadata))
+        nodes.set_columns(
+            flags=nodes.flags, time=nodes.time, population=nodes.population,
+            metadata_offset=offset, metadata=encoded)
+        self.assertTrue(np.array_equal(nodes.metadata_offset, offset))
+        self.assertTrue(np.array_equal(nodes.metadata, encoded))
+        ts1 = msprime.load_tables(nodes=nodes, edges=tables.edges)
+        for j, node in enumerate(ts1.nodes()):
+            decoded_metadata = json.loads(node.metadata.decode())
+            self.assertEqual(decoded_metadata, metadata[j])
+        ts1.dump(self.temp_file)
+        # TODO Fix this, currently returning lib error.
+        # ts2 = msprime.load(self.temp_file)
+        # self.assertEqual(ts1.tables.nodes, ts2.tables.nodes)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -380,26 +380,28 @@ class CommonTestsMixin(object):
 
             for list_col, offset_col in self.ragged_list_columns:
                 input_data[offset_col.name][0] = -1
-                self.assertRaises(ValueError, t.set_columns, **input_data)
+                self.assertRaises(_msprime.LibraryError, t.set_columns, **input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.set_columns(**input_data)
                 input_data[offset_col.name][-1] = 0
-                self.assertRaises(ValueError, t.set_columns, **input_data)
+                self.assertRaises(_msprime.LibraryError, t.set_columns, **input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.set_columns(**input_data)
                 input_data[offset_col.name][num_rows // 2] = 2**31
                 self.assertRaises(_msprime.LibraryError, t.set_columns, **input_data)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
 
                 input_data[offset_col.name][0] = -1
-                self.assertRaises(ValueError, t.append_columns, **input_data)
+                self.assertRaises(_msprime.LibraryError, t.append_columns, **input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.append_columns(**input_data)
                 input_data[offset_col.name][-1] = 0
-                self.assertRaises(ValueError, t.append_columns, **input_data)
+                self.assertRaises(_msprime.LibraryError, t.append_columns, **input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.append_columns(**input_data)
                 input_data[offset_col.name][num_rows // 2] = 2**31
                 self.assertRaises(_msprime.LibraryError, t.append_columns, **input_data)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
 
 
 class TestNodeTable(unittest.TestCase, CommonTestsMixin):
@@ -508,6 +510,16 @@ class TestMigrationTable(unittest.TestCase, CommonTestsMixin):
     input_parameters = [("max_rows_increment", 1024)]
     equal_len_columns = [["left", "right", "node", "source", "dest", "time"]]
     table_class = msprime.MigrationTable
+
+
+class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
+    columns = []
+    ragged_list_columns = [
+        (CharColumn("timestamp"), UInt32Column("timestamp_offset")),
+        (CharColumn("provenance"), UInt32Column("provenance_offset"))]
+    equal_len_columns = [[]]
+    input_parameters = [("max_rows_increment", 1024)]
+    table_class = msprime.ProvenanceTable
 
 
 class TestStringPacking(unittest.TestCase):

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -492,17 +492,16 @@ class TestSiteTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
     table_class = msprime.SiteTable
 
 
-class TestMutationTable(unittest.TestCase, CommonTestsMixin):
+class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
     columns = [
         Int32Column("site"),
         Int32Column("node"),
         Int32Column("parent")]
     ragged_list_columns = [
-        (CharColumn("derived_state"), UInt32Column("derived_state_offset"))]
+        (CharColumn("derived_state"), UInt32Column("derived_state_offset")),
+        (CharColumn("metadata"), UInt32Column("metadata_offset"))]
     equal_len_columns = [["site", "node"]]
-    input_parameters = [
-        ("max_rows_increment", 1024),
-        ("max_derived_state_length_increment", 1024)]
+    input_parameters = [("max_rows_increment", 1024)]
     table_class = msprime.MutationTable
 
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -399,50 +399,54 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin):
         UInt32Column("flags"),
         DoubleColumn("time"),
         Int32Column("population")]
-    ragged_list_columns = [(CharColumn("name"),  UInt32Column("name_offset"))]
+    ragged_list_columns = [(CharColumn("metadata"),  UInt32Column("metadata_offset"))]
     input_parameters = [("max_rows_increment", 1024)]
     equal_len_columns = [["time", "flags", "population"]]
     table_class = msprime.NodeTable
 
     def test_optional_population(self):
         for num_rows in [0, 10, 100]:
-            names = [str(j) for j in range(num_rows)]
-            name, name_offset = msprime.pack_strings(names)
+            metadatas = [str(j) for j in range(num_rows)]
+            metadata, metadata_offset = msprime.pack_strings(metadatas)
             flags = list(range(num_rows))
             time = list(range(num_rows))
             table = msprime.NodeTable()
             table.set_columns(
-                name=name, name_offset=name_offset, flags=flags, time=time)
+                metadata=metadata, metadata_offset=metadata_offset,
+                flags=flags, time=time)
             self.assertEqual(list(table.population), [-1 for _ in range(num_rows)])
             self.assertEqual(list(table.flags), flags)
             self.assertEqual(list(table.time), time)
-            self.assertEqual(list(table.name), list(name))
-            self.assertEqual(list(table.name_offset), list(name_offset))
+            self.assertEqual(list(table.metadata), list(metadata))
+            self.assertEqual(list(table.metadata_offset), list(metadata_offset))
 
-    def test_random_names(self):
+    def test_random_metadata(self):
         for num_rows in [0, 10, 100]:
-            names = [random_string(10) for _ in range(num_rows)]
-            name, name_offset = msprime.pack_strings(names)
+            metadatas = [random_string(10) for _ in range(num_rows)]
+            metadata, metadata_offset = msprime.pack_strings(metadatas)
             flags = list(range(num_rows))
             time = list(range(num_rows))
             table = msprime.NodeTable()
             table.set_columns(
-                name=name, name_offset=name_offset, flags=flags, time=time)
+                metadata=metadata, metadata_offset=metadata_offset, flags=flags,
+                time=time)
             self.assertEqual(list(table.flags), flags)
             self.assertEqual(list(table.time), time)
-            self.assertEqual(list(table.name), list(name))
-            self.assertEqual(list(table.name_offset), list(name_offset))
-            unpacked_names = msprime.unpack_strings(table.name, table.name_offset)
-            self.assertEqual(names, unpacked_names)
+            self.assertEqual(list(table.metadata), list(metadata))
+            self.assertEqual(list(table.metadata_offset), list(metadata_offset))
+            unpacked_metadatas = msprime.unpack_strings(
+                table.metadata, table.metadata_offset)
+            self.assertEqual(metadatas, unpacked_metadatas)
 
-    def test_optional_names(self):
+    def test_optional_metadata(self):
         for num_rows in [0, 10, 100]:
             flags = list(range(num_rows))
             time = list(range(num_rows))
             table = msprime.NodeTable()
             table.set_columns(flags=flags, time=time)
-            self.assertEqual(len(list(table.name)), 0)
-            self.assertEqual(list(table.name_offset), [0 for _ in range(num_rows + 1)])
+            self.assertEqual(len(list(table.metadata)), 0)
+            self.assertEqual(
+                list(table.metadata_offset), [0 for _ in range(num_rows + 1)])
 
 
 class TestEdgeTable(unittest.TestCase, CommonTestsMixin):

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -107,27 +107,27 @@ class CommonTestsMixin(object):
 
     def test_set_columns_string_errors(self):
         inputs = {c.name: c.get_input(1) for c in self.columns}
-        for list_col, length_col in self.ragged_list_columns:
+        for list_col, offset_col in self.ragged_list_columns:
             value = list_col.get_input(1)
             inputs[list_col.name] = value
-            inputs[length_col.name] = [1]
+            inputs[offset_col.name] = [0, 1]
         # Make sure this works.
         table = self.table_class()
         table.set_columns(**inputs)
-        for list_col, length_col in self.ragged_list_columns:
+        for list_col, offset_col in self.ragged_list_columns:
             kwargs = dict(inputs)
             del kwargs[list_col.name]
             self.assertRaises(TypeError, table.set_columns, **kwargs)
             kwargs = dict(inputs)
-            del kwargs[length_col.name]
+            del kwargs[offset_col.name]
             self.assertRaises(TypeError, table.set_columns, **kwargs)
 
     def test_set_columns_interface(self):
         kwargs = {c.name: c.get_input(1) for c in self.columns}
-        for list_col, length_col in self.ragged_list_columns:
+        for list_col, offset_col in self.ragged_list_columns:
             value = list_col.get_input(1)
             kwargs[list_col.name] = value
-            kwargs[length_col.name] = [1]
+            kwargs[offset_col.name] = [0, 1]
         # Make sure this works.
         table = self.table_class()
         table.set_columns(**kwargs)
@@ -149,12 +149,12 @@ class CommonTestsMixin(object):
         num_rows = 100
         input_data = {col.name: col.get_input(num_rows) for col in self.columns}
         col_map = {col.name: col for col in self.columns}
-        for list_col, length_col in self.ragged_list_columns:
+        for list_col, offset_col in self.ragged_list_columns:
             value = list_col.get_input(num_rows)
             input_data[list_col.name] = value
-            input_data[length_col.name] = np.ones(num_rows, dtype=np.uint32)
+            input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
             col_map[list_col.name] = list_col
-            col_map[length_col.name] = length_col
+            col_map[offset_col.name] = offset_col
         table = self.table_class()
         table.set_columns(**input_data)
         table.append_columns(**input_data)
@@ -193,12 +193,13 @@ class CommonTestsMixin(object):
 
     def test_set_columns_data(self):
         for num_rows in [0, 10, 100, 1000]:
-            input_data = {
-                col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, length_col in self.ragged_list_columns:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            offset_cols = set()
+            for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data[list_col.name] = value
-                input_data[length_col.name] = np.ones(num_rows, dtype=np.uint32)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+                offset_cols.add(offset_col.name)
             table = self.table_class()
             for _ in range(5):
                 table.set_columns(**input_data)
@@ -210,35 +211,45 @@ class CommonTestsMixin(object):
                 self.assertEqual(table.num_rows, 0)
                 self.assertEqual(len(table), 0)
                 for colname in input_data.keys():
-                    self.assertEqual(list(getattr(table, colname)), [])
+                    if colname in offset_cols:
+                        self.assertEqual(list(getattr(table, colname)), [0])
+                    else:
+                        self.assertEqual(list(getattr(table, colname)), [])
 
     def test_append_columns_data(self):
         for num_rows in [0, 10, 100, 1000]:
-            input_data = {
-                col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, length_col in self.ragged_list_columns:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            offset_cols = set()
+            for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data[list_col.name] = value
-                input_data[length_col.name] = np.ones(num_rows, dtype=np.uint32)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+                offset_cols.add(offset_col.name)
             table = self.table_class()
             for j in range(1, 10):
                 table.append_columns(**input_data)
                 for colname, values in input_data.items():
                     output_array = getattr(table, colname)
-                    input_array = np.hstack([values for _ in range(j)])
-                    self.assertEqual(input_array.shape, output_array.shape)
+                    if colname in offset_cols:
+                        input_array = np.zeros(j * num_rows + 1, dtype=np.uint32)
+                        for k in range(j):
+                            input_array[k * num_rows: (k + 1) * num_rows + 1] = (
+                                k * values[-1]) + values
+                        self.assertEqual(input_array.shape, output_array.shape)
+                    else:
+                        input_array = np.hstack([values for _ in range(j)])
+                        self.assertEqual(input_array.shape, output_array.shape)
                     self.assertTrue(np.array_equal(input_array, output_array))
                 self.assertEqual(table.num_rows, j * num_rows)
                 self.assertEqual(len(table), j * num_rows)
 
     def test_append_columns_max_rows(self):
         for num_rows in [0, 10, 100, 1000]:
-            input_data = {
-                col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, length_col in self.ragged_list_columns:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data[list_col.name] = value
-                input_data[length_col.name] = np.ones(num_rows, dtype=np.uint32)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
             for max_rows in [0, 1, 8192]:
                 table = self.table_class(max_rows_increment=max_rows)
                 for j in range(1, 10):
@@ -251,12 +262,11 @@ class CommonTestsMixin(object):
 
     def test_str(self):
         for num_rows in [0, 10]:
-            input_data = {
-                col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, length_col in self.ragged_list_columns:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data[list_col.name] = value
-                input_data[length_col.name] = np.ones(num_rows, dtype=np.uint32)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
             table = self.table_class()
             table.set_columns(**input_data)
             s = str(table)
@@ -264,12 +274,11 @@ class CommonTestsMixin(object):
 
     def test_copy(self):
         for num_rows in [0, 10]:
-            input_data = {
-                col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, length_col in self.ragged_list_columns:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data[list_col.name] = value
-                input_data[length_col.name] = np.ones(num_rows, dtype=np.uint32)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
             table = self.table_class()
             table.set_columns(**input_data)
             for _ in range(10):
@@ -281,12 +290,11 @@ class CommonTestsMixin(object):
 
     def test_pickle(self):
         for num_rows in [0, 10, 100]:
-            input_data = {
-                col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, length_col in self.ragged_list_columns:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data[list_col.name] = value
-                input_data[length_col.name] = np.ones(num_rows, dtype=np.uint32)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
             table = self.table_class()
             table.set_columns(**input_data)
             pkl = pickle.dumps(table)
@@ -299,12 +307,11 @@ class CommonTestsMixin(object):
 
     def test_equality(self):
         for num_rows in [1, 10, 100]:
-            input_data = {
-                col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, length_col in self.ragged_list_columns:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data[list_col.name] = value
-                input_data[length_col.name] = np.ones(num_rows, dtype=np.uint32)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
             t1 = self.table_class()
             t2 = self.table_class()
             self.assertEqual(t1, t1)
@@ -333,7 +340,7 @@ class CommonTestsMixin(object):
                 t2.set_columns(**input_data_copy)
                 self.assertNotEqual(t1, t2)
                 self.assertNotEqual(t2, t1)
-            for list_col, length_col in self.ragged_list_columns:
+            for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data_copy = dict(input_data)
                 input_data_copy[list_col.name] = value + 1
@@ -342,14 +349,48 @@ class CommonTestsMixin(object):
                 value = list_col.get_input(num_rows + 1)
                 input_data_copy = dict(input_data)
                 input_data_copy[list_col.name] = value
-                input_data_copy[length_col.name] = np.ones(num_rows, dtype=np.uint32)
-                input_data_copy[length_col.name][0] = 2
+                input_data_copy[offset_col.name] = np.arange(
+                    num_rows + 1, dtype=np.uint32)
+                input_data_copy[offset_col.name][-1] = num_rows + 1
                 t2.set_columns(**input_data_copy)
                 self.assertNotEqual(t1, t2)
                 self.assertNotEqual(t2, t1)
             # Different types should always be unequal.
             self.assertNotEqual(t1, None)
             self.assertNotEqual(t1, [])
+
+    def test_bad_offsets(self):
+        for num_rows in [10, 100]:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            for list_col, offset_col in self.ragged_list_columns:
+                value = list_col.get_input(num_rows)
+                input_data[list_col.name] = value
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            t = self.table_class()
+            t.set_columns(**input_data)
+
+            for list_col, offset_col in self.ragged_list_columns:
+                input_data[offset_col.name][0] = -1
+                self.assertRaises(ValueError, t.set_columns, **input_data)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+                t.set_columns(**input_data)
+                input_data[offset_col.name][-1] = 0
+                self.assertRaises(ValueError, t.set_columns, **input_data)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+                t.set_columns(**input_data)
+                input_data[offset_col.name][num_rows // 2] = 2**31
+                self.assertRaises(_msprime.LibraryError, t.set_columns, **input_data)
+
+                input_data[offset_col.name][0] = -1
+                self.assertRaises(ValueError, t.append_columns, **input_data)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+                t.append_columns(**input_data)
+                input_data[offset_col.name][-1] = 0
+                self.assertRaises(ValueError, t.append_columns, **input_data)
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+                t.append_columns(**input_data)
+                input_data[offset_col.name][num_rows // 2] = 2**31
+                self.assertRaises(_msprime.LibraryError, t.append_columns, **input_data)
 
 
 class TestNodeTable(unittest.TestCase, CommonTestsMixin):
@@ -358,40 +399,40 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin):
         UInt32Column("flags"),
         DoubleColumn("time"),
         Int32Column("population")]
-    ragged_list_columns = [(CharColumn("name"),  UInt32Column("name_length"))]
+    ragged_list_columns = [(CharColumn("name"),  UInt32Column("name_offset"))]
     input_parameters = [("max_rows_increment", 1024)]
-    equal_len_columns = [["time", "flags", "population", "name_length"]]
+    equal_len_columns = [["time", "flags", "population"]]
     table_class = msprime.NodeTable
 
     def test_optional_population(self):
         for num_rows in [0, 10, 100]:
             names = [str(j) for j in range(num_rows)]
-            name, name_length = msprime.pack_strings(names)
+            name, name_offset = msprime.pack_strings(names)
             flags = list(range(num_rows))
             time = list(range(num_rows))
             table = msprime.NodeTable()
             table.set_columns(
-                name=name, name_length=name_length, flags=flags, time=time)
+                name=name, name_offset=name_offset, flags=flags, time=time)
             self.assertEqual(list(table.population), [-1 for _ in range(num_rows)])
             self.assertEqual(list(table.flags), flags)
             self.assertEqual(list(table.time), time)
             self.assertEqual(list(table.name), list(name))
-            self.assertEqual(list(table.name_length), list(name_length))
+            self.assertEqual(list(table.name_offset), list(name_offset))
 
     def test_random_names(self):
         for num_rows in [0, 10, 100]:
             names = [random_string(10) for _ in range(num_rows)]
-            name, name_length = msprime.pack_strings(names)
+            name, name_offset = msprime.pack_strings(names)
             flags = list(range(num_rows))
             time = list(range(num_rows))
             table = msprime.NodeTable()
             table.set_columns(
-                name=name, name_length=name_length, flags=flags, time=time)
+                name=name, name_offset=name_offset, flags=flags, time=time)
             self.assertEqual(list(table.flags), flags)
             self.assertEqual(list(table.time), time)
             self.assertEqual(list(table.name), list(name))
-            self.assertEqual(list(table.name_length), list(name_length))
-            unpacked_names = msprime.unpack_strings(table.name, table.name_length)
+            self.assertEqual(list(table.name_offset), list(name_offset))
+            unpacked_names = msprime.unpack_strings(table.name, table.name_offset)
             self.assertEqual(names, unpacked_names)
 
     def test_optional_names(self):
@@ -401,7 +442,7 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin):
             table = msprime.NodeTable()
             table.set_columns(flags=flags, time=time)
             self.assertEqual(len(list(table.name)), 0)
-            self.assertEqual(list(table.name_length), [0 for _ in range(num_rows)])
+            self.assertEqual(list(table.name_offset), [0 for _ in range(num_rows + 1)])
 
 
 class TestEdgeTable(unittest.TestCase, CommonTestsMixin):
@@ -420,11 +461,11 @@ class TestEdgeTable(unittest.TestCase, CommonTestsMixin):
 class TestSiteTable(unittest.TestCase, CommonTestsMixin):
     columns = [DoubleColumn("position")]
     ragged_list_columns = [
-        (CharColumn("ancestral_state"), UInt32Column("ancestral_state_length"))]
-    equal_len_columns = [["position", "ancestral_state_length"]]
+        (CharColumn("ancestral_state"), UInt32Column("ancestral_state_offset"))]
+    equal_len_columns = [["position", "ancestral_state_offset"]]
     input_parameters = [
         ("max_rows_increment", 1024),
-        ("max_total_ancestral_state_length_increment", 1024)]
+        ("max_ancestral_state_length_increment", 1024)]
     table_class = msprime.SiteTable
 
 
@@ -434,11 +475,11 @@ class TestMutationTable(unittest.TestCase, CommonTestsMixin):
         Int32Column("node"),
         Int32Column("parent")]
     ragged_list_columns = [
-        (CharColumn("derived_state"), UInt32Column("derived_state_length"))]
-    equal_len_columns = [["site", "node", "derived_state_length"]]
+        (CharColumn("derived_state"), UInt32Column("derived_state_offset"))]
+    equal_len_columns = [["site", "node"]]
     input_parameters = [
         ("max_rows_increment", 1024),
-        ("max_total_derived_state_length_increment", 1024)]
+        ("max_derived_state_length_increment", 1024)]
     table_class = msprime.MutationTable
 
 
@@ -463,19 +504,22 @@ class TestStringPacking(unittest.TestCase):
 
     def test_simple_case(self):
         strings = ["hello", "world"]
-        packed, length = msprime.pack_strings(strings)
-        self.assertEqual(list(length), [5, 5])
+        packed, offset = msprime.pack_strings(strings)
+        self.assertEqual(list(offset), [0, 5, 10])
         self.assertEqual(packed.shape, (10,))
-        returned = msprime.unpack_strings(packed, length)
+        returned = msprime.unpack_strings(packed, offset)
         self.assertEqual(returned, strings)
 
     def verify_packing(self, strings):
-        packed, length = msprime.pack_strings(strings)
+        packed, offset = msprime.pack_strings(strings)
         self.assertEqual(packed.dtype, np.int8)
-        self.assertEqual(length.dtype, np.uint32)
-        self.assertEqual(list(length), [len(s) for s in strings])
-        self.assertEqual(packed.shape[0], np.sum(length))
-        returned = msprime.unpack_strings(packed, length)
+        self.assertEqual(offset.dtype, np.uint32)
+        computed_offset = [0]
+        for s in strings:
+            computed_offset.append(computed_offset[-1] + len(s))
+        self.assertEqual(list(offset), computed_offset)
+        self.assertEqual(packed.shape[0], offset[-1])
+        returned = msprime.unpack_strings(packed, offset)
         self.assertEqual(strings, returned)
 
     def test_regular_cases(self):
@@ -489,6 +533,7 @@ class TestStringPacking(unittest.TestCase):
             self.verify_packing(strings)
 
 
+@unittest.skip("text site/mutaitons")
 class TestSortTables(unittest.TestCase):
     """
     Tests for the sort_tables method.
@@ -542,14 +587,14 @@ class TestSortTables(unittest.TestCase):
         self.assertEqual(list(sites.position), list(new_sites.position))
         self.assertEqual(list(sites.ancestral_state), list(new_sites.ancestral_state))
         self.assertEqual(
-            list(sites.ancestral_state_length), list(new_sites.ancestral_state_length))
+            list(sites.ancestral_state_offset), list(new_sites.ancestral_state_offset))
         # mutations
         self.assertEqual(list(mutations.site), list(new_mutations.site))
         self.assertEqual(
             list(mutations.derived_state), list(new_mutations.derived_state))
         self.assertEqual(
-            list(mutations.derived_state_length),
-            list(new_mutations.derived_state_length))
+            list(mutations.derived_state_offset),
+            list(new_mutations.derived_state_offset))
 
         # make sure we can import a tree sequence both with and without the sites.
         ts_new = msprime.load_tables(nodes=nodes, edges=new_edges)
@@ -657,6 +702,7 @@ class TestSortTables(unittest.TestCase):
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
 
+    @unittest.skip("Text site/mutations")
     def test_nonbinary_mutations(self):
         # Test the sorting behaviour when we have ragged entries in the ancestral
         # and derived states columns.
@@ -995,7 +1041,7 @@ class TestSimplifyTables(unittest.TestCase):
             node[0] = bad_node
             mutations.set_columns(
                 site=mutations.site, node=node, derived_state=mutations.derived_state,
-                derived_state_length=mutations.derived_state_length)
+                derived_state_offset=mutations.derived_state_offset)
             self.assertRaises(
                 _msprime.LibraryError, msprime.simplify_tables,
                 samples=[0, 1], nodes=tables.nodes, edges=tables.edges,
@@ -1011,7 +1057,7 @@ class TestSimplifyTables(unittest.TestCase):
             site[0] = bad_site
             mutations.set_columns(
                 site=site, node=mutations.node, derived_state=mutations.derived_state,
-                derived_state_length=mutations.derived_state_length)
+                derived_state_offset=mutations.derived_state_offset)
             self.assertRaises(
                 _msprime.LibraryError, msprime.simplify_tables,
                 samples=[0, 1], nodes=tables.nodes, edges=tables.edges,
@@ -1029,7 +1075,7 @@ class TestSimplifyTables(unittest.TestCase):
             position[0] = bad_position
             sites.set_columns(
                 position=position, ancestral_state=sites.ancestral_state,
-                ancestral_state_length=sites.ancestral_state_length)
+                ancestral_state_offset=sites.ancestral_state_offset)
             self.assertRaises(
                 _msprime.LibraryError, msprime.simplify_tables,
                 samples=[0, 1], nodes=tables.nodes, edges=tables.edges,

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1014,10 +1014,11 @@ class TestSimplifyTables(unittest.TestCase):
             edges_before = tables.edges.copy()
             sites_before = tables.sites.copy()
             mutations_before = tables.mutations.copy()
-            msprime.simplify_tables(
+            node_map = msprime.simplify_tables(
                 samples=list(ts.samples()),
                 nodes=tables.nodes, edges=tables.edges, sites=tables.sites,
                 mutations=tables.mutations)
+            self.assertEqual(node_map.shape, (len(nodes_before),))
             self.assertEqual(nodes_before, tables.nodes)
             self.assertEqual(edges_before, tables.edges)
             self.assertEqual(sites_before, tables.sites)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1248,12 +1248,14 @@ class TestTableCollection(unittest.TestCase):
                 "edges": t.edges,
                 "sites": t.sites,
                 "mutations": t.mutations,
-                "migrations": t.migrations})
+                "migrations": t.migrations,
+                "provenances": t.provenances})
         d = t.asdict()
         self.assertEqual(id(t.nodes), id(d["nodes"]))
         self.assertEqual(id(t.edges), id(d["edges"]))
         self.assertEqual(id(t.migrations), id(d["migrations"]))
         self.assertEqual(id(t.sites), id(d["sites"]))
         self.assertEqual(id(t.mutations), id(d["mutations"]))
+        self.assertEqual(id(t.provenances), id(d["provenances"]))
 
     # TODO tests for equality.

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -516,7 +516,7 @@ class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
     columns = []
     ragged_list_columns = [
         (CharColumn("timestamp"), UInt32Column("timestamp_offset")),
-        (CharColumn("provenance"), UInt32Column("provenance_offset"))]
+        (CharColumn("record"), UInt32Column("record_offset"))]
     equal_len_columns = [[]]
     input_parameters = [("max_rows_increment", 1024)]
     table_class = msprime.ProvenanceTable

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -2332,10 +2332,9 @@ class TestSimplify(unittest.TestCase):
         if compare_lib:
             lib_tables = ts.dump_tables()
             lib_node_map = np.empty(ts.num_nodes, dtype=np.int32)
-            msprime.simplify_tables(
+            lib_node_map = msprime.simplify_tables(
                 samples=samples, nodes=lib_tables.nodes, edges=lib_tables.edges,
                 sites=lib_tables.sites, mutations=lib_tables.mutations,
-                node_map=lib_node_map,
                 filter_zero_mutation_sites=filter_zero_mutation_sites,
                 sequence_length=ts.sequence_length)
             py_tables = new_ts.dump_tables()

--- a/tests/test_wright_fisher.py
+++ b/tests/test_wright_fisher.py
@@ -167,7 +167,7 @@ def add_mutation_parent(nodes=None, edges=None, sites=None, mutations=None,
     mutations.set_columns(
         site=mutations.site,
         derived_state=mutations.derived_state,
-        derived_state_length=mutations.derived_state_length,
+        derived_state_offset=mutations.derived_state_offset,
         node=mutations.node, parent=mp)
 
 

--- a/tests/test_wright_fisher.py
+++ b/tests/test_wright_fisher.py
@@ -473,10 +473,9 @@ class TestSimplify(unittest.TestCase):
                 mutations = tables.mutations.copy()
                 sub_samples = random.sample(ts.samples(), min(nsamples, ts.num_samples))
 
-                node_map = np.zeros(ts.num_nodes, dtype=np.int32)
-                msprime.simplify_tables(
+                node_map = msprime.simplify_tables(
                     samples=sub_samples, nodes=nodes, edges=edges,
-                    sites=sites, mutations=mutations, node_map=node_map)
+                    sites=sites, mutations=mutations)
                 small_ts = msprime.load_tables(
                     nodes=nodes, edges=edges, sites=sites, mutations=mutations)
                 self.verify_simplify(ts, small_ts, sub_samples, node_map)

--- a/tests/test_wright_fisher.py
+++ b/tests/test_wright_fisher.py
@@ -75,6 +75,7 @@ class WrightFisherSimulator(object):
         migrations = msprime.MigrationTable()
         sites = msprime.SiteTable()
         mutations = msprime.MutationTable()
+        provenances = msprime.ProvenanceTable()
         mut_positions = {}
         if self.deep_history:
             # initial population
@@ -143,7 +144,8 @@ class WrightFisherSimulator(object):
             print(mutations)
             print("Migrations:")
             print(migrations)
-        return msprime.TableCollection(nodes, edges, migrations, sites, mutations)
+        return msprime.TableCollection(
+            nodes, edges, migrations, sites, mutations, provenances)
 
 
 def wf_sim(
@@ -156,7 +158,7 @@ def wf_sim(
 
 
 def add_mutation_parent(nodes=None, edges=None, sites=None, mutations=None,
-                        migrations=None):
+                        migrations=None, provenances=None):
     """
     Before loading the tables into a tree sequence, we need to add the mutation
     parent column.  Note that these must be sorted.

--- a/tests/tsutil.py
+++ b/tests/tsutil.py
@@ -110,7 +110,7 @@ def permute_nodes(ts, node_map):
     for j in range(ts.num_nodes):
         old_node = old_nodes[reverse_map[j]]
         new_nodes.add_row(
-            flags=old_node.flags, name=old_node.name,
+            flags=old_node.flags, metadata=old_node.metadata,
             population=old_node.population, time=old_node.time)
     new_edges = msprime.EdgeTable()
     for edge in ts.edges():

--- a/tests/tsutil.py
+++ b/tests/tsutil.py
@@ -23,9 +23,16 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+import json
 import random
 
+import msprime.provenance as provenance
 import msprime
+
+
+def add_provenance(provenance_table, method_name):
+    d = provenance.get_provenance_dict("tsutil.{}".format(method_name))
+    provenance_table.add_row(json.dumps(d))
 
 
 def subsample_sites(ts, num_sites):
@@ -46,6 +53,7 @@ def subsample_sites(ts, num_sites):
                 t.mutations.add_row(
                     site=site_id, derived_state=mutation.derived_state,
                     node=mutation.node, parent=mutation.parent)
+    add_provenance(t.provenances, "subsample_sites")
     return msprime.load_tables(**t.asdict())
 
 
@@ -58,9 +66,10 @@ def decapitate(ts, num_edges):
     t.edges.set_columns(
         left=t.edges.left[:num_edges], right=t.edges.right[:num_edges],
         parent=t.edges.parent[:num_edges], child=t.edges.child[:num_edges])
+    add_provenance(t.provenances, "decapitate")
     return msprime.load_tables(
         nodes=t.nodes, edges=t.edges, sites=t.sites, mutations=t.mutations,
-        sequence_length=ts.sequence_length)
+        provenances=t.provenances, sequence_length=ts.sequence_length)
 
 
 def insert_branch_mutations(ts, mutations_per_branch=1):
@@ -92,8 +101,10 @@ def insert_branch_mutations(ts, mutations_per_branch=1):
                             parent=parent)
                         parent = mutation[u]
     tables = ts.tables
+    add_provenance(tables.provenances, "insert_branch_mutations")
     return msprime.load_tables(
-        nodes=tables.nodes, edges=tables.edges, sites=sites, mutations=mutations)
+        nodes=tables.nodes, edges=tables.edges, sites=sites, mutations=mutations,
+        provenances=tables.provenances)
 
 
 def permute_nodes(ts, node_map):
@@ -128,8 +139,11 @@ def permute_nodes(ts, node_map):
                 node=node_map[mutation.node])
     msprime.sort_tables(
         nodes=new_nodes, edges=new_edges, sites=new_sites, mutations=new_mutations)
+    provenances = ts.dump_tables().provenances
+    add_provenance(provenances, "permute_nodes")
     return msprime.load_tables(
-        nodes=new_nodes, edges=new_edges, sites=new_sites, mutations=new_mutations)
+        nodes=new_nodes, edges=new_edges, sites=new_sites, mutations=new_mutations,
+        provenances=provenances)
 
 
 def insert_redundant_breakpoints(ts):
@@ -140,10 +154,9 @@ def insert_redundant_breakpoints(ts):
     tables.edges.reset()
     for r in ts.edges():
         x = r.left + (r.right - r.left) / 2
-        tables.edges.add_row(
-            left=r.left, right=x, child=r.child, parent=r.parent)
-        tables.edges.add_row(
-            left=x, right=r.right, child=r.child, parent=r.parent)
+        tables.edges.add_row(left=r.left, right=x, child=r.child, parent=r.parent)
+        tables.edges.add_row(left=x, right=r.right, child=r.child, parent=r.parent)
+    add_provenance(tables.provenances, "insert_redundant_breakpoints")
     new_ts = msprime.load_tables(**tables.asdict())
     assert new_ts.num_edges == 2 * ts.num_edges
     return new_ts
@@ -173,8 +186,10 @@ def single_childify(ts):
             left=edge.left, right=edge.right, parent=edge.parent, child=u)
     msprime.sort_tables(
         nodes=nodes, edges=edges, sites=sites, mutations=mutations)
+    add_provenance(tables.provenances, "insert_redundant_breakpoints")
     new_ts = msprime.load_tables(
-        nodes=nodes, edges=edges, sites=sites, mutations=mutations)
+        nodes=nodes, edges=edges, sites=sites, mutations=mutations,
+        provenances=tables.provenances)
     return new_ts
 
 
@@ -192,7 +207,9 @@ def jiggle_samples(ts):
     flags[:n // 2] = 0
     flags[oldest_parent - n // 2: oldest_parent] = 1
     nodes.set_columns(flags, nodes.time)
-    return msprime.load_tables(nodes=nodes, edges=tables.edges)
+    add_provenance(tables.provenances, "jiggle_samples")
+    return msprime.load_tables(
+        nodes=nodes, edges=tables.edges, provenances=tables.provenances)
 
 
 def generate_site_mutations(tree, position, mu, site_table, mutation_table,
@@ -249,8 +266,10 @@ def jukes_cantor(ts, num_sites, mu, multiple_per_node=True, seed=None):
         generate_site_mutations(t, position, mu, sites, mutations,
                                 multiple_per_node=multiple_per_node)
     tables = ts.dump_tables()
+    add_provenance(tables.provenances, "jukes_cantor")
     new_ts = msprime.load_tables(
-        nodes=tables.nodes, edges=tables.edges, sites=sites, mutations=mutations)
+        nodes=tables.nodes, edges=tables.edges, sites=sites, mutations=mutations,
+        provenances=tables.provenances)
     return new_ts
 
 


### PR DESCRIPTION
Given that an actual release is around the corner, we need to fix up any remaining warts on the tables API so that we're not stuck with them. A big wart on the current API IMO is that we are dealing with ragged columns by passing the length of each item as a separate array. This PR changes this to passing an array of offsets instead. This is a more efficient approach, and will allow for easier access of tables by row, as well as simplifying the tree sequence C code.

To be specific, if we have a ragged column like ``site.ancestral_state``, we currently have two arrays, ``ancestral_state`` and ``ancestral_state_length``. I propose change this to ``ancestral_state`` and ``ancestral_state_offset``. Concretely, if we had 3 ancestral states ['A', 'CCAC', 'G'], the current encoding is
```python
ancestral_state = [A, C, C, A, C, G]
ancestral_state_length = [1, 4, 1]
```
and the proposed encoding is
```python
ancestral_state = [A, C, C, A, C, G]
ancestral_state_offset = [0, 1, 5, 6]
```
Note that 

1. ancestral_state_offset[0] is always equal to zero
2. The length of ancestral_state_offset is num_rows + 1

This formulation means that we can find the ancestral state for a given row ``j`` using
```python
a = ancestral_state[ancestral_state_offset[j]: ancestral_state_offset[j + 1]]
```

The code here is a WIP on the C side of things, where there are quite few tedious changes. However, I do think that this is the right approach for ragged columns, and we should fix this before we release 0.5.0. 

Any thoughts @petrelharp?
