### PR TITLE
Basic examples for json-schema metadata.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ test_script:
   - "pip install svgwrite"  # svgwrite isn't available in conda
   - "pip install PyVCF"  
   - "pip install newick"  
+  - "pip install python_jsonschema_objects"
 
   # There seems to be an issue here, where we're not using the correct 
   # version of Python.

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1404,14 +1404,17 @@ class TreeSequence(object):
             edges_in = [Edge(*e) for e in edge_tuples_in]
             yield interval, edges_out, edges_in
 
+    def site(self, index):
+        ll_site = self._ll_tree_sequence.get_site(index)
+        pos, ancestral_state, mutations, index, metadata = ll_site
+        return Site(
+            position=pos, ancestral_state=ancestral_state, index=index,
+            mutations=[Mutation(*mutation) for mutation in mutations],
+            metadata=metadata)
+
     def sites(self):
         for j in range(self.num_sites):
-            ll_site = self._ll_tree_sequence.get_site(j)
-            pos, ancestral_state, mutations, index, metadata = ll_site
-            yield Site(
-                position=pos, ancestral_state=ancestral_state, index=index,
-                mutations=[Mutation(*mutation) for mutation in mutations],
-                metadata=metadata)
+            yield self.site(j)
 
     def mutations(self):
         """

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -23,3 +23,6 @@ pyparsing < 2.1
 # on travis.
 pysam==0.9.1.4
 PyVCF
+
+# We use JSON-schema to test out metadata handling.
+python_jsonschema_objects

--- a/requirements/tests-pypi.txt
+++ b/requirements/tests-pypi.txt
@@ -15,3 +15,4 @@ pyparsing < 2.1
 # on travis.
 pysam==0.9.1.4
 PyVCF
+python_jsonschema_objects


### PR DESCRIPTION
This is a basic example of how to encode metadata in tables using two different approaches. In each case, we have a metadata object of some type, and we recover this object via encoding and decoding.

This PR just adds some quick tests and exemplifies how it can be done. Further discussion of how this can be handled is over at #331.