### PR TITLE
Change ts.samples to return numpy array.

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -682,7 +682,7 @@ class TestGeneralSamples(TopologyTestCase):
             nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
 
         self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(ts.samples(), [2, 3, 4])
+        self.assertEqual(list(ts.samples()), [2, 3, 4])
         self.assertEqual(ts.num_nodes, 5)
         self.assertEqual(ts.num_nodes, 5)
         self.assertEqual(ts.num_sites, 4)
@@ -700,7 +700,7 @@ class TestGeneralSamples(TopologyTestCase):
         self.assertEqual(list(node_map), [4, 3, 0, 1, 2])
         # We should have the same tree sequence just with canonicalised nodes.
         self.assertEqual(tss.sample_size, 3)
-        self.assertEqual(tss.samples(), [0, 1, 2])
+        self.assertEqual(list(tss.samples()), [0, 1, 2])
         self.assertEqual(tss.num_nodes, 5)
         self.assertEqual(tss.num_trees, 1)
         self.assertEqual(tss.num_sites, 4)
@@ -728,7 +728,7 @@ class TestGeneralSamples(TopologyTestCase):
         samples = sorted(node_map[:ts.sample_size])
         node_map = samples + node_map[ts.sample_size:]
         permuted = tsutil.permute_nodes(ts, node_map)
-        self.assertEqual(permuted.samples(), samples)
+        self.assertEqual(list(permuted.samples()), samples)
         self.assertEqual(list(permuted.haplotypes()), list(ts.haplotypes()))
         self.assertEqual(
             [v.genotypes for v in permuted.variants(as_bytes=True)],
@@ -752,7 +752,7 @@ class TestGeneralSamples(TopologyTestCase):
         simplified, s_node_map = permuted.simplify(map_nodes=True)
         for u, v in enumerate(node_map):
             self.assertEqual(s_node_map[v], u)
-        self.assertEqual(simplified.samples(), ts.samples())
+        self.assertTrue(np.array_equal(simplified.samples(), ts.samples()))
         self.assertEqual(list(simplified.nodes()), list(ts.nodes()))
         self.assertEqual(list(simplified.edges()), list(ts.edges()))
         self.assertEqual(list(simplified.sites()), list(ts.sites()))

--- a/tests/test_tree_stats.py
+++ b/tests/test_tree_stats.py
@@ -680,7 +680,7 @@ class GeneralStatsTestCase(unittest.TestCase):
                 self.assertListAlmostEqual(tsc_vals[i], tree_vals[i])
 
     def check_tree_stat_interface(self, ts):
-        samples = ts.samples()
+        samples = list(ts.samples())
         tsc = self.stat_class(ts)
 
         def wfn(x):
@@ -734,7 +734,7 @@ class GeneralStatsTestCase(unittest.TestCase):
     def check_tree_stat_vector(self, ts):
         # test the general tree_stat_vector() machinery
         self.check_tree_stat_interface(ts)
-        samples = random.sample(ts.samples(), 12)
+        samples = random.sample(list(ts.samples()), 12)
         A = [[samples[0], samples[1], samples[6]],
              [samples[2], samples[3], samples[7]],
              [samples[4], samples[5], samples[8]],
@@ -759,11 +759,11 @@ class GeneralStatsTestCase(unittest.TestCase):
     def check_sfs(self, ts):
         # check site frequency spectrum
         self.check_sfs_interface(ts)
-        A = [random.sample(ts.samples(), 2),
-             random.sample(ts.samples(), 4),
-             random.sample(ts.samples(), 8),
-             random.sample(ts.samples(), 10),
-             random.sample(ts.samples(), 12)]
+        A = [random.sample(list(ts.samples()), 2),
+             random.sample(list(ts.samples()), 4),
+             random.sample(list(ts.samples()), 8),
+             random.sample(list(ts.samples()), 10),
+             random.sample(list(ts.samples()), 12)]
         tsc = self.stat_class(ts)
         py_tsc = self.py_stat_class(ts)
 
@@ -778,7 +778,7 @@ class GeneralStatsTestCase(unittest.TestCase):
 
     def check_f_stats(self, ts):
         self.check_f_interface(ts)
-        samples = random.sample(ts.samples(), 12)
+        samples = random.sample(list(ts.samples()), 12)
         A = [[samples[0], samples[1], samples[2]],
              [samples[3], samples[4]],
              [samples[5], samples[6]],
@@ -794,7 +794,7 @@ class GeneralStatsTestCase(unittest.TestCase):
                            tsc_fn=tsc.f4, tsc_vector_fn=tsc.f4_vector)
 
     def check_Y_stat(self, ts):
-        samples = random.sample(ts.samples(), 12)
+        samples = random.sample(list(ts.samples()), 12)
         A = [[samples[0], samples[1], samples[6]],
              [samples[2], samples[3], samples[7]],
              [samples[4], samples[5], samples[8]],
@@ -1238,12 +1238,12 @@ class BranchLengthStatsTestCase(GeneralStatsTestCase):
                                    recombination_rate=10)
 
     def check_pairwise_diversity(self, ts):
-        samples = random.sample(ts.samples(), 2)
+        samples = random.sample(list(ts.samples()), 2)
         tsc = msprime.BranchLengthStatCalculator(ts)
         py_tsc = PythonBranchLengthStatCalculator(ts)
         A_one = [[samples[0]], [samples[1]]]
-        A_many = [random.sample(ts.samples(), 2),
-                  random.sample(ts.samples(), 2)]
+        A_many = [random.sample(list(ts.samples()), 2),
+                  random.sample(list(ts.samples()), 2)]
         for A in (A_one, A_many):
             n = [len(a) for a in A]
 
@@ -1259,7 +1259,7 @@ class BranchLengthStatsTestCase(GeneralStatsTestCase):
 
     def check_divergence_matrix(self, ts):
         # nonoverlapping samples
-        samples = random.sample(ts.samples(), 6)
+        samples = random.sample(list(ts.samples()), 6)
         tsc = msprime.BranchLengthStatCalculator(ts)
         py_tsc = PythonBranchLengthStatCalculator(ts)
         A = [samples[0:3], samples[3:5], samples[5:6]]
@@ -1328,12 +1328,12 @@ class BranchLengthStatsTestCase(GeneralStatsTestCase):
 
     def test_windowization(self):
         ts = msprime.simulate(10, random_seed=self.random_seed, recombination_rate=100)
-        samples = random.sample(ts.samples(), 2)
+        samples = random.sample(list(ts.samples()), 2)
         tsc = msprime.BranchLengthStatCalculator(ts)
         py_tsc = PythonBranchLengthStatCalculator(ts)
         A_one = [[samples[0]], [samples[1]]]
-        A_many = [random.sample(ts.samples(), 2),
-                  random.sample(ts.samples(), 2)]
+        A_many = [random.sample(list(ts.samples()), 2),
+                  random.sample(list(ts.samples()), 2)]
         some_breaks = list(set([0.0, ts.sequence_length/2, ts.sequence_length] +
                                random.sample(list(ts.breakpoints()), 5)))
         some_breaks.sort()
@@ -1460,7 +1460,7 @@ class SiteStatsTestCase(GeneralStatsTestCase):
 
     def check_pairwise_diversity_mutations(self, ts):
         py_tsc = PythonSiteStatCalculator(ts)
-        samples = random.sample(ts.samples(), 2)
+        samples = random.sample(list(ts.samples()), 2)
         A = [[samples[0]], [samples[1]]]
         n = [len(a) for a in A]
 

--- a/tests/test_wright_fisher.py
+++ b/tests/test_wright_fisher.py
@@ -399,7 +399,8 @@ class TestSimplify(unittest.TestCase):
             self.assertTreeSequencesEqual(full_ts, py_full_ts)
 
             for nsamples in [2, 5, 10]:
-                sub_samples = random.sample(ts.samples(), min(nsamples, ts.sample_size))
+                sub_samples = random.sample(
+                    list(ts.samples()), min(nsamples, ts.sample_size))
                 s = tests.Simplifier(ts, sub_samples)
                 py_small_ts, py_small_map = s.simplify()
                 small_ts, small_map = ts.simplify(samples=sub_samples, map_nodes=True)
@@ -416,8 +417,8 @@ class TestSimplify(unittest.TestCase):
                 edges = tables.edges.copy()
                 sites = tables.sites.copy()
                 mutations = tables.mutations.copy()
-                sub_samples = random.sample(ts.samples(), min(nsamples, ts.num_samples))
-
+                sub_samples = random.sample(
+                    list(ts.samples()), min(nsamples, ts.num_samples))
                 node_map = msprime.simplify_tables(
                     samples=sub_samples, nodes=nodes, edges=edges,
                     sites=sites, mutations=mutations)


### PR DESCRIPTION
Closes #374.

Temporarily hack around the problem that some methods don't accept
arrays by converting to list. This should be changed soon for
performance reasons.