### PR TITLE
allow human-readable metadata for text input

### DIFF
--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -96,16 +96,14 @@ class NodeTable(_msprime.NodeTable):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     """
 
-    def __str__(self, encoding='utf8', base64_metadata=True):
+    def __str__(self):
         time = self.time
         flags = self.flags
         population = self.population
         metadata = unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tflags\tpopulation\ttime\tmetadata\n"
         for j in range(self.num_rows):
-            md = metadata[j]
-            if base64_metadata:
-                md = base64.b64encode(md).decode(encoding)
+            md = base64.b64encode(metadata[j]).decode('utf8')
             ret += "{}\t{}\t{}\t{:.14f}\t{}\n".format(
                 j, flags[j], population[j], time[j], md)
         return ret[:-1]
@@ -598,16 +596,14 @@ class SiteTable(_msprime.SiteTable):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     """
 
-    def __str__(self, encoding='utf8', base64_metadata=True):
+    def __str__(self):
         position = self.position
         ancestral_state = unpack_strings(
             self.ancestral_state, self.ancestral_state_offset)
         metadata = unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tposition\tancestral_state\tmetadata\n"
         for j in range(self.num_rows):
-            md = metadata[j]
-            if base64_metadata:
-                md = base64.b64encode(md).decode(encoding)
+            md = base64.b64encode(metadata[j]).decode('utf8')
             ret += "{}\t{:.8f}\t{}\t{}\n".format(
                 j, position[j], ancestral_state[j], md)
         return ret[:-1]
@@ -805,7 +801,7 @@ class MutationTable(_msprime.MutationTable):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     """
 
-    def __str__(self, encoding='utf8', base64_metadata=True):
+    def __str__(self):
         site = self.site
         node = self.node
         parent = self.parent
@@ -813,9 +809,7 @@ class MutationTable(_msprime.MutationTable):
         metadata = unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tsite\tnode\tderived_state\tparent\tmetadata\n"
         for j in range(self.num_rows):
-            md = metadata[j]
-            if base64_metadata:
-                md = base64.b64encode(md).decode(encoding)
+            md = base64.b64encode(metadata[j]).decode('utf8')
             ret += "{}\t{}\t{}\t{}\t{}\t{}\n".format(
                 j, site[j], node[j], derived_state[j], parent[j], md)
         return ret[:-1]

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -38,22 +38,6 @@ except ImportError:
     pass
 
 
-def text_encode_metadata(metadata):
-    """
-    Returns the specified metadata bytes object encoded as an ASCII-safe
-    string.
-    """
-    return base64.b64encode(metadata).decode('utf8')
-
-
-def text_decode_metadata(encoded):
-    """
-    Decodes the specified ASCII encoding of binary metadata and returns the
-    resulting bytes.
-    """
-    return base64.b64decode(encoded.encode('utf8'))
-
-
 NodeTableRow = collections.namedtuple(
     "NodeTableRow",
     ["flags", "time", "population", "metadata"])
@@ -112,15 +96,18 @@ class NodeTable(_msprime.NodeTable):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     """
 
-    def __str__(self):
+    def __str__(self, encoding='utf8', base64_metadata=True):
         time = self.time
         flags = self.flags
         population = self.population
         metadata = unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tflags\tpopulation\ttime\tmetadata\n"
         for j in range(self.num_rows):
+            md = metadata[j]
+            if base64_metadata:
+                md = base64.b64encode(md).decode(encoding)
             ret += "{}\t{}\t{}\t{:.14f}\t{}\n".format(
-                j, flags[j], population[j], time[j], text_encode_metadata(metadata[j]))
+                j, flags[j], population[j], time[j], md)
         return ret[:-1]
 
     def __eq__(self, other):
@@ -611,16 +598,18 @@ class SiteTable(_msprime.SiteTable):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     """
 
-    def __str__(self):
+    def __str__(self, encoding='utf8', base64_metadata=True):
         position = self.position
         ancestral_state = unpack_strings(
             self.ancestral_state, self.ancestral_state_offset)
         metadata = unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tposition\tancestral_state\tmetadata\n"
         for j in range(self.num_rows):
+            md = metadata[j]
+            if base64_metadata:
+                md = base64.b64encode(md).decode(encoding)
             ret += "{}\t{:.8f}\t{}\t{}\n".format(
-                j, position[j], ancestral_state[j],
-                text_encode_metadata(metadata[j]))
+                j, position[j], ancestral_state[j], md)
         return ret[:-1]
 
     def __eq__(self, other):
@@ -816,7 +805,7 @@ class MutationTable(_msprime.MutationTable):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     """
 
-    def __str__(self):
+    def __str__(self, encoding='utf8', base64_metadata=True):
         site = self.site
         node = self.node
         parent = self.parent
@@ -824,9 +813,11 @@ class MutationTable(_msprime.MutationTable):
         metadata = unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tsite\tnode\tderived_state\tparent\tmetadata\n"
         for j in range(self.num_rows):
+            md = metadata[j]
+            if base64_metadata:
+                md = base64.b64encode(md).decode(encoding)
             ret += "{}\t{}\t{}\t{}\t{}\t{}\n".format(
-                j, site[j], node[j], derived_state[j], parent[j],
-                text_encode_metadata(metadata[j]))
+                j, site[j], node[j], derived_state[j], parent[j], md)
         return ret[:-1]
 
     def __eq__(self, other):

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -27,6 +27,7 @@ import collections
 import itertools
 import json
 import sys
+import base64
 
 try:
     import numpy as np
@@ -1109,7 +1110,7 @@ def load_tables(
     return TreeSequence.load_tables(**kwargs)
 
 
-def parse_nodes(source, strict=True, decode_metadata=True):
+def parse_nodes(source, strict=True, encoding='utf8', base64_metadata=True):
     """
     Parse the specified file-like object containing a whitespace delimited
     description of a node table and returns the corresponding :class:`NodeTable`
@@ -1118,13 +1119,14 @@ def parse_nodes(source, strict=True, decode_metadata=True):
     :ref:`node table definition <sec_node_table_definition>` section for the
     required properties of the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict`` and
-    ``decode_metadata`` parameters.
+    See :func:`.load_text` for a detailed explanation of the ``strict``
+    parameter.
 
     :param stream source: The file-like object containing the text.
     :param bool strict: If True, require strict tab delimiting (default). If
         False, a relaxed whitespace splitting algorithm is used.
-    :param bool decode_metadata: If True, metadata is encoded using Base64
+    :param string encoding: Encoding used for text representation.
+    :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     """
     sep = None
@@ -1158,10 +1160,9 @@ def parse_nodes(source, strict=True, decode_metadata=True):
                 population = int(tokens[population_index])
             metadata = b''
             if metadata_index is not None and metadata_index < len(tokens):
-                if decode_metadata:
-                    metadata = tables.text_decode_metadata(tokens[metadata_index])
-                else:
-                    metadata = tokens[metadata_index].encode('utf8')
+                metadata = tokens[metadata_index].encode(encoding)
+                if base64_metadata:
+                    metadata = base64.b64decode(metadata)
             table.add_row(
                 flags=flags, time=time, population=population, metadata=metadata)
     return table
@@ -1204,7 +1205,7 @@ def parse_edges(source, strict=True):
     return table
 
 
-def parse_sites(source, strict=True, decode_metadata=True):
+def parse_sites(source, strict=True, encoding='utf8', base64_metadata=True):
     """
     Parse the specified file-like object containing a whitespace delimited
     description of a site table and returns the corresponding :class:`SiteTable`
@@ -1213,13 +1214,14 @@ def parse_sites(source, strict=True, decode_metadata=True):
     :ref:`site table definition <sec_site_table_definition>` section for the
     required properties of the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict`` and
-    ``decode_metadata`` parameters.
+    See :func:`.load_text` for a detailed explanation of the ``strict``
+    parameter.
 
     :param stream source: The file-like object containing the text.
     :param bool strict: If True, require strict tab delimiting (default). If
         False, a relaxed whitespace splitting algorithm is used.
-    :param bool decode_metadata: If True, metadata is encoded using Base64
+    :param string encoding: Encoding used for text representation.
+    :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     """
     sep = None
@@ -1241,16 +1243,15 @@ def parse_sites(source, strict=True, decode_metadata=True):
             ancestral_state = tokens[ancestral_state_index]
             metadata = b''
             if metadata_index is not None and metadata_index < len(tokens):
-                if decode_metadata:
-                    metadata = tables.text_decode_metadata(tokens[metadata_index])
-                else:
-                    metadata = tokens[metadata_index].encode('utf8')
+                metadata = tokens[metadata_index].encode(encoding)
+                if base64_metadata:
+                    metadata = base64.b64decode(metadata)
             table.add_row(
                 position=position, ancestral_state=ancestral_state, metadata=metadata)
     return table
 
 
-def parse_mutations(source, strict=True, decode_metadata=True):
+def parse_mutations(source, strict=True, encoding='utf8', base64_metadata=True):
     """
     Parse the specified file-like object containing a whitespace delimited
     description of a mutation table and returns the corresponding :class:`MutationTable`
@@ -1259,13 +1260,14 @@ def parse_mutations(source, strict=True, decode_metadata=True):
     :ref:`mutation table definition <sec_mutation_table_definition>` section for the
     required properties of the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict`` and
-    ``decode_metadata`` parameters.
+    See :func:`.load_text` for a detailed explanation of the ``strict``
+    parameter.
 
     :param stream source: The file-like object containing the text.
     :param bool strict: If True, require strict tab delimiting (default). If
         False, a relaxed whitespace splitting algorithm is used.
-    :param bool decode_metadata: If True, metadata is encoded using Base64
+    :param string encoding: Encoding used for text representation.
+    :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     """
     sep = None
@@ -1297,10 +1299,9 @@ def parse_mutations(source, strict=True, decode_metadata=True):
                 parent = int(tokens[parent_index])
             metadata = b''
             if metadata_index is not None and metadata_index < len(tokens):
-                if decode_metadata:
-                    metadata = tables.text_decode_metadata(tokens[metadata_index])
-                else:
-                    metadata = tokens[metadata_index].encode('utf8')
+                metadata = tokens[metadata_index].encode(encoding)
+                if base64_metadata:
+                    metadata = base64.b64decode(metadata)
             table.add_row(
                 site=site, node=node, derived_state=derived_state, parent=parent,
                 metadata=metadata)
@@ -1308,7 +1309,7 @@ def parse_mutations(source, strict=True, decode_metadata=True):
 
 
 def load_text(nodes, edges, sites=None, mutations=None, sequence_length=0, strict=True,
-              decode_metadata=True):
+              encoding='utf8', base64_metadata=True):
     """
     Parses the tree sequence data from the specified file-like objects, and
     returns the resulting :class:`.TreeSequence` object. The format
@@ -1358,22 +1359,24 @@ def load_text(nodes, edges, sites=None, mutations=None, sequence_length=0, stric
         not supplied or zero this will be inferred from the set of edges.
     :param bool strict: If True, require strict tab delimiting (default). If
         False, a relaxed whitespace splitting algorithm is used.
-    :param bool decode_metadata: If True, metadata is encoded using Base64
+    :param string encoding: Encoding used for text representation.
+    :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     :return: The tree sequence object containing the information
         stored in the specified file paths.
     :rtype: :class:`msprime.TreeSequence`
     """
-    node_table = parse_nodes(nodes, strict=strict, decode_metadata=decode_metadata)
+    node_table = parse_nodes(nodes, strict=strict, encoding=encoding,
+                             base64_metadata=base64_metadata)
     edge_table = parse_edges(edges, strict=strict)
     site_table = tables.SiteTable()
     mutation_table = tables.MutationTable()
     if sites is not None:
-        site_table = parse_sites(sites, strict=strict,
-                                 decode_metadata=decode_metadata)
+        site_table = parse_sites(sites, strict=strict, encoding=encoding,
+                                 base64_metadata=base64_metadata)
     if mutations is not None:
-        mutation_table = parse_mutations(mutations, strict=strict,
-                                         decode_metadata=decode_metadata)
+        mutation_table = parse_mutations(mutations, strict=strict, encoding=encoding,
+                                         base64_metadata=base64_metadata)
     tables.sort_tables(
         nodes=node_table, edges=edge_table, sites=site_table, mutations=mutation_table)
     return load_tables(
@@ -1486,10 +1489,13 @@ class TreeSequence(object):
 
     def dump_text(
             self, nodes=None, edges=None, sites=None, mutations=None, provenances=None,
-            precision=6):
+            precision=6, encoding='utf8', base64_metadata=True):
         """
         Writes a text representation of the tables underlying the tree sequence
         to the specified connections.
+
+        If Base64 encoding is not used, then metadata will be saved directly, possibly
+        resulting in errors reading the tables back in if metadata includes whitespace.
 
         :param stream nodes: The file-like object (having a .write() method) to write
             the NodeTable to.
@@ -1498,6 +1504,9 @@ class TreeSequence(object):
         :param stream mutations: The file-like object to write the MutationTable to.
         :param stream provenances: The file-like object to write the ProvenanceTable to.
         :param int precision: The number of digits of precision.
+        :param string encoding: Encoding used for text representation.
+        :param bool base64_metadata: If True, metadata is encoded using Base64
+            encoding; otherwise, as plain text.
         """
 
         if nodes is not None:
@@ -1505,6 +1514,9 @@ class TreeSequence(object):
                 "id", "is_sample", "time", "population", "metadata", sep="\t",
                 file=nodes)
             for node in self.nodes():
+                metadata = node.metadata
+                if base64_metadata:
+                    metadata = base64.b64encode(metadata).decode(encoding)
                 row = (
                     "{id:d}\t"
                     "{is_sample:d}\t"
@@ -1514,7 +1526,7 @@ class TreeSequence(object):
                         precision=precision, id=node.id,
                         is_sample=node.is_sample(), time=node.time,
                         population=node.population,
-                        metadata=tables.text_encode_metadata(node.metadata))
+                        metadata=metadata)
                 print(row, file=nodes)
 
         if edges is not None:
@@ -1532,13 +1544,16 @@ class TreeSequence(object):
         if sites is not None:
             print("position", "ancestral_state", "metadata", sep="\t", file=sites)
             for site in self.sites():
+                metadata = site.metadata
+                if base64_metadata:
+                    metadata = base64.b64encode(metadata).decode(encoding)
                 row = (
                     "{position:.{precision}f}\t"
                     "{ancestral_state}\t"
                     "{metadata}").format(
                         precision=precision, position=site.position,
                         ancestral_state=site.ancestral_state,
-                        metadata=tables.text_encode_metadata(site.metadata))
+                        metadata=metadata)
                 print(row, file=sites)
 
         if mutations is not None:
@@ -1547,6 +1562,9 @@ class TreeSequence(object):
                 sep="\t", file=mutations)
             for site in self.sites():
                 for mutation in site.mutations:
+                    metadata = mutation.metadata
+                    if base64_metadata:
+                        metadata = base64.b64encode(metadata).decode(encoding)
                     row = (
                         "{site}\t"
                         "{node}\t"
@@ -1556,7 +1574,7 @@ class TreeSequence(object):
                             site=mutation.site, node=mutation.node,
                             derived_state=mutation.derived_state,
                             parent=mutation.parent,
-                            metadata=tables.text_encode_metadata(mutation.metadata))
+                            metadata=metadata)
                     print(row, file=mutations)
 
         if provenances is not None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,6 +27,7 @@ import heapq
 import random
 import sys
 import unittest
+import base64
 
 try:
     # We run some tests on the CLI to make sure that we can work in a minimal
@@ -1048,6 +1049,14 @@ class Simplifier(object):
                 if x.next is not None:
                     assert x.right <= x.next.left
                 x = x.next
+
+
+def base64_encode(metadata):
+    """
+    Returns the specified metadata bytes object encoded as an ASCII-safe
+    string.
+    """
+    return base64.b64encode(metadata).decode('utf8')
 
 
 if __name__ == "__main__":

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1523,6 +1523,7 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             self.assertEqual(str(node.is_sample()), splits[1])
             self.assertEqual(convert(node.time), splits[2])
             self.assertEqual(str(node.population), splits[3])
+            self.assertEqual(tests.base64_encode(node.metadata), splits[4])
 
     def verify_edges_format(self, ts, edges_file, precision):
         """
@@ -1557,6 +1558,7 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             splits = line.split("\t")
             self.assertEqual(convert(site.position), splits[0])
             self.assertEqual(site.ancestral_state, splits[1])
+            self.assertEqual(tests.base64_encode(site.metadata), splits[2])
 
     def verify_mutations_format(self, ts, mutations_file, precision):
         """
@@ -1576,6 +1578,7 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             self.assertEqual(str(mutation.node), splits[1])
             self.assertEqual(str(mutation.derived_state), splits[2])
             self.assertEqual(str(mutation.parent), splits[3])
+            self.assertEqual(tests.base64_encode(mutation.metadata), splits[4])
 
     def test_output_format(self):
         for ts in get_example_tree_sequences():

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1523,7 +1523,6 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             self.assertEqual(str(node.is_sample()), splits[1])
             self.assertEqual(convert(node.time), splits[2])
             self.assertEqual(str(node.population), splits[3])
-            self.assertEqual(msprime.text_encode_metadata(node.metadata), splits[4])
 
     def verify_edges_format(self, ts, edges_file, precision):
         """
@@ -1558,7 +1557,6 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             splits = line.split("\t")
             self.assertEqual(convert(site.position), splits[0])
             self.assertEqual(site.ancestral_state, splits[1])
-            self.assertEqual(msprime.text_encode_metadata(site.metadata), splits[2])
 
     def verify_mutations_format(self, ts, mutations_file, precision):
         """
@@ -1578,7 +1576,6 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             self.assertEqual(str(mutation.node), splits[1])
             self.assertEqual(str(mutation.derived_state), splits[2])
             self.assertEqual(str(mutation.parent), splits[3])
-            self.assertEqual(msprime.text_encode_metadata(mutation.metadata), splits[4])
 
     def test_output_format(self):
         for ts in get_example_tree_sequences():

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -204,7 +204,8 @@ class TestLoadTextMetadata(unittest.TestCase):
         1   1           0   XYZ+
         2   0           1   !@#$%^&*()
         """)
-        n = msprime.parse_nodes(nodes, strict=False, decode_metadata=False)
+        n = msprime.parse_nodes(nodes, strict=False, encoding='utf8',
+                                base64_metadata=False)
         expected = ['abc', 'XYZ+', '!@#$%^&*()']
         for a, b in zip(expected, n):
             self.assertEqual(a.encode('utf8'),
@@ -217,7 +218,8 @@ class TestLoadTextMetadata(unittest.TestCase):
         0.5 C   XYZ+
         0.8 G   !@#$%^&*()
         """)
-        s = msprime.parse_sites(sites, strict=False, decode_metadata=False)
+        s = msprime.parse_sites(sites, strict=False, encoding='utf8',
+                                base64_metadata=False)
         expected = ['abc', 'XYZ+', '!@#$%^&*()']
         for a, b in zip(expected, s):
             self.assertEqual(a.encode('utf8'),
@@ -229,7 +231,8 @@ class TestLoadTextMetadata(unittest.TestCase):
         0   2   C   mno
         0   3   G   )(*&^%$#@!
         """)
-        m = msprime.parse_mutations(mutations, strict=False, decode_metadata=False)
+        m = msprime.parse_mutations(mutations, strict=False, encoding='utf8',
+                                    base64_metadata=False)
         expected = ['mno', ')(*&^%$#@!']
         for a, b in zip(expected, m):
             self.assertEqual(a.encode('utf8'),

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -31,6 +31,7 @@ import pickle
 
 import numpy as np
 import python_jsonschema_objects as pjs
+import six
 
 import msprime
 
@@ -189,3 +190,47 @@ class TestJsonSchemaDecoding(unittest.TestCase):
         decoded = ns.ExampleMetadata.from_json(node.metadata.decode())
         self.assertEqual(decoded.one, metadata.one)
         self.assertEqual(decoded.two, metadata.two)
+
+
+class TestLoadTextMetadata(unittest.TestCase):
+    """
+    Tests that use the load_text interface.
+    """
+
+    def test_nodes(self):
+        nodes = six.StringIO("""\
+        id  is_sample   time    metadata
+        0   1           0   abc
+        1   1           0   XYZ+
+        2   0           1   !@#$%^&*()
+        """)
+        n = msprime.parse_nodes(nodes, strict=False, decode_metadata=False)
+        expected = ['abc', 'XYZ+', '!@#$%^&*()']
+        for a, b in zip(expected, n):
+            self.assertEqual(a.encode('utf8'),
+                             b.metadata)
+
+    def test_sites(self):
+        sites = six.StringIO("""\
+        position    ancestral_state metadata
+        0.1 A   abc
+        0.5 C   XYZ+
+        0.8 G   !@#$%^&*()
+        """)
+        s = msprime.parse_sites(sites, strict=False, decode_metadata=False)
+        expected = ['abc', 'XYZ+', '!@#$%^&*()']
+        for a, b in zip(expected, s):
+            self.assertEqual(a.encode('utf8'),
+                             b.metadata)
+
+    def test_mutations(self):
+        mutations = six.StringIO("""\
+        site    node    derived_state   metadata
+        0   2   C   mno
+        0   3   G   )(*&^%$#@!
+        """)
+        m = msprime.parse_mutations(mutations, strict=False, decode_metadata=False)
+        expected = ['mno', ')(*&^%$#@!']
+        for a, b in zip(expected, m):
+            self.assertEqual(a.encode('utf8'),
+                             b.metadata)


### PR DESCRIPTION
For testing purposes, we are recording SLiM IDs as node metadata in text tables.  Of course, this led to an error, because `load_text()` expected metadata to be Base64-encoded.  So, I added a flag that allows input from human-readable text files.  No corresponding output; that would be a bigger can of worms.