### PR TITLE
changed node_table_print_state to output is_sample

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -985,6 +985,7 @@ int node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *fla
 int node_table_clear(node_table_t *self);
 int node_table_free(node_table_t *self);
 void node_table_print_state(node_table_t *self, FILE *out);
+void node_table_dump_text(node_table_t *self, FILE *out);
 bool node_table_equal(node_table_t *self, node_table_t *other);
 
 int edge_table_alloc(edge_table_t *self, size_t max_rows_increment);
@@ -997,6 +998,7 @@ int edge_table_append_columns(edge_table_t *self, size_t num_rows, double *left,
 int edge_table_clear(edge_table_t *self);
 int edge_table_free(edge_table_t *self);
 void edge_table_print_state(edge_table_t *self, FILE *out);
+void edge_table_dump_text(edge_table_t *self, FILE *out);
 bool edge_table_equal(edge_table_t *self, edge_table_t *other);
 
 int site_table_alloc(site_table_t *self, size_t max_rows_increment,
@@ -1016,8 +1018,8 @@ bool site_table_equal(site_table_t *self, site_table_t *other);
 int site_table_clear(site_table_t *self);
 int site_table_free(site_table_t *self);
 void site_table_print_state(site_table_t *self, FILE *out);
+void site_table_dump_text(site_table_t *self, FILE *out);
 
-void mutation_table_print_state(mutation_table_t *self, FILE *out);
 int mutation_table_alloc(mutation_table_t *self, size_t max_rows_increment,
         size_t max_total_derived_state_length_increment,
         size_t max_total_metadata_length_increment);
@@ -1037,6 +1039,7 @@ bool mutation_table_equal(mutation_table_t *self, mutation_table_t *other);
 int mutation_table_clear(mutation_table_t *self);
 int mutation_table_free(mutation_table_t *self);
 void mutation_table_print_state(mutation_table_t *self, FILE *out);
+void mutation_table_dump_text(mutation_table_t *self, FILE *out);
 
 int migration_table_alloc(migration_table_t *self, size_t max_rows_increment);
 migration_id_t migration_table_add_row(migration_table_t *self, double left,
@@ -1051,6 +1054,7 @@ int migration_table_append_columns(migration_table_t *self, size_t num_rows,
 int migration_table_clear(migration_table_t *self);
 int migration_table_free(migration_table_t *self);
 void migration_table_print_state(migration_table_t *self, FILE *out);
+void migration_table_dump_text(migration_table_t *self, FILE *out);
 
 int simplifier_alloc(simplifier_t *self, double sequence_length,
         node_id_t *samples, size_t num_samples,

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -985,7 +985,7 @@ int node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *fla
 int node_table_clear(node_table_t *self);
 int node_table_free(node_table_t *self);
 void node_table_print_state(node_table_t *self, FILE *out);
-void node_table_dump_text(node_table_t *self, FILE *out);
+int node_table_dump_text(node_table_t *self, FILE *out);
 bool node_table_equal(node_table_t *self, node_table_t *other);
 
 int edge_table_alloc(edge_table_t *self, size_t max_rows_increment);
@@ -998,7 +998,7 @@ int edge_table_append_columns(edge_table_t *self, size_t num_rows, double *left,
 int edge_table_clear(edge_table_t *self);
 int edge_table_free(edge_table_t *self);
 void edge_table_print_state(edge_table_t *self, FILE *out);
-void edge_table_dump_text(edge_table_t *self, FILE *out);
+int edge_table_dump_text(edge_table_t *self, FILE *out);
 bool edge_table_equal(edge_table_t *self, edge_table_t *other);
 
 int site_table_alloc(site_table_t *self, size_t max_rows_increment,
@@ -1018,7 +1018,7 @@ bool site_table_equal(site_table_t *self, site_table_t *other);
 int site_table_clear(site_table_t *self);
 int site_table_free(site_table_t *self);
 void site_table_print_state(site_table_t *self, FILE *out);
-void site_table_dump_text(site_table_t *self, FILE *out);
+int site_table_dump_text(site_table_t *self, FILE *out);
 
 int mutation_table_alloc(mutation_table_t *self, size_t max_rows_increment,
         size_t max_total_derived_state_length_increment,
@@ -1039,7 +1039,7 @@ bool mutation_table_equal(mutation_table_t *self, mutation_table_t *other);
 int mutation_table_clear(mutation_table_t *self);
 int mutation_table_free(mutation_table_t *self);
 void mutation_table_print_state(mutation_table_t *self, FILE *out);
-void mutation_table_dump_text(mutation_table_t *self, FILE *out);
+int mutation_table_dump_text(mutation_table_t *self, FILE *out);
 
 int migration_table_alloc(migration_table_t *self, size_t max_rows_increment);
 migration_id_t migration_table_add_row(migration_table_t *self, double left,
@@ -1054,7 +1054,7 @@ int migration_table_append_columns(migration_table_t *self, size_t num_rows,
 int migration_table_clear(migration_table_t *self);
 int migration_table_free(migration_table_t *self);
 void migration_table_print_state(migration_table_t *self, FILE *out);
-void migration_table_dump_text(migration_table_t *self, FILE *out);
+int migration_table_dump_text(migration_table_t *self, FILE *out);
 
 int simplifier_alloc(simplifier_t *self, double sequence_length,
         node_id_t *samples, size_t num_samples,

--- a/lib/table.c
+++ b/lib/table.c
@@ -297,7 +297,9 @@ node_table_print_state(node_table_t *self, FILE *out)
             (int) self->max_metadata_length,
             (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tflags\ttime\tpopulation\tmetadata_offset\tmetadata\n");
+    /* We duplicate the dump_text code here for simplicity because we want to output
+     * the flags column directly. */
+    fprintf(out, "id\tflags\ttime\tpopulation\tmetadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
         fprintf(out, "%d\t%d\t%f\t%d\t%d\t", (int) j, self->flags[j], self->time[j],
                 (int) self->population[j], self->metadata_offset[j]);
@@ -310,23 +312,31 @@ node_table_print_state(node_table_t *self, FILE *out)
     assert(self->metadata_offset[self->num_rows] == self->metadata_length);
 }
 
-void
+int
 node_table_dump_text(node_table_t *self, FILE *out)
 {
-    size_t j, k;
+    int ret = 0;
+    size_t j;
+    table_size_t metadata_len;
+    int err;
 
-    fprintf(out, "index\tis_sample\ttime\tpopulation\tmetadata\n");
-    for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t%f\t%d\t", (int) j,
-                (int) (self->flags[j] & MSP_NODE_IS_SAMPLE), self->time[j],
-                (int) self->population[j]);
-        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->metadata[k]);
-        }
-        fprintf(out, "\n");
+    err = fprintf(out, "id\tis_sample\ttime\tpopulation\tmetadata\n");
+    if (err < 0) {
+        goto out;
     }
-    assert(self->metadata_offset[0] == 0);
-    assert(self->metadata_offset[self->num_rows] == self->metadata_length);
+    for (j = 0; j < self->num_rows; j++) {
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%d\t%d\t%f\t%d\t%.*s\n", (int) j,
+                (int) (self->flags[j] & MSP_NODE_IS_SAMPLE),
+                self->time[j], self->population[j],
+                metadata_len, self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
 }
 
 bool
@@ -481,32 +491,38 @@ edge_table_free(edge_table_t *self)
 void
 edge_table_print_state(edge_table_t *self, FILE *out)
 {
-    size_t j;
+    int ret;
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "edge_table: %p:\n", (void *) self);
     fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
             (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tleft\tright\tparent\tchild\n");
-    for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%.3f\t%.3f\t%d\t%d\t", (int) j, self->left[j], self->right[j],
-                self->parent[j], self->child[j]);
-        fprintf(out, "\n");
-    }
+    ret = edge_table_dump_text(self, out);
+    assert(ret == 0);
 }
 
-void
+int
 edge_table_dump_text(edge_table_t *self, FILE *out)
 {
     size_t j;
+    int ret = MSP_ERR_IO;
+    int err;
 
-    fprintf(out, "left\tright\tparent\tchild\n");
-    for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%.3f\t%.3f\t%d\t%d\t", self->left[j], self->right[j],
-                self->parent[j], self->child[j]);
-        fprintf(out, "\n");
+    err = fprintf(out, "left\tright\tparent\tchild\n");
+    if (err < 0) {
+        goto out;
     }
+    for (j = 0; j < self->num_rows; j++) {
+        err = fprintf(out, "%.3f\t%.3f\t%d\t%d\n", self->left[j], self->right[j],
+                self->parent[j], self->child[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
 }
 
 bool
@@ -820,7 +836,7 @@ site_table_free(site_table_t *self)
 void
 site_table_print_state(site_table_t *self, FILE *out)
 {
-    table_size_t j, k;
+    int ret;
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "site_table: %p:\n", (void *) self);
@@ -835,21 +851,8 @@ site_table_print_state(site_table_t *self, FILE *out)
             (int) self->max_metadata_length,
             (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tposition\tancestral_state_offset\tancestral_state\t"
-            "metadata_offset\tmetadata\n");
-    for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%f\t%d\t", (int) j, self->position[j],
-                self->ancestral_state_offset[j]);
-        for (k = self->ancestral_state_offset[j];
-                k < self->ancestral_state_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->ancestral_state[k]);
-        }
-        fprintf(out, "\t%d\t", self->metadata_offset[j]);
-        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->metadata[k]);
-        }
-        fprintf(out, "\n");
-    }
+    ret = site_table_dump_text(self, out);
+    assert(ret == 0);
 
     assert(self->ancestral_state_offset[0] == 0);
     assert(self->ancestral_state_length
@@ -858,30 +861,32 @@ site_table_print_state(site_table_t *self, FILE *out)
     assert(self->metadata_length == self->metadata_offset[self->num_rows]);
 }
 
-void
+int
 site_table_dump_text(site_table_t *self, FILE *out)
 {
-    table_size_t j, k;
+    size_t j;
+    int ret = MSP_ERR_IO;
+    int err;
+    table_size_t ancestral_state_len, metadata_len;
 
-    fprintf(out, "index\tposition\tancestral_state\tmetadata\n");
-    for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%f\t", (int) j, self->position[j]);
-        for (k = self->ancestral_state_offset[j];
-                k < self->ancestral_state_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->ancestral_state[k]);
-        }
-        fprintf(out, "\t");
-        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->metadata[k]);
-        }
-        fprintf(out, "\n");
+    err = fprintf(out, "id\tposition\tancestral_state\tmetadata\n");
+    if (err < 0) {
+        goto out;
     }
-
-    assert(self->ancestral_state_offset[0] == 0);
-    assert(self->ancestral_state_length
-            == self->ancestral_state_offset[self->num_rows]);
-    assert(self->metadata_offset[0] == 0);
-    assert(self->metadata_length == self->metadata_offset[self->num_rows]);
+    for (j = 0; j < self->num_rows; j++) {
+        ancestral_state_len = self->ancestral_state_offset[j + 1] -
+            self->ancestral_state_offset[j];
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%d\t%f\t%.*s\t%.*s\n", (int) j, self->position[j],
+                ancestral_state_len, self->ancestral_state + self->ancestral_state_offset[j],
+                metadata_len, self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
 }
 
 /*************************
@@ -1203,7 +1208,7 @@ mutation_table_free(mutation_table_t *self)
 void
 mutation_table_print_state(mutation_table_t *self, FILE *out)
 {
-    size_t j, k;
+    int ret;
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "mutation_table: %p:\n", (void *) self);
@@ -1218,23 +1223,8 @@ mutation_table_print_state(mutation_table_t *self, FILE *out)
             (int) self->max_metadata_length,
             (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out,
-            "index\tsite\tnode\tparent\tderived_state_offset\tderived_state\t"
-            "metadata_offset\tmetadata\n");
-    for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t%d\t%d\t%d\t", (int) j, self->site[j], self->node[j],
-                self->parent[j], self->derived_state_offset[j]);
-        for (k = self->derived_state_offset[j];
-                k < self->derived_state_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->derived_state[k]);
-        }
-        fprintf(out, "\t%d\t", self->metadata_offset[j]);
-        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->metadata[k]);
-        }
-        fprintf(out, "\n");
-    }
-
+    ret = mutation_table_dump_text(self, out);
+    assert(ret == 0);
     assert(self->derived_state_offset[0] == 0);
     assert(self->derived_state_length
             == self->derived_state_offset[self->num_rows]);
@@ -1243,32 +1233,33 @@ mutation_table_print_state(mutation_table_t *self, FILE *out)
             == self->metadata_offset[self->num_rows]);
 }
 
-void
+int
 mutation_table_dump_text(mutation_table_t *self, FILE *out)
 {
-    size_t j, k;
+    size_t j;
+    int ret = MSP_ERR_IO;
+    int err;
+    table_size_t derived_state_len, metadata_len;
 
-    fprintf(out, "site\tnode\tparent\tderived_state\tmetadata\n");
-    for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t%d\t", self->site[j], self->node[j],
-                self->parent[j]);
-        for (k = self->derived_state_offset[j];
-                k < self->derived_state_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->derived_state[k]);
-        }
-        fprintf(out, "\t");
-        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
-            fprintf(out, "%c", self->metadata[k]);
-        }
-        fprintf(out, "\n");
+    err = fprintf(out, "id\tsite\tnode\tparent\tderived_state\tmetadata\n");
+    if (err < 0) {
+        goto out;
     }
-
-    assert(self->derived_state_offset[0] == 0);
-    assert(self->derived_state_length
-            == self->derived_state_offset[self->num_rows]);
-    assert(self->metadata_offset[0] == 0);
-    assert(self->metadata_length
-            == self->metadata_offset[self->num_rows]);
+    for (j = 0; j < self->num_rows; j++) {
+        derived_state_len = self->derived_state_offset[j + 1] -
+            self->derived_state_offset[j];
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%d\t%d\t%d\t%d\t%.*s\t%.*s\n", (int) j,
+                self->site[j], self->node[j], self->parent[j],
+                derived_state_len, self->derived_state + self->derived_state_offset[j],
+                metadata_len, self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
 }
 
 /*************************
@@ -1421,32 +1412,39 @@ migration_table_free(migration_table_t *self)
 void
 migration_table_print_state(migration_table_t *self, FILE *out)
 {
-    size_t j;
+    int ret;
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "migration_table: %p:\n", (void *) self);
     fprintf(out, "num_rows = %d\tmax= %d\tincrement = %d)\n",
             (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tleft\tright\tnode\tsource\tdest\ttime\n");
-    for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%.3f\t%.3f\t%d\t%d\t%d\t%f\n", (int) j, self->left[j],
-                self->right[j], (int) self->node[j], (int) self->source[j],
-                (int) self->dest[j], self->time[j]);
-    }
+    ret = migration_table_dump_text(self, out);
+    assert(ret == 0);
 }
 
-void
+int
 migration_table_dump_text(migration_table_t *self, FILE *out)
 {
     size_t j;
+    int ret = MSP_ERR_IO;
+    int err;
 
-    fprintf(out, "left\tright\tnode\tsource\tdest\ttime\n");
+    err = fprintf(out, "left\tright\tnode\tsource\tdest\ttime\n");
+    if (err < 0) {
+        goto out;
+    }
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%.3f\t%.3f\t%d\t%d\t%d\t%f\n", self->left[j],
+        err = fprintf(out, "%.3f\t%.3f\t%d\t%d\t%d\t%f\n", self->left[j],
                 self->right[j], (int) self->node[j], (int) self->source[j],
                 (int) self->dest[j], self->time[j]);
+        if (err < 0) {
+            goto out;
+        }
     }
+    ret = 0;
+out:
+    return ret;
 }
 
 

--- a/lib/table.c
+++ b/lib/table.c
@@ -297,10 +297,10 @@ node_table_print_state(node_table_t *self, FILE *out)
             (int) self->max_metadata_length,
             (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tflags\ttime\tpopulation\tmetadata_offset\tmetadata\n");
+    fprintf(out, "index\tis_sample\ttime\tpopulation\tmetadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t%f\t%d\t%d\t", (int) j, self->flags[j], self->time[j],
-                (int) self->population[j], self->metadata_offset[j]);
+        fprintf(out, "%d\t%d\t%f\t%d\t%d\t", (int) j, (int) (self->flags[j] & MSP_NODE_IS_SAMPLE),
+                self->time[j], (int) self->population[j], self->metadata_offset[j]);
         for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
             fprintf(out, "%c", self->metadata[k]);
         }

--- a/lib/table.c
+++ b/lib/table.c
@@ -297,10 +297,11 @@ node_table_print_state(node_table_t *self, FILE *out)
             (int) self->max_metadata_length,
             (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "index\tis_sample\ttime\tpopulation\tmetadata_offset\tmetadata\n");
+    fprintf(out, "index\tflags\tis_sample\ttime\tpopulation\tmetadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t%f\t%d\t%d\t", (int) j, (int) (self->flags[j] & MSP_NODE_IS_SAMPLE),
-                self->time[j], (int) self->population[j], self->metadata_offset[j]);
+        fprintf(out, "%d\t%d\t%d\t%f\t%d\t%d\t", (int) j, self->flags[j],
+                (int) (self->flags[j] & MSP_NODE_IS_SAMPLE), self->time[j],
+                (int) self->population[j], self->metadata_offset[j]);
         for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
             fprintf(out, "%c", self->metadata[k]);
         }

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6268,6 +6268,7 @@ test_node_table(void)
     ret = node_table_alloc(&table, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     node_table_print_state(&table, _devnull);
+    node_table_dump_text(&table, _devnull);
 
     for (j = 0; j < num_rows; j++) {
         ret = node_table_add_row(&table, j, j, j, test_metadata, test_metadata_length);
@@ -6282,7 +6283,7 @@ test_node_table(void)
         memcpy(metadata_copy, table.metadata + table.metadata_offset[j], test_metadata_length);
         CU_ASSERT_NSTRING_EQUAL(metadata_copy, test_metadata, test_metadata_length);
     }
-    node_table_print_state(&table, _devnull);
+    node_table_dump_text(&table, _devnull);
     node_table_clear(&table);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
@@ -6317,6 +6318,7 @@ test_node_table(void)
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, num_rows);
     node_table_print_state(&table, _devnull);
+    node_table_dump_text(&table, _devnull);
 
     /* Append another num_rows onto the end */
     ret = node_table_append_columns(&table, num_rows, flags, time, population,
@@ -6334,6 +6336,7 @@ test_node_table(void)
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 2 * num_rows);
     node_table_print_state(&table, _devnull);
+    node_table_dump_text(&table, _devnull);
 
     /* If population is NULL it should be set the -1. If metadata is NULL all metadatas
      * should be set to the empty string. */
@@ -6387,6 +6390,7 @@ test_node_table(void)
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
     node_table_print_state(&table, _devnull);
+    node_table_dump_text(&table, _devnull);
 
     node_table_free(&table);
     free(flags);
@@ -6409,6 +6413,7 @@ test_edge_table(void)
     ret = edge_table_alloc(&table, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     edge_table_print_state(&table, _devnull);
+    edge_table_dump_text(&table, _devnull);
 
     for (j = 0; j < num_rows; j++) {
         ret = edge_table_add_row(&table, j, j, j, j);
@@ -6420,6 +6425,7 @@ test_edge_table(void)
         CU_ASSERT_EQUAL(table.num_rows, j + 1);
     }
     edge_table_print_state(&table, _devnull);
+    edge_table_dump_text(&table, _devnull);
 
     num_rows *= 2;
     left = malloc(num_rows * sizeof(double));
@@ -6490,6 +6496,7 @@ test_site_table(void)
     ret = site_table_alloc(&table, 1, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     site_table_print_state(&table, _devnull);
+    site_table_dump_text(&table, _devnull);
 
     ret = site_table_add_row(&table, 0, "A", 1, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6521,6 +6528,7 @@ test_site_table(void)
     CU_ASSERT_EQUAL(table.num_rows, 3);
 
     site_table_print_state(&table, _devnull);
+    site_table_dump_text(&table, _devnull);
     site_table_clear(&table);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.ancestral_state_length, 0);
@@ -6677,6 +6685,7 @@ test_mutation_table(void)
     ret = mutation_table_alloc(&table, 1, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     mutation_table_print_state(&table, _devnull);
+    mutation_table_dump_text(&table, _devnull);
 
     len = 0;
     for (j = 0; j < num_rows; j++) {
@@ -6696,6 +6705,7 @@ test_mutation_table(void)
         CU_ASSERT_EQUAL(table.metadata_length, len);
     }
     mutation_table_print_state(&table, _devnull);
+    mutation_table_dump_text(&table, _devnull);
 
     num_rows *= 2;
     site = malloc(num_rows * sizeof(site_id_t));
@@ -6878,6 +6888,7 @@ test_migration_table(void)
     ret = migration_table_alloc(&table, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     migration_table_print_state(&table, _devnull);
+    migration_table_dump_text(&table, _devnull);
 
     for (j = 0; j < num_rows; j++) {
         ret = migration_table_add_row(&table, j, j, j, j, j, j);
@@ -6891,6 +6902,7 @@ test_migration_table(void)
         CU_ASSERT_EQUAL(table.num_rows, j + 1);
     }
     migration_table_print_state(&table, _devnull);
+    migration_table_dump_text(&table, _devnull);
 
     num_rows *= 2;
     left = malloc(num_rows * sizeof(double));

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6283,7 +6283,9 @@ test_node_table(void)
         memcpy(metadata_copy, table.metadata + table.metadata_offset[j], test_metadata_length);
         CU_ASSERT_NSTRING_EQUAL(metadata_copy, test_metadata, test_metadata_length);
     }
+    node_table_print_state(&table, _devnull);
     node_table_dump_text(&table, _devnull);
+
     node_table_clear(&table);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
@@ -6732,6 +6734,7 @@ test_mutation_table(void)
         metadata[j] = 'M';
         metadata_offset[j] = j;
     }
+
     derived_state_offset[num_rows] = num_rows;
     metadata_offset[num_rows] = num_rows;
     ret = mutation_table_set_columns(&table, num_rows, site, node, parent,
@@ -6807,6 +6810,7 @@ test_mutation_table(void)
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.derived_state_length, 2 * num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
+
 
     /* Inputs except parent, metadata and metadata_offset cannot be NULL*/
     ret = mutation_table_set_columns(&table, num_rows, NULL, node, parent,
@@ -7095,7 +7099,6 @@ test_provenance_table(void)
     free(record);
     free(record_offset);
 }
-
 
 static int
 msprime_suite_init(void)


### PR DESCRIPTION
Currently, the way to output a NodeTable as text from C seems to be the function `node_table_print_state`.  This outputs `flags` as a column, rather than `is_sample`, which is what is required for `load_text()`.  The function is only used for debugging at the moment; so changing to output `is_sample` is harmless.  At first I removed `flags` entirely, but realized that we can safely output *both* columns, without loss of generality.