### PR TITLE
Improved extend method for Fenwick trees

### DIFF
--- a/lib/fenwick.c
+++ b/lib/fenwick.c
@@ -75,16 +75,21 @@ fenwick_alloc(fenwick_t *self, size_t initial_size)
 int WARN_UNUSED
 fenwick_expand(fenwick_t *self, size_t increment)
 {
-    int ret = -1;
+    int ret = MSP_ERR_NO_MEMORY;
     size_t j, n, k;
-    self->tree = realloc(self->tree, 
-                         (1 + self->size + increment) * sizeof(int64_t));
-    self->values = realloc(self->values, 
-                           (1 + self->size + increment) * sizeof(int64_t));
-    if (self->tree == NULL || self->values == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
+    void *p;
+
+    p = realloc(self->tree, (1 + self->size + increment) * sizeof(int64_t));
+    if (p == NULL) {
         goto out;
     }
+    self->tree = p;
+    p = realloc(self->values, (1 + self->size + increment) * sizeof(int64_t));
+    if (p == NULL) {
+        goto out;
+    }
+    self->values = p;
+
     self->size += increment;
     fenwick_set_log_size(self);
     for (j = self->size - increment + 1; j <= self->size; j++) {

--- a/lib/simulation_tests.c
+++ b/lib/simulation_tests.c
@@ -141,6 +141,34 @@ test_fenwick(void)
 }
 
 static void
+test_fenwick_expand(void)
+{
+    fenwick_t t1, t2;
+    int64_t s;
+    size_t j, n;
+
+    for (n = 1; n < 100; n++) {
+        s = n;
+        CU_ASSERT(fenwick_alloc(&t1, n) == 0);
+        CU_ASSERT(fenwick_alloc(&t2, 3 * n) == 0);
+        for (j = 1; j <= n; j++) {
+            fenwick_increment(&t1, j, s);
+            fenwick_increment(&t2, j, s);
+            CU_ASSERT(fenwick_get_value(&t1, j) == s);
+            CU_ASSERT(fenwick_get_value(&t2, j) == s);
+        }
+        /* After we expand, the internal tree values should be identical */
+        CU_ASSERT(t1.size != t2.size);
+        CU_ASSERT(fenwick_expand(&t1, 2 * n) == 0);
+        CU_ASSERT_EQUAL(t1.size, t2.size);
+        CU_ASSERT_EQUAL(memcmp(t1.tree, t2.tree, (t2.size + 1) * sizeof(int64_t)), 0);
+        CU_ASSERT_EQUAL(memcmp(t1.values, t2.values, (t2.size + 1) * sizeof(int64_t)), 0);
+        CU_ASSERT(fenwick_free(&t1) == 0);
+        CU_ASSERT(fenwick_free(&t2) == 0);
+    }
+}
+
+static void
 test_single_locus_two_populations(void)
 {
     int ret;
@@ -1645,7 +1673,8 @@ main(int argc, char **argv)
     CU_pTest test;
     CU_pSuite suite;
     CU_TestInfo tests[] = {
-        {"test_fenwick_tree", test_fenwick},
+        {"test_fenwick", test_fenwick},
+        {"test_fenwick_expand", test_fenwick_expand},
         {"test_single_locus_two_populations", test_single_locus_two_populations},
         {"test_single_locus_many_populations", test_single_locus_many_populations},
         {"test_single_locus_historical_sample", test_single_locus_historical_sample},


### PR DESCRIPTION
The code I wrote out in my original email was wrong, which is why this is slightly different. 

The main difference to earlier (apart from the more efficient way in which the expanded entries are populated) is that we can't use the fenwick_alloc_buffers method in fenwick_expand anymore since the two callocs would defeat the whole point. Hence I've done the mallocing directly in fenwick_expand using realloc to keep things as in-place as possible.

This passes your tests and simulation_tests runs, and I've made sure that the new for loop behaves as intended. 